### PR TITLE
Dockerfile in core is now up to date with software

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,25 +1,34 @@
-FROM elixir:1.14.0 as builder
+FROM elixir:1.17.0-otp-27 AS builder
 
 WORKDIR /workspace
 
-ENV NODE_MAJOR 18
-ENV MIX_ENV prod
-ENV SSL_PROXIED true
+ENV NODE_MAJOR=18
+ENV MIX_ENV=prod
+ENV SSL_PROXIED=true
 
 RUN set -x &&\
     mix local.hex --force &&\
     mix local.rebar --force &&\
-    curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash - &&\
-    apt-get install -y nodejs inotify-tools
+    curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
 
-RUN mix archive.install --force hex phx_new 1.5.5
-
+RUN apt-get update && apt-get install -y \
+    locales \
+    curl \
+    git \
+    nodejs \
+    build-essential \
+    unzip \
+    automake \
+    autoconf \
+    libssl-dev \
+    libncurses-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG BUNDLE
 ARG VERSION
 
-ENV BUNDLE $BUNDLE
-ENV VERSION $VERSION
+ENV BUNDLE=$BUNDLE
+ENV VERSION=$VERSION
 
 COPY mix.exs .
 RUN mix deps.get
@@ -28,12 +37,12 @@ COPY . .
 RUN scripts/build-frontend
 RUN scripts/build-release
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ARG VERSION
-ENV VERSION $VERSION
-ENV MIX_ENV prod
+ENV VERSION=$VERSION
+ENV MIX_ENV=prod
 
-RUN apt-get update && apt-get install -y inotify-tools
+RUN apt-get update && apt-get install -y inotify-tools libssl-dev
 
 EXPOSE 8000
 
@@ -42,4 +51,3 @@ COPY --from=builder /workspace/$VERSION /opt/app
 COPY ./scripts/migrate-and-start /opt/app/bin
 
 CMD ["/opt/app/bin/migrate-and-start"]
-


### PR DESCRIPTION
# Dockerfile is out of date and does not work anymore

Breaking issues: 
- upgrade the builder image to elixir 1.17 this is needed because the code does not compile with elixir 1.14. I used the version that is specified in .tool-versions
- added libssl-dev, to the runner image this is needed because it provided a shared object file that erlang needs.

Other updates:
- changed ENV syntax to prevent warnings
- Added extra build install dependencies, I took those from the main Dockerfile in the root directory. 
- Updated the image that runs the app to bookwork (From the main Dockerfile I also see you are using debian 12, so I updated to bookwork)
- Removed line 15 which is not needed

