### PR TITLE
Fix flaky goto-advert-button click in PaNL study advert feature test

### DIFF
--- a/core/test/features/panl_study_advert_test.exs
+++ b/core/test/features/panl_study_advert_test.exs
@@ -107,17 +107,22 @@ defmodule CoreWeb.Features.PanlStudyAdvertTest do
     |> click(Query.css("[data-testid='create-advert-button']"))
     |> assert_has(Query.css("[data-testid='goto-advert-button']"))
 
-    # Publish the assignment
+    # Publish the assignment. Wait for the retract-button to appear — it
+    # replaces publish-button once status flips to :online, so its presence
+    # is a stable signal that the publish-triggered DOM morphs have settled.
     researcher_session
     |> assert_has(Query.css("[data-testid='publish-button']"))
     |> click(Query.css("[data-testid='publish-button']"))
-    |> assert_has(Query.css("[data-phx-main].phx-connected"))
+    |> assert_has(Query.css("[data-testid='retract-button']"))
 
-    # Navigate to the advert
+    # Navigate to the advert. Wrapped in retry_stale to re-find the button
+    # if its element reference is invalidated between find and action.
+    retry_stale do
+      researcher_session |> click(Query.css("[data-testid='goto-advert-button']"))
+    end
+
     researcher_session
-    |> assert_has(Query.css("[data-testid='goto-advert-button']"))
-    |> click(Query.css("[data-testid='goto-advert-button']"))
-    |> assert_has(Query.css("[data-phx-main].phx-connected"))
+    |> assert_has(Query.css("[data-testid='advert-publish-button']"))
 
     # Publish the advert
     researcher_session


### PR DESCRIPTION
- Replace generic phx-connected post-click assertion with a wait for advert-publish-button — the page-specific element only present after navigation to the advert content page completes
- The phx-connected indicator can be true on both the source and target pages, allowing the test to proceed before navigation settled and causing intermittent stale-reference and timeout failures

# Pull request

## Basecamp link

...

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have not added superfluous logging
- [ ] I have added QA steps to the Basecamp ticket
- [ ] Security
  - [ ] I have considered the security implications of my changes
- [ ] Privacy
  - [ ] I have considered the privacy implications of my changes
  - [ ] I have checked new log messages for PII
  - [ ] I have added no unnecessary logging
