### PR TITLE
feat: add manual builder to library for Panl studies

### DIFF
--- a/core/systems/assignment/template_questionnaire.ex
+++ b/core/systems/assignment/template_questionnaire.ex
@@ -39,6 +39,12 @@ defmodule Systems.Assignment.TemplateQuestionnaire do
         library: %Workflow.LibraryModel{
           items: [
             %Workflow.LibraryItemModel{
+              special: :manual,
+              tool: :manual_tool,
+              title: Assignment.WorkflowItemSpecials.translate(:manual),
+              description: dgettext("eyra-assignment", "workflow_item.manual.description")
+            },
+            %Workflow.LibraryItemModel{
               special: :general_instruction,
               tool: :instruction_tool,
               title: Assignment.WorkflowItemSpecials.translate(:general_instruction),


### PR DESCRIPTION
I added the Manual Builder (beta) library item to the library for Panl studies as per Adrienne's request.

![image](https://github.com/user-attachments/assets/ca9003ed-e848-4db7-90c3-a5c8ab2c20cc)

https://3.basecamp.com/5734045/buckets/35926565/todos/8576991434
