### PR TITLE
Copy update sign up page and nl text participants

### DIFF
--- a/core/assets/js/file_input.js
+++ b/core/assets/js/file_input.js
@@ -105,7 +105,7 @@ export class FileInput {
   continueText() {
     return {
       en: "Do you want to continue with the selected file or select a different file?",
-      nl: "Wilt u doorgaan met het gekozen bestand of een ander bestand kiezen?",
+      nl: "Wil je doorgaan met het gekozen bestand of een ander bestand kiezen?",
     };
   }
 

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -177,7 +177,15 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.label"
-msgstr "Ich stimme den PaNL %{terms_link} und der %{privacy_link} zu"
+msgstr "Ich stimme den %{terms_link} und der %{privacy_link} von Panl zu"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.privacy"
+msgstr "Datenschutzerklärung"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.terms"
+msgstr "Allgemeinen Geschäftsbedingungen"
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.required"
@@ -185,7 +193,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.label"
-msgstr "Ich stimme den Next %{terms_link} und der %{privacy_link} zu"
+msgstr "Ich stimme den %{terms_link} und der %{privacy_link} von Next zu"
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.required"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
@@ -176,7 +176,15 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.label"
-msgstr "I agree to the PaNL %{terms_link} and %{privacy_link}"
+msgstr "I agree to the %{terms_link} and %{privacy_link} of Panl"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.privacy"
+msgstr "Privacy Policy"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.terms"
+msgstr "Terms of Use"
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.required"
@@ -184,7 +192,7 @@ msgstr "You must accept the privacy policy to continue"
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.label"
-msgstr "I agree to the Next %{terms_link} and %{privacy_link}"
+msgstr "I agree to the %{terms_link} and %{privacy_link} of Next"
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.required"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -434,7 +434,7 @@ msgstr "Invite link"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "settings.language.fixed_nl_message"
-msgstr "The default language for Panl studies is dutch"
+msgstr "The default language for Panl studies is Dutch"
 
 #, elixir-autogen, elixir-format
 msgid "finished_view.body.declined"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -177,7 +177,15 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.label"
-msgstr "Acepto los %{terms_link} y la %{privacy_link} de PaNL"
+msgstr "Acepto los %{terms_link} y la %{privacy_link} de Panl"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.privacy"
+msgstr "política de privacidad"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.terms"
+msgstr "términos y condiciones"
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.required"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -177,7 +177,15 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.label"
-msgstr "Accetto i %{terms_link} e la %{privacy_link} di PaNL"
+msgstr "Accetto i %{terms_link} e l'%{privacy_link} di Panl"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.privacy"
+msgstr "informativa sulla privacy"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.terms"
+msgstr "termini e condizioni"
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.required"
@@ -185,7 +193,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.label"
-msgstr "Accetto i %{terms_link} e la %{privacy_link} di Next"
+msgstr "Accetto i %{terms_link} e l'%{privacy_link} di Next"
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.required"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -186,7 +186,15 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.label"
-msgstr "Sutinku su PaNL %{terms_link} ir %{privacy_link}"
+msgstr "Sutinku su %{terms_link} ir %{privacy_link} Panl"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.privacy"
+msgstr "privatumo politika"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.terms"
+msgstr "naudojimo sąlygomis"
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.required"
@@ -194,7 +202,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.label"
-msgstr "Sutinku su Next %{terms_link} ir %{privacy_link}"
+msgstr "Sutinku su %{terms_link} ir %{privacy_link} Next"
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.required"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
@@ -108,7 +108,7 @@ msgstr "Activatie mislukt"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "activation.confirm.body"
-msgstr "Klik op de knop hieronder om uw account te activeren. U wordt doorgestuurd naar het inlogscherm."
+msgstr "Klik op de knop hieronder om je account te activeren. Je wordt doorgestuurd naar het inlogscherm."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "activation.confirm.title"
@@ -144,7 +144,7 @@ msgstr "Ik weet het zeker"
 
 #, elixir-autogen, elixir-format
 msgid "people.confirm_remove.text"
-msgstr "Weet u zeker dat u uzelf wilt verwijderen van dit project?"
+msgstr "Weet je zeker dat je jezelf uit dit project wilt verwijderen?"
 
 #, elixir-autogen, elixir-format
 msgid "Account activated successfully."
@@ -176,19 +176,27 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.label"
-msgstr "Ik ga akkoord met de PaNL %{terms_link} en het %{privacy_link}"
+msgstr "Ik ga akkoord met de %{terms_link} en het %{privacy_link} van Panl"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.privacy"
+msgstr "privacybeleid"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.terms"
+msgstr "algemene voorwaarden"
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.required"
-msgstr "U moet akkoord gaan met het privacybeleid om door te gaan"
+msgstr "Je moet akkoord gaan met de voorwaarden en het privacybeleid om door te gaan."
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.label"
-msgstr "Ik ga akkoord met de Next %{terms_link} en het %{privacy_link}"
+msgstr "Ik ga akkoord met de %{terms_link} en het %{privacy_link} van Next"
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.required"
-msgstr "U moet akkoord gaan met de voorwaarden en het privacybeleid om door te gaan"
+msgstr "Je moet akkoord gaan met de voorwaarden en het privacybeleid om door te gaan."
 
 #, elixir-autogen, elixir-format
 msgid "sso.error.generic"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-alliance.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-alliance.po
@@ -112,4 +112,4 @@ msgstr "Doorgaan"
 
 #, elixir-autogen, elixir-format
 msgid "tool.description"
-msgstr "U staat op het punt een vragenlijst te starten. Zodra u de vragenlijst heeft afgerond, komt u automatisch terug op deze pagina."
+msgstr "Je staat op het punt een vragenlijst te starten. Zodra je de vragenlijst hebt afgerond, kom je automatisch terug op deze pagina."

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -188,7 +188,7 @@ msgstr "Geen toestemming"
 
 #, elixir-autogen, elixir-format
 msgid "finished_view.body"
-msgstr "Bedankt voor uw deelname."
+msgstr "Bedankt voor je deelname."
 
 #, elixir-autogen, elixir-format
 msgid "finished_view.title"
@@ -418,7 +418,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "finished_view.body.redirect"
-msgstr "Bedankt. U heeft dit onderdeel afgerond. Klik op Doorgaan om verder te gaan."
+msgstr "Bedankt. Je hebt dit onderdeel afgerond. Klik op Doorgaan om verder te gaan."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "redirect.button"
@@ -438,11 +438,11 @@ msgstr "De standaardtaal voor Panl-studies is het Nederlands."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "finished_view.body.declined"
-msgstr "U heeft ervoor gekozen niet deel te nemen. Uw keuze is opgeslagen. U kunt dit venster nu sluiten."
+msgstr "Je hebt ervoor gekozen niet deel te nemen. Deze keuze is opgeslagen."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "finished_view.body.declined.redirect"
-msgstr "U heeft ervoor gekozen niet deel te nemen. Uw keuze is opgeslagen. U kunt dit venster nu sluiten."
+msgstr "Je hebt ervoor gekozen niet deel te nemen. Deze keuze is opgeslagen."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "finished_view.title.declined"
@@ -462,11 +462,11 @@ msgstr "Terug"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "finished_view.body.declined.redirect.platform"
-msgstr "U heeft ervoor gekozen niet deel te nemen. Uw keuze is opgeslagen. Klik op Doorgaan om verder te gaan naar %{platform}."
+msgstr "Je hebt ervoor gekozen niet deel te nemen. Deze keuze is opgeslagen. Klik op Doorgaan om verder te gaan naar %{platform}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "finished_view.body.redirect.platform"
-msgstr "Bedankt. U heeft dit onderdeel afgerond. Klik op Doorgaan om verder te gaan naar %{platform}."
+msgstr "Bedankt. Je hebt dit onderdeel afgerond. Klik op Doorgaan om verder te gaan naar %{platform}."
 
 #, elixir-autogen, elixir-format
 msgid "storage.failed.warning"
@@ -526,11 +526,11 @@ msgstr "Versturen"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.body"
-msgstr "U ontvangt binnenkort een e-mail met meer informatie."
+msgstr "Je ontvangt binnenkort een e-mail met meer informatie."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.title"
-msgstr "Bedankt voor uw interesse in panl"
+msgstr "Bedankt voor je interesse in Panl"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.title"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-consent.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-consent.po
@@ -17,7 +17,7 @@ msgstr "<div>Voeg hier de voorwaarden toe waar deelnemers goedkeuring op moeten 
 
 #, elixir-autogen, elixir-format
 msgid "click_wrap.consent.validation"
-msgstr "Gaat u akkoord met de bovenstaande voorwaarden?"
+msgstr "Ga je akkoord met de bovenstaande voorwaarden?"
 
 #, elixir-autogen, elixir-format
 msgid "locked.error.message"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-crew.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-crew.po
@@ -52,7 +52,7 @@ msgstr "Gestart"
 
 #, elixir-autogen, elixir-format
 msgid "home.intro.description"
-msgstr "Het Next-platform biedt open-source, direct beschikbare softwarediensten die zijn ontworpen om uw onderzoek efficiënt te laten verlopen. Ze worden door Eyra ontwikkeld, voor en samen met onderzoekers, en worden voortdurend verbeterd. Klaar om aan de slag te gaan? U vindt hieronder alles wat u nodig hebt."
+msgstr "Het Next-platform biedt open-source, direct beschikbare softwarediensten die zijn ontworpen om je onderzoek efficiënt te laten verlopen. Ze worden door Eyra ontwikkeld, voor en samen met onderzoekers, en worden voortdurend verbeterd. Klaar om aan de slag te gaan? Je vindt hieronder alles wat je nodig hebt."
 
 #, elixir-autogen, elixir-format
 msgid "home.intro.image_alt"
@@ -72,7 +72,7 @@ msgstr "Ontdek de diensten"
 
 #, elixir-autogen, elixir-format
 msgid "home.services.description"
-msgstr "Benieuwd naar de softwarediensten die u op het platform kunt gebruiken? Klik op de knop hieronder om de beschikbare diensten en bijbehorende prijzen te bekijken. Het Next-platform is advertentievrij en hanteert een eerlijk prijsmodel om de lange termijn duurzaamheid te ondersteunen. Door een dienst aan te schaffen, draagt u direct bij aan het open ecosysteem dat het platform beschikbaar houdt voor onderzoekers zoals u."
+msgstr "Benieuwd naar de softwarediensten die je op het platform kunt gebruiken? Klik op de knop hieronder om de beschikbare diensten en bijbehorende prijzen te bekijken. Het Next-platform is advertentievrij en hanteert een eerlijk prijsmodel om de lange termijn duurzaamheid te ondersteunen. Door een dienst aan te schaffen, draag je direct bij aan het open ecosysteem dat het platform beschikbaar houdt voor onderzoekers."
 
 #, elixir-autogen, elixir-format
 msgid "home.services.image_alt"
@@ -96,7 +96,7 @@ msgstr "Account aanmaken"
 
 #, elixir-autogen, elixir-format
 msgid "home.steps.step2.description"
-msgstr "Start uw eerste project en kies een softwaredienst. U zult zien hoe eenvoudig het is om alles in te stellen en aan te passen."
+msgstr "Start je eerste project en kies een softwaredienst. Je zult zien hoe eenvoudig het is om alles in te stellen en aan te passen."
 
 #, elixir-autogen, elixir-format
 msgid "home.steps.step2.title"
@@ -104,7 +104,7 @@ msgstr "Maak een project aan"
 
 #, elixir-autogen, elixir-format
 msgid "home.steps.step3.description"
-msgstr "Bekijk en deel uw project gratis met andere platformgebruikers. Er geldt pas een vergoeding wanneer u publiceert of een dienst gebruikt voor uw onderzoek."
+msgstr "Bekijk en deel je project gratis met andere platformgebruikers. Er geldt pas een vergoeding wanneer je publiceert of een dienst gebruikt voor je onderzoek."
 
 #, elixir-autogen, elixir-format
 msgid "home.steps.step3.title"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-feldspar.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-feldspar.po
@@ -53,7 +53,7 @@ msgstr "Het geselecteerde bestand is te groot (max 20MB)"
 
 #, elixir-autogen, elixir-format
 msgid "tool.description"
-msgstr "U staat op het punt om een aantal stappen te doorlopen om uw gegevens te doneren. Vooraf kunt u uw gegevens bekijken en daarna toestemming geven om ze te delen. Het laden van de pagina kan even duren — dank u wel voor uw geduld."
+msgstr "Je staat op het punt om een aantal stappen te doorlopen om je gegevens te doneren. Vooraf kun je je gegevens bekijken en daarna toestemming geven om ze te delen. Het laden van de pagina kan even duren — bedankt voor je geduld."
 
 #, elixir-autogen, elixir-format
 msgid "tool.button"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-manual.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-manual.po
@@ -41,7 +41,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "setup.annotation"
-msgstr "<div><h1>Hoe stelt u instructies voor deelnemers in?</h1><ul><li>Maak <strong>secties</strong> om de instructies op te delen in duidelijke onderdelen.</li><li>Gebruik <strong>labels</strong> voor secties om deelnemers te helpen de relevante sectie te vinden.</li><li>Voeg meerdere korte <strong>instructies</strong> toe binnen elke sectie.</li><li>Voeg <strong>afbeeldingen</strong> toe om instructies gemakkelijker te volgen te maken.</li></ul></div>"
+msgstr "<div><h1>Hoe stel je instructies voor deelnemers in?</h1><ul><li>Maak <strong>secties</strong> om de instructies op te delen in duidelijke onderdelen.</li><li>Gebruik <strong>labels</strong> voor secties om deelnemers te helpen de relevante sectie te vinden.</li><li>Voeg meerdere korte <strong>instructies</strong> toe binnen elke sectie.</li><li>Voeg <strong>afbeeldingen</strong> toe om instructies gemakkelijker te volgen te maken.</li></ul></div>"
 
 #, elixir-autogen, elixir-format
 msgid "builder.chapter.overview"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -186,7 +186,15 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.label"
-msgstr "Sunt de acord cu %{terms_link} și %{privacy_link} PaNL"
+msgstr "Sunt de acord cu %{terms_link} și cu %{privacy_link} ale Panl"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.privacy"
+msgstr "politica de confidențialitate"
+
+#, elixir-autogen, elixir-format
+msgid "privacy.link.terms"
+msgstr "termenii și condițiile"
 
 #, elixir-autogen, elixir-format
 msgid "panl.privacy.policy.required"
@@ -194,7 +202,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.label"
-msgstr "Sunt de acord cu %{terms_link} și %{privacy_link} Next"
+msgstr "Sunt de acord cu %{terms_link} și cu %{privacy_link} ale Next"
 
 #, elixir-autogen, elixir-format
 msgid "privacy.next-policy.required"


### PR DESCRIPTION
Changes:
- Added copy for terms and privacy policy links in all languages for the sign up page
- For the NL copy for participants, changed the copy containing "U" to "Je"
- Fixed a typo: dutch --> Dutch

# Pull request

## Basecamp link
https://3.basecamp.com/5734045/buckets/35926565/todos/9803835731