### PR TITLE
Normalize Panl capitalization in translations

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -499,7 +499,7 @@ msgstr "Konto aktivieren"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.body"
-msgstr "Hinterlassen Sie Ihre E-Mail-Adresse, um Informationen zur Teilnahme an Forschung über panl zu erhalten."
+msgstr "Hinterlassen Sie Ihre E-Mail-Adresse, um Informationen zur Teilnahme an Forschung über Panl zu erhalten."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.email.label"
@@ -531,7 +531,7 @@ msgstr "Sie erhalten in Kürze eine E-Mail mit weiteren Informationen."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.title"
-msgstr "Vielen Dank für Ihr Interesse an panl"
+msgstr "Vielen Dank für Ihr Interesse an Panl"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.title"

--- a/core/priv/gettext/de/LC_MESSAGES/link-advert.po
+++ b/core/priv/gettext/de/LC_MESSAGES/link-advert.po
@@ -93,4 +93,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "submission.available.sub_heading"
-msgstr "Hier findest du die aktuellsten Studien, die im panl-Pool veröffentlicht wurden. Klicke auf eine Studie, um weitere Details zu lesen."
+msgstr "Hier findest du die aktuellsten Studien, die im Panl-Pool veröffentlicht wurden. Klicke auf eine Studie, um weitere Details zu lesen."

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -498,7 +498,7 @@ msgstr "Activate your account"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.body"
-msgstr "Leave your email address to receive information about participating in research via panl."
+msgstr "Leave your email address to receive information about participating in research via Panl."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.email.label"
@@ -530,7 +530,7 @@ msgstr "You will receive an email with more information soon."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.title"
-msgstr "Thank you for your interest in panl"
+msgstr "Thank you for your interest in Panl"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.title"

--- a/core/priv/gettext/en/LC_MESSAGES/link-advert.po
+++ b/core/priv/gettext/en/LC_MESSAGES/link-advert.po
@@ -92,4 +92,4 @@ msgstr "Go to Settings"
 
 #, elixir-autogen, elixir-format
 msgid "submission.available.sub_heading"
-msgstr "Here you can find the most recent studies published in the panl pool. Click on a study to read more details."
+msgstr "Here you can find the most recent studies published in the Panl pool. Click on a study to read more details."

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -499,7 +499,7 @@ msgstr "Active su cuenta"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.body"
-msgstr "Deja tu dirección de correo electrónico para recibir información sobre cómo participar en investigaciones a través de panl."
+msgstr "Deja tu dirección de correo electrónico para recibir información sobre cómo participar en investigaciones a través de Panl."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.email.label"
@@ -531,7 +531,7 @@ msgstr "Recibirás pronto un correo electrónico con más información."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.title"
-msgstr "Gracias por tu interés en panl"
+msgstr "Gracias por tu interés en Panl"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.title"

--- a/core/priv/gettext/es/LC_MESSAGES/link-advert.po
+++ b/core/priv/gettext/es/LC_MESSAGES/link-advert.po
@@ -93,4 +93,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "submission.available.sub_heading"
-msgstr "Aquí encontrarás los estudios más recientes publicados en el pool de panl. Haz clic en un estudio para leer más detalles."
+msgstr "Aquí encontrarás los estudios más recientes publicados en el pool de Panl. Haz clic en un estudio para leer más detalles."

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -499,7 +499,7 @@ msgstr "Attiva il tuo account"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.body"
-msgstr "Lascia il tuo indirizzo email per ricevere informazioni su come partecipare alla ricerca tramite panl."
+msgstr "Lascia il tuo indirizzo email per ricevere informazioni su come partecipare alla ricerca tramite Panl."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.email.label"
@@ -531,7 +531,7 @@ msgstr "Riceverai presto un'email con maggiori informazioni."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.title"
-msgstr "Grazie per il tuo interesse in panl"
+msgstr "Grazie per il tuo interesse in Panl"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.title"

--- a/core/priv/gettext/it/LC_MESSAGES/link-advert.po
+++ b/core/priv/gettext/it/LC_MESSAGES/link-advert.po
@@ -93,4 +93,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "submission.available.sub_heading"
-msgstr "Qui di seguito trovi i più recenti studi pubblicati nel pool di panl. Clicca su uno studio per leggere ulteriori dettagli."
+msgstr "Qui di seguito trovi i più recenti studi pubblicati nel pool di Panl. Clicca su uno studio per leggere ulteriori dettagli."

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -509,7 +509,7 @@ msgstr "Aktyvuokite savo paskyrą"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.body"
-msgstr "Palikite savo el. pašto adresą, kad gautumėte informacijos apie dalyvavimą tyrimuose per panl."
+msgstr "Palikite savo el. pašto adresą, kad gautumėte informacijos apie dalyvavimą tyrimuose per Panl."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.email.label"
@@ -541,7 +541,7 @@ msgstr "Netrukus gausite el. laišką su daugiau informacijos."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.title"
-msgstr "Ačiū, kad domitės panl"
+msgstr "Ačiū, kad domitės Panl"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.title"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -498,7 +498,7 @@ msgstr "Activeer je account"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.body"
-msgstr "Laat je e-mailadres achter om informatie te ontvangen over meedoen aan onderzoek via panl."
+msgstr "Laat je e-mailadres achter om informatie te ontvangen over meedoen aan onderzoek via Panl."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.email.label"

--- a/core/priv/gettext/nl/LC_MESSAGES/link-advert.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/link-advert.po
@@ -92,4 +92,4 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "submission.available.sub_heading"
-msgstr "Hieronder vind je de meest recente studies die in panl pool gepubliceerd zijn. Klik op een studie om meer details te lezen."
+msgstr "Hieronder vind je de meest recente studies die in Panl pool gepubliceerd zijn. Klik op een studie om meer details te lezen."

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -509,7 +509,7 @@ msgstr "Activați-vă contul"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.body"
-msgstr "Lăsați adresa de email pentru a primi informații despre participarea la cercetare prin panl."
+msgstr "Lăsați adresa de email pentru a primi informații despre participarea la cercetare prin Panl."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.email.label"
@@ -541,7 +541,7 @@ msgstr "Veți primi în curând un e-mail cu mai multe informații."
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.success.title"
-msgstr "Vă mulțumim pentru interesul față de panl"
+msgstr "Vă mulțumim pentru interesul față de Panl"
 
 #, elixir-autogen, elixir-format
 msgid "email_capture.title"


### PR DESCRIPTION
## Summary
- Fix 18 occurrences of lowercase "panl" to "Panl" in translation msgstr values
- Across all 7 locales in eyra-assignment.po and link-advert.po

## Test plan
- [ ] Verify Panl name shows capitalized in participant flow
- [ ] Verify Panl name shows capitalized on home page adverts