### PR TITLE
Fix SURFconext config key: site → base_url

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -160,7 +160,7 @@ config :core, Systems.Email.Mailer,
 config :core, Core.SurfConext,
   client_id: "not-set",
   client_secret: "not-set",
-  site: "https://connect.test.surfconext.nl",
+  base_url: "https://connect.test.surfconext.nl",
   redirect_uri: "not-set",
   limit_schac_home_organization: nil
 

--- a/core/config/runtime.aws.exs
+++ b/core/config/runtime.aws.exs
@@ -182,7 +182,7 @@ if config_env() == :prod do
 
   config :core, Core.SurfConext,
     redirect_uri: "#{base_url}/auth/surfconext/callback",
-    site: System.get_env("SURFCONEXT_SITE"),
+    base_url: System.get_env("SURFCONEXT_SITE"),
     client_id: System.get_env("SURFCONEXT_CLIENT_ID"),
     client_secret: System.get_env("SURFCONEXT_CLIENT_SECRET")
 

--- a/core/config/runtime.fly.exs
+++ b/core/config/runtime.fly.exs
@@ -164,7 +164,7 @@ if config_env() == :prod do
 
   config :core, Core.SurfConext,
     redirect_uri: "#{base_url}/auth/surfconext/callback",
-    site: System.get_env("SURFCONEXT_SITE"),
+    base_url: System.get_env("SURFCONEXT_SITE"),
     client_id: System.get_env("SURFCONEXT_CLIENT_ID"),
     client_secret: System.get_env("SURFCONEXT_CLIENT_SECRET")
 

--- a/core/test/core/surfconext/plug_test.exs
+++ b/core/test/core/surfconext/plug_test.exs
@@ -51,7 +51,7 @@ defmodule Core.SurfConext.FakeOIDC do
   end
 
   def authorize_url(config) do
-    {:ok, %{url: Keyword.get(config, :site), session_params: %{some: :stuff}}}
+    {:ok, %{url: Keyword.get(config, :base_url), session_params: %{some: :stuff}}}
   end
 end
 
@@ -68,7 +68,7 @@ defmodule Core.SurfConext.AuthorizePlug.Test do
       Application.put_env(:test, Core.SurfConext,
         client_id: domain,
         client_secret: Faker.Lorem.sentence(),
-        site: "https://connect.test.surfconext.nl",
+        base_url: "https://connect.test.surfconext.nl",
         redirect_uri: "https://#{domain}/auth/surfconext/callback",
         oidc_module: Core.SurfConext.FakeOIDC
       )
@@ -101,7 +101,7 @@ defmodule Core.SurfConext.CallbackController.Test do
     test_conf = [
       client_id: domain,
       client_secret: Faker.Lorem.sentence(),
-      site: "https://connect.test.surfconext.nl",
+      base_url: "https://connect.test.surfconext.nl",
       redirect_uri: "https://#{domain}/auth/surfconext/callback",
       oidc_module: Core.SurfConext.FakeOIDC
     ]


### PR DESCRIPTION
## Summary

Assent OIDC requires `:base_url`; SURFconext config was passing `:site` (legacy key from before the Assent dep update at `f26a706a5`). Result: any request to `/auth/surfconext` crashed with `Assent.MissingConfigError`.

Nobody noticed earlier because creators sign in with passwords. Staging deploy of #1509 was the first time the SURFconext OIDC flow was actually exercised end-to-end.

## Changes

- `core/config/config.exs`: `site:` → `base_url:`
- `core/config/runtime.fly.exs`: `site: System.get_env("SURFCONEXT_SITE")` → `base_url: ...`
- `core/config/runtime.aws.exs`: same
- `core/test/core/surfconext/plug_test.exs`: test fixtures + FakeOIDC stub updated to match

Env var name `SURFCONEXT_SITE` is kept — only the Elixir config key changed, so no devops/secrets update needed.

## Test plan

- [x] `mix test test/core/surfconext/` — 13/13 pass
- [ ] After merge → redeploy staging → `/auth/surfconext` should redirect to SURFconext IdP instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)