### PR TITLE
Fix E2E workflow to use correct env var name

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run E2E tests
         working-directory: core/test/e2e
         env:
-          BASE_URL: https://${{ inputs.app_name }}.fly.dev
+          E2E_BASE_URL: https://${{ inputs.app_name }}.fly.dev
           ASSIGNMENT_PATH: ${{ inputs.assignment_path }}
         run: npm run e2e
 


### PR DESCRIPTION
## Summary
- Fix env var mismatch: workflow set `BASE_URL` but `global-setup.ts` expects `E2E_BASE_URL`
- This caused E2E tests to hit `localhost:4000` instead of the Fly app
- Fixes auto-start not triggering for suspended apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)