### PR TITLE
Refactor create_transaction signature into Transaction.Request struct

### DIFF
--- a/core/systems/budget/_public.ex
+++ b/core/systems/budget/_public.ex
@@ -95,17 +95,18 @@ defmodule Systems.Budget.Public do
     opts = [return_url: return_url]
     opts = if partner_fee > 0, do: Keyword.put(opts, :partner_fee, partner_fee), else: opts
 
-    with {:ok, provider_result} <-
-           Payment.Public.create_transaction(
-             merchant_uid,
-             total_amount,
-             currency,
-             invoice_id,
-             idempotence_key,
-             description,
-             metadata,
-             opts
-           ),
+    request = %Payment.Transaction.Request{
+      merchant_uid: merchant_uid,
+      total_amount: total_amount,
+      currency: currency,
+      invoice_id: invoice_id,
+      idempotence_key: idempotence_key,
+      description: description,
+      metadata: metadata,
+      opts: opts
+    }
+
+    with {:ok, provider_result} <- Payment.Public.create_transaction(request),
          {:ok, transaction} <-
            %Budget.TransactionModel{}
            |> Budget.TransactionModel.changeset(%{

--- a/core/systems/payment/_public.ex
+++ b/core/systems/payment/_public.ex
@@ -25,36 +25,10 @@ defmodule Systems.Payment.Public do
 
   # Transactions
 
-  @spec create_transaction(
-          merchant_uid :: String.t(),
-          total_amount :: pos_integer(),
-          currency :: atom(),
-          invoice_id :: String.t(),
-          idempotence_key :: String.t(),
-          description :: Transaction.Description.t(),
-          metadata :: Transaction.Metadata.t(),
-          opts :: keyword()
-        ) :: {:ok, Provider.transaction()} | {:error, Error.t()}
-  def create_transaction(
-        merchant_uid,
-        total_amount,
-        currency,
-        invoice_id,
-        idempotence_key,
-        description,
-        metadata,
-        opts \\ []
-      ) do
-    provider().create_transaction(
-      merchant_uid,
-      total_amount,
-      currency,
-      invoice_id,
-      idempotence_key,
-      description,
-      metadata,
-      opts
-    )
+  @spec create_transaction(Transaction.Request.t()) ::
+          {:ok, Provider.transaction()} | {:error, Error.t()}
+  def create_transaction(%Transaction.Request{} = request) do
+    provider().create_transaction(request)
   end
 
   @spec get_transaction(uid :: String.t()) :: {:ok, Provider.transaction()} | {:error, Error.t()}

--- a/core/systems/payment/provider.ex
+++ b/core/systems/payment/provider.ex
@@ -56,16 +56,8 @@ defmodule Systems.Payment.Provider do
     * `return_url` - redirect URL after payment completion
     * `notify_url` - webhook URL for transaction status updates
   """
-  @callback create_transaction(
-              merchant_uid :: String.t(),
-              total_amount :: pos_integer(),
-              currency :: atom(),
-              invoice_id :: String.t(),
-              idempotence_key :: String.t(),
-              description :: Transaction.Description.t(),
-              metadata :: Transaction.Metadata.t(),
-              opts :: keyword()
-            ) :: {:ok, transaction()} | {:error, Error.t()}
+  @callback create_transaction(request :: Transaction.Request.t()) ::
+              {:ok, transaction()} | {:error, Error.t()}
   @callback get_transaction(uid :: String.t()) :: {:ok, transaction()} | {:error, Error.t()}
 
   # Withdrawals

--- a/core/systems/payment/provider/local.ex
+++ b/core/systems/payment/provider/local.ex
@@ -30,16 +30,16 @@ defmodule Systems.Payment.Provider.Local do
   # Transactions
 
   @impl true
-  def create_transaction(
-        merchant_uid,
-        total_amount,
-        currency,
-        invoice_id,
-        idempotence_key,
-        %Transaction.Description{} = description,
-        %Transaction.Metadata{},
-        opts
-      )
+  def create_transaction(%Transaction.Request{
+        merchant_uid: merchant_uid,
+        total_amount: total_amount,
+        currency: currency,
+        invoice_id: invoice_id,
+        idempotence_key: idempotence_key,
+        description: %Transaction.Description{} = description,
+        metadata: %Transaction.Metadata{},
+        opts: opts
+      })
       when is_binary(merchant_uid) and is_integer(total_amount) and total_amount > 0 and
              is_atom(currency) and is_binary(invoice_id) and is_binary(idempotence_key) do
     uid = generate_uid()

--- a/core/systems/payment/provider/opp.ex
+++ b/core/systems/payment/provider/opp.ex
@@ -62,16 +62,16 @@ defmodule Systems.Payment.Provider.OPP do
   # Transactions
 
   @impl true
-  def create_transaction(
-        merchant_uid,
-        total_amount,
-        currency,
-        invoice_id,
-        idempotence_key,
-        %Transaction.Description{} = description,
-        %Transaction.Metadata{} = metadata,
-        opts
-      )
+  def create_transaction(%Transaction.Request{
+        merchant_uid: merchant_uid,
+        total_amount: total_amount,
+        currency: currency,
+        invoice_id: invoice_id,
+        idempotence_key: idempotence_key,
+        description: %Transaction.Description{} = description,
+        metadata: %Transaction.Metadata{} = metadata,
+        opts: opts
+      })
       when is_binary(merchant_uid) and is_integer(total_amount) and total_amount > 0 and
              is_atom(currency) and is_binary(invoice_id) and is_binary(idempotence_key) do
     notify_url = Systems.Payment.Public.webhook_url()

--- a/core/systems/payment/transaction.ex
+++ b/core/systems/payment/transaction.ex
@@ -1,6 +1,43 @@
 defmodule Systems.Payment.Transaction do
   @moduledoc false
 
+  defmodule Request do
+    @moduledoc false
+
+    alias Systems.Payment.Transaction
+
+    @type t :: %__MODULE__{
+            merchant_uid: String.t(),
+            total_amount: pos_integer(),
+            currency: atom(),
+            invoice_id: String.t(),
+            idempotence_key: String.t(),
+            description: Transaction.Description.t(),
+            metadata: Transaction.Metadata.t(),
+            opts: keyword()
+          }
+
+    @enforce_keys [
+      :merchant_uid,
+      :total_amount,
+      :currency,
+      :invoice_id,
+      :idempotence_key,
+      :description,
+      :metadata
+    ]
+    defstruct [
+      :merchant_uid,
+      :total_amount,
+      :currency,
+      :invoice_id,
+      :idempotence_key,
+      :description,
+      :metadata,
+      opts: []
+    ]
+  end
+
   defmodule Description do
     @moduledoc false
 

--- a/core/test/systems/payment/provider_test.exs
+++ b/core/test/systems/payment/provider_test.exs
@@ -27,7 +27,7 @@ defmodule Systems.Payment.ProviderTest do
     end
   end
 
-  describe "create_transaction/8" do
+  describe "create_transaction/1" do
     test "returns transaction with payment url" do
       description = %Transaction.Description{
         platform: "Eyra Next",
@@ -44,18 +44,18 @@ defmodule Systems.Payment.ProviderTest do
         amount_per_participant: 250
       }
 
-      invoice_id = "NEXT-NL-0128"
-      idempotence_key = "assignment=1,user=42,type=payment"
+      request = %Transaction.Request{
+        merchant_uid: "m1",
+        total_amount: 10_000,
+        currency: :EUR,
+        invoice_id: "NEXT-NL-0128",
+        idempotence_key: "assignment=1,user=42,type=payment",
+        description: description,
+        metadata: metadata
+      }
 
       ProviderMock
-      |> expect(:create_transaction, fn "m1",
-                                        10_000,
-                                        :EUR,
-                                        ^invoice_id,
-                                        ^idempotence_key,
-                                        ^description,
-                                        ^metadata,
-                                        [] ->
+      |> expect(:create_transaction, fn ^request ->
         {:ok,
          %{
            uid: "t1",
@@ -66,16 +66,7 @@ defmodule Systems.Payment.ProviderTest do
       end)
 
       assert {:ok, %{uid: "t1", payment_url: url}} =
-               ProviderMock.create_transaction(
-                 "m1",
-                 10_000,
-                 :EUR,
-                 invoice_id,
-                 idempotence_key,
-                 description,
-                 metadata,
-                 []
-               )
+               ProviderMock.create_transaction(request)
 
       assert is_binary(url)
     end


### PR DESCRIPTION
- Add Systems.Payment.Transaction.Request struct alongside the existing Description and Metadata structs, wrapping merchant_uid, total_amount, currency, invoice_id, idempotence_key, description, metadata, and opts
- Collapse the 8-arg Provider.create_transaction/8 callback to /1
- Update OPP and Local provider implementations to pattern-match the struct
- Update Payment.Public.create_transaction/8 forwarder to /1
- Update Budget.Public.create_paid_pay_in caller to build the struct
- Update provider_test.exs to use the struct shape

Fixes: FX#9895598018

# Pull request

## Basecamp link

...

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have not added superfluous logging
- [ ] I have added QA steps to the Basecamp ticket
- [ ] Security
  - [ ] I have considered the security implications of my changes
- [ ] Privacy
  - [ ] I have considered the privacy implications of my changes
  - [ ] I have checked new log messages for PII
  - [ ] I have added no unnecessary logging
