### PR TITLE
Add translations for auth.signup.* and terms_and_privacy.onboarding.*

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -229,16 +229,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.body"
-msgstr ""
+msgstr "Sie sind jetzt mit Ihrem institutionellen Konto angemeldet. Bitte lesen Sie die Allgemeinen Geschäftsbedingungen und die Datenschutzerklärung, bevor Sie fortfahren."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms"
-msgstr ""
+msgstr "Ich stimme den %{terms} und der %{privacy} zu."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms.required"
-msgstr ""
+msgstr "Bitte akzeptieren Sie die Allgemeinen Geschäftsbedingungen und die Datenschutzerklärung, um fortzufahren."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.title"
-msgstr ""
+msgstr "Willkommen"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-next.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-next.po
@@ -25,12 +25,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.body"
-msgstr ""
+msgstr "Melden Sie sich mit Ihrem institutionellen Konto an, um fortzufahren.<br>Sie werden zur sicheren Anmeldeseite von %{identity_provider} weitergeleitet."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.button"
-msgstr ""
+msgstr "Anmelden mit %{identity_provider}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.title"
-msgstr ""
+msgstr "Willkommen"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -229,16 +229,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.body"
-msgstr ""
+msgstr "Ahora ha iniciado sesión con su cuenta institucional. Antes de continuar, revise los Términos y la Declaración de Privacidad."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms"
-msgstr ""
+msgstr "Acepto los %{terms} y la %{privacy}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms.required"
-msgstr ""
+msgstr "Acepte los términos y la declaración de privacidad para continuar."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.title"
-msgstr ""
+msgstr "Bienvenido"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-next.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-next.po
@@ -25,12 +25,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.body"
-msgstr ""
+msgstr "Inicie sesión con su cuenta institucional para continuar.<br>Será redirigido a la página de inicio de sesión segura de %{identity_provider}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.button"
-msgstr ""
+msgstr "Iniciar sesión con %{identity_provider}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.title"
-msgstr ""
+msgstr "Bienvenido"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -229,16 +229,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.body"
-msgstr ""
+msgstr "Hai effettuato l'accesso con il tuo account istituzionale. Prima di continuare, rivedi i Termini e l'Informativa sulla privacy."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms"
-msgstr ""
+msgstr "Accetto i %{terms} e l'%{privacy}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms.required"
-msgstr ""
+msgstr "Accetta i termini e l'informativa sulla privacy per continuare."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.title"
-msgstr ""
+msgstr "Benvenuto"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-next.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-next.po
@@ -25,12 +25,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.body"
-msgstr ""
+msgstr "Accedi con il tuo account istituzionale per continuare.<br>Verrai reindirizzato alla pagina di accesso sicura di %{identity_provider}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.button"
-msgstr ""
+msgstr "Accedi con %{identity_provider}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.title"
-msgstr ""
+msgstr "Benvenuto"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -238,16 +238,16 @@ msgstr "Ką norite pridėti?"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.body"
-msgstr ""
+msgstr "Dabar esate prisijungę naudodami savo institucinę paskyrą. Prieš tęsdami, peržiūrėkite Sąlygas ir Privatumo politiką."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms"
-msgstr ""
+msgstr "Sutinku su %{terms} ir %{privacy}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms.required"
-msgstr ""
+msgstr "Norėdami tęsti, sutikite su sąlygomis ir privatumo politika."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.title"
-msgstr ""
+msgstr "Sveiki"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-next.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-next.po
@@ -25,12 +25,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.body"
-msgstr ""
+msgstr "Prisijunkite naudodami savo institucinę paskyrą, kad galėtumėte tęsti.<br>Būsite nukreipti į saugų %{identity_provider} prisijungimo puslapį."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.button"
-msgstr ""
+msgstr "Prisijungti su %{identity_provider}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.title"
-msgstr ""
+msgstr "Sveiki"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
@@ -228,16 +228,16 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.body"
-msgstr ""
+msgstr "Je bent nu ingelogd met je institutionele account. Lees de Algemene Voorwaarden en het Privacybeleid voordat je verdergaat."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms"
-msgstr ""
+msgstr "Ik ga akkoord met de %{terms} en het %{privacy}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms.required"
-msgstr ""
+msgstr "Accepteer de algemene voorwaarden en privacyverklaring om door te gaan."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.title"
-msgstr ""
+msgstr "Welkom"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-next.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-next.po
@@ -25,12 +25,12 @@ msgstr "Heeft jouw organisatie toestemming gegeven om in te loggen via SURFconex
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.body"
-msgstr ""
+msgstr "Log in met je institutionele account om door te gaan.<br>Je wordt doorgestuurd naar de beveiligde inlogpagina van %{identity_provider}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.button"
-msgstr ""
+msgstr "Inloggen met %{identity_provider}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.title"
-msgstr ""
+msgstr "Welkom"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -238,16 +238,16 @@ msgstr "Pe cine doriți să adăugați?"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.body"
-msgstr ""
+msgstr "V-ați conectat acum cu contul instituțional. Înainte de a continua, vă rugăm să examinați Termenii și Declarația de confidențialitate."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms"
-msgstr ""
+msgstr "Sunt de acord cu %{terms} și %{privacy}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.terms.required"
-msgstr ""
+msgstr "Vă rugăm să acceptați termenii și declarația de confidențialitate pentru a continua."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "terms_and_privacy.onboarding.title"
-msgstr ""
+msgstr "Bun venit"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-next.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-next.po
@@ -25,12 +25,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.body"
-msgstr ""
+msgstr "Conectați-vă cu contul instituțional pentru a continua.<br>Veți fi redirecționat către pagina securizată de autentificare %{identity_provider}."
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.button"
-msgstr ""
+msgstr "Conectați-vă cu %{identity_provider}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "auth.signup.title"
-msgstr ""
+msgstr "Bun venit"


### PR DESCRIPTION
## Summary

PR #1509 introduced these keys but only filled the EN msgstrs. ES/DE/NL/IT/LT/RO were empty, so staging rendered the raw msgid ("auth.signup.title", etc.) for non-EN users.

These keys never existed in milestone/23, so restoring from master couldn't supply translations — they had to be written.

## Keys covered

- `eyra-next.po`: `auth.signup.{title,body,button}`
- `eyra-account.po`: `terms_and_privacy.onboarding.{title,body,terms,terms.required}`

6 locales × 7 keys = 42 msgstrs, best-effort. **Translators should review** (NL/DE/ES/IT/RO confident; LT best-effort).

## Test plan

- [ ] On staging post-merge, sign in flow + onboarding render localized strings (not raw msgids) for all 6 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)