### PR TITLE
Add LinkedIn as a supported platform

### DIFF
--- a/core/priv/gettext/en/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-enums.po
@@ -279,6 +279,10 @@ msgid "platforms.instagram"
 msgstr "Instagram"
 
 #, elixir-autogen, elixir-format
+msgid "platforms.linkedin"
+msgstr "LinkedIn"
+
+#, elixir-autogen, elixir-format
 msgid "platforms.x"
 msgstr "X"
 

--- a/core/priv/gettext/eyra-enums.pot
+++ b/core/priv/gettext/eyra-enums.pot
@@ -279,6 +279,10 @@ msgid "platforms.instagram"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "platforms.linkedin"
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "platforms.x"
 msgstr ""
 

--- a/core/priv/static/images/logos/platforms/linkedin.svg
+++ b/core/priv/static/images/logos/platforms/linkedin.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="24" cy="24" r="20" fill="#0A66C2"/>
+</svg>

--- a/core/priv/static/images/logos/platforms/linkedin_square.svg
+++ b/core/priv/static/images/logos/platforms/linkedin_square.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="48" height="48" rx="8" fill="#0A66C2"/>
+</svg>

--- a/core/systems/workflow/platforms.ex
+++ b/core/systems/workflow/platforms.ex
@@ -13,6 +13,7 @@ defmodule Systems.Workflow.Platforms do
          :facebook,
          :google,
          :instagram,
+         :linkedin,
          :netflix,
          :samsung,
          :snapchat,


### PR DESCRIPTION
# Pull request

This adds LinkedIn to the platforms list. I'm supporting a researcher now who's using this platform (among others) and it would make it look more professional to have all platforms offer an icon. 

 **Summary**                                                                                                
                                                                                                           
 - Adds :linkedin to the Workflow.Platforms enum                                                          
 - Adds placeholder SVG icons (circle and square variants) in LinkedIn blue (#0A66C2)
 - Adds English gettext translation for platforms.linkedin                                                
 - Adds entry to the .pot template   

**Notes for maintainers**

 - Icons are placeholders -- proper branded LinkedIn icons should be exported from the Figma design system according to `core/systems/workflow/platforms.ex` but I don't have access. Hope it's okay to submit it in this state. 
- I didn't run  mix  to propagate the new platforms.linkedin key, not sure how you all prefer to receive auto-built things

## Basecamp link

I don't think I have access to the correct Basecamp project. Unless this is the Google Forms feature request? 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [x] I have not added superfluous logging
- [ ] I have added QA steps to the Basecamp ticket
- [x] Security
  - [x] I have considered the security implications of my changes
- [x] Privacy
  - [x] I have considered the privacy implications of my changes
  - [x] I have checked new log messages for PII
  - [x] I have added no unnecessary logging
