### PR TITLE
Ensure feature flags are only used at runtime

### DIFF
--- a/core/lib/core/feature_flags.ex
+++ b/core/lib/core/feature_flags.ex
@@ -1,5 +1,29 @@
 defmodule Core.FeatureFlags do
-  def feature_enabled?(feature_id) when is_atom(feature_id) do
+  defmacro __using__(_opts \\ []) do
+    quote do
+      import Core.FeatureFlags, only: [feature_enabled?: 1, require_feature: 1]
+    end
+  end
+
+  defmacro feature_enabled?(feature_id) when is_atom(feature_id) do
+    unless __CALLER__.function do
+      throw("Feature checking must be used from inside a function to allow i18n.")
+    end
+
+    quote bind_quoted: [feature_id: feature_id] do
+      Core.FeatureFlags.conf_enabled?(feature_id)
+    end
+  end
+
+  defmacro require_feature(feature_id) when is_atom(feature_id) do
+    quote do
+      unless Core.FeatureFlags.feature_enabled?(unquote(feature_id)) do
+        throw("Feature: #{unquote(feature_id)} is required")
+      end
+    end
+  end
+
+  def conf_enabled?(feature_id) do
     Application.get_env(:core, :features, [])
     |> Keyword.get(feature_id, true)
   end

--- a/core/lib/core_web.ex
+++ b/core/lib/core_web.ex
@@ -55,6 +55,7 @@ defmodule CoreWeb do
       import Core.Authorization, only: [can_access?: 2]
       use GreenLight.Live, Core.Authorization
       use CoreWeb.LiveAssignHelper
+      import Core.FeatureFlags
 
       use Surface.LiveView,
         layout: {CoreWeb.LayoutView, "live.html"}

--- a/core/lib/core_web/controllers/user_session_controller.ex
+++ b/core/lib/core_web/controllers/user_session_controller.ex
@@ -1,10 +1,11 @@
 defmodule CoreWeb.UserSessionController do
   use CoreWeb, :controller
+  import CoreWeb.Gettext
 
-  if feature_enabled?(:signin_with_apple) do
-    plug(:setup_sign_in_with_apple, :core when action != :delete)
+  plug(:setup_sign_in_with_apple, :core when action != :delete)
 
-    defp setup_sign_in_with_apple(conn, otp_app) do
+  defp setup_sign_in_with_apple(conn, otp_app) do
+    if feature_enabled?(:signin_with_apple) do
       conf = Application.fetch_env!(otp_app, SignInWithApple)
       SignInWithApple.Helpers.setup_session(conn, conf)
     end
@@ -14,18 +15,15 @@ defmodule CoreWeb.UserSessionController do
     render(conn, "new.html")
   end
 
-  if feature_enabled?(:password_sign_in) do
-    import CoreWeb.Gettext
+  def create(conn, %{"user" => user_params}) do
+    require_feature(:password_sign_in)
+    %{"email" => email, "password" => password} = user_params
 
-    def create(conn, %{"user" => user_params}) do
-      %{"email" => email, "password" => password} = user_params
-
-      if user = Core.Accounts.get_user_by_email_and_password(email, password) do
-        CoreWeb.UserAuth.log_in_user(conn, user, false, user_params)
-      else
-        message = dgettext("eyra-user", "Invalid email or password")
-        render(conn |> put_flash(:error, message), "new.html")
-      end
+    if user = Core.Accounts.get_user_by_email_and_password(email, password) do
+      CoreWeb.UserAuth.log_in_user(conn, user, false, user_params)
+    else
+      message = dgettext("eyra-user", "Invalid email or password")
+      render(conn |> put_flash(:error, message), "new.html")
     end
   end
 

--- a/core/lib/core_web/live/user/await_confirmation.ex
+++ b/core/lib/core_web/live/user/await_confirmation.ex
@@ -13,6 +13,7 @@ defmodule CoreWeb.User.AwaitConfirmation do
   data(changeset, :any)
 
   def mount(_params, _session, socket) do
+    require_feature(:password_sign_in)
     changeset = Accounts.change_user_registration(%User{})
 
     {:ok,

--- a/core/lib/core_web/live/user/confirm_token.ex
+++ b/core/lib/core_web/live/user/confirm_token.ex
@@ -16,6 +16,8 @@ defmodule CoreWeb.User.ConfirmToken do
   data(changeset, :any)
 
   def mount(%{"token" => token}, _session, socket) do
+    require_feature(:password_sign_in)
+
     case Accounts.confirm_user(token) do
       {:ok, _} ->
         {:ok,

--- a/core/lib/core_web/live/user/routes.ex
+++ b/core/lib/core_web/live/user/routes.ex
@@ -5,16 +5,14 @@ defmodule CoreWeb.Live.User.Routes do
         pipe_through([:browser, :redirect_if_user_is_authenticated])
         get("/user/signin", UserSessionController, :new)
 
-        if feature_enabled?(:password_sign_in) do
-          live("/user/signup", User.Signup)
-          live("/user/confirm/:token", User.ConfirmToken)
-          live("/user/confirm", User.ConfirmToken)
-          live("/user/await-confirmation", User.AwaitConfirmation)
+        live("/user/signup", User.Signup)
+        live("/user/confirm/:token", User.ConfirmToken)
+        live("/user/confirm", User.ConfirmToken)
+        live("/user/await-confirmation", User.AwaitConfirmation)
 
-          post("/user/signin", UserSessionController, :create)
-          live("/user/reset-password", User.ResetPassword)
-          live("/user/reset-password/:token", User.ResetPasswordToken)
-        end
+        post("/user/signin", UserSessionController, :create)
+        live("/user/reset-password", User.ResetPassword)
+        live("/user/reset-password/:token", User.ResetPasswordToken)
       end
 
       ## User routes

--- a/core/lib/core_web/live/user/signup.ex
+++ b/core/lib/core_web/live/user/signup.ex
@@ -17,6 +17,7 @@ defmodule CoreWeb.User.Signup do
   data(focus, :string, default: "")
 
   def mount(_params, _session, socket) do
+    require_feature(:password_sign_in)
     changeset = Accounts.change_user_registration(%User{})
 
     {:ok,

--- a/core/lib/core_web/router.ex
+++ b/core/lib/core_web/router.ex
@@ -1,6 +1,5 @@
 defmodule CoreWeb.Router do
   use CoreWeb, :router
-  import Core.FeatureFlags
 
   require Core.BundleOverrides
   require Core.SurfConext
@@ -9,15 +8,11 @@ defmodule CoreWeb.Router do
 
   Core.BundleOverrides.routes()
 
-  if feature_enabled?(:google_sign_in) do
-    require GoogleSignIn
-    GoogleSignIn.routes(:core)
-  end
+  require GoogleSignIn
+  GoogleSignIn.routes(:core)
 
-  if feature_enabled?(:sign_in_with_apple) do
-    require SignInWithApple
-    SignInWithApple.routes(:core)
-  end
+  require SignInWithApple
+  SignInWithApple.routes(:core)
 
   Core.SurfConext.routes(:core)
 

--- a/core/lib/google_sign_in/plug.ex
+++ b/core/lib/google_sign_in/plug.ex
@@ -21,10 +21,12 @@ defmodule GoogleSignIn.AuthorizePlug do
   """
   import Plug.Conn
   import GoogleSignIn.PlugUtils
+  use Core.FeatureFlags
 
   def init(otp_app) when is_atom(otp_app), do: otp_app
 
   def call(conn, otp_app) do
+    require_feature(:google_sign_in)
     config = config(otp_app)
 
     {:ok, %{url: url, session_params: session_params}} =
@@ -39,10 +41,12 @@ end
 defmodule(GoogleSignIn.CallbackPlug) do
   import Plug.Conn
   import GoogleSignIn.PlugUtils
+  use Core.FeatureFlags
 
   def init(otp_app) when is_atom(otp_app), do: otp_app
 
   def call(conn, otp_app) do
+    require_feature(:google_sign_in)
     session_params = get_session(conn, :google_sign_in)
 
     config = config(otp_app) |> Keyword.put(:session_params, session_params)

--- a/core/lib/sign_in_with_apple/plug.ex
+++ b/core/lib/sign_in_with_apple/plug.ex
@@ -1,10 +1,12 @@
 defmodule SignInWithApple.CallbackPlug do
   import Plug.Conn
   import SignInWithApple.Helpers, only: [backend_module: 1, apply_defaults: 1]
+  use Core.FeatureFlags
 
   def init(otp_app) when is_atom(otp_app), do: otp_app
 
   def call(conn, otp_app) do
+    require_feature(:sign_in_with_apple)
     config = otp_app |> Application.get_env(SignInWithApple) |> apply_defaults
     session_params = get_session(conn, :sign_in_with_apple)
     config = Keyword.put(config, :session_params, session_params)

--- a/core/test/core/feature_flags_test.exs
+++ b/core/test/core/feature_flags_test.exs
@@ -1,10 +1,10 @@
 defmodule Core.FeatureFlagsTest do
   use Core.DataCase, async: true
-  alias Core.FeatureFlags
+  use Core.FeatureFlags
 
   describe "feature_enabled?/1" do
     test "return true by default" do
-      assert FeatureFlags.feature_enabled?(:some_unconfigured_flag)
+      assert feature_enabled?(:some_unconfigured_flag)
     end
 
     test "allow configuration via the application env" do
@@ -16,7 +16,26 @@ defmodule Core.FeatureFlagsTest do
         Keyword.put(current_env, :a_feature_used_by_this_test, false)
       )
 
-      refute FeatureFlags.feature_enabled?(:a_feature_used_by_this_test)
+      refute feature_enabled?(:a_feature_used_by_this_test)
+    end
+  end
+
+  describe "require_feature/1" do
+    test "do nothing when feature is enabled" do
+      require_feature(:some_unconfigured_flag)
+    end
+
+    test "throw when feature is disabled" do
+      current_env = Application.get_env(:core, :features, [])
+
+      Application.put_env(
+        :core,
+        :features,
+        Keyword.put(current_env, :a_feature_used_by_this_test, false)
+      )
+
+      assert catch_throw(require_feature(:a_feature_used_by_this_test)) ==
+               "Feature: a_feature_used_by_this_test is required"
     end
   end
 end


### PR DESCRIPTION
This fixes issues with gettext extraction due to compilation differences.