### PR TITLE
Merge milestone/23 hotfixes into master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ======================
 # Builder Stage
 # ======================
-FROM debian:trixie-20260406 AS builder
+FROM debian:12 AS builder
 
 WORKDIR /root
 
@@ -125,7 +125,7 @@ RUN echo "Release build info:" && \
 # =======================
 # Prod Stage
 # =======================
-FROM debian:13-slim AS prod
+FROM debian:12-slim AS prod
 
 RUN apt-get update && apt-get install -y \
       libssl-dev \

--- a/core/frameworks/utility/ecto_helper.ex
+++ b/core/frameworks/utility/ecto_helper.ex
@@ -72,11 +72,13 @@ defmodule Frameworks.Utility.EctoHelper do
 
   def apply_virtual_change(changeset, field, virtual, delimiters)
       when is_atom(field) and is_atom(virtual) and is_list(delimiters) do
-    if virtual_string = Changeset.get_change(changeset, virtual) do
-      value = virtual_string |> String.split(delimiters, trim: true)
-      Changeset.put_change(changeset, field, value)
-    else
-      changeset
+    case Map.fetch(changeset.params || %{}, to_string(virtual)) do
+      {:ok, virtual_string} when is_binary(virtual_string) ->
+        value = virtual_string |> String.split(delimiters, trim: true)
+        Changeset.put_change(changeset, field, value)
+
+      _ ->
+        changeset
     end
   end
 

--- a/core/systems/org/node_model.ex
+++ b/core/systems/org/node_model.ex
@@ -83,6 +83,7 @@ defmodule Systems.Org.NodeModel do
     |> apply_text_bundle_changes(attrs, :short_name_bundle)
     |> apply_virtual_changes()
     |> validate_required(@required_fields)
+    |> validate_length(:identifier, min: 1)
     |> unique_constraint(:identifier)
   end
 

--- a/core/test/frameworks/utility/ecto_helper_test.exs
+++ b/core/test/frameworks/utility/ecto_helper_test.exs
@@ -1,0 +1,48 @@
+defmodule Frameworks.Utility.EctoHelperTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Changeset
+  import Frameworks.Utility.EctoHelper, only: [apply_virtual_change: 4]
+
+  defmodule TestSchema do
+    use Ecto.Schema
+
+    embedded_schema do
+      field(:items, {:array, :string})
+      field(:items_string, :string, virtual: true)
+    end
+  end
+
+  defp changeset(data, params) do
+    cast({data, %{items: {:array, :string}, items_string: :string}}, params, [:items_string])
+  end
+
+  describe "apply_virtual_change/4" do
+    test "splits a non-empty virtual_string into the array field" do
+      cs =
+        %{items: ["old"], items_string: "old"}
+        |> changeset(%{"items_string" => "a b c"})
+        |> apply_virtual_change(:items, :items_string, [" ", ","])
+
+      assert get_change(cs, :items) == ["a", "b", "c"]
+    end
+
+    test "clears the array field when the user empties the virtual string" do
+      cs =
+        %{items: ["old"], items_string: "old"}
+        |> changeset(%{"items_string" => ""})
+        |> apply_virtual_change(:items, :items_string, [" ", ","])
+
+      assert get_change(cs, :items) == []
+    end
+
+    test "leaves the array field untouched when the virtual field is absent from params" do
+      cs =
+        %{items: ["old"], items_string: "old"}
+        |> changeset(%{})
+        |> apply_virtual_change(:items, :items_string, [" ", ","])
+
+      assert get_change(cs, :items) == nil
+    end
+  end
+end

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,12 @@
       "matchPackageNames": ["hackney"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Debian major bumps break AWS prod (Ubuntu 20.04 / glibc 2.31) — keep on debian:12 until prod is upgraded",
+      "matchPackageNames": ["debian"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Summary
Three post-release fixes that shipped in `core_2026-05-26_23` (release `next_2026-05-25_800`):

- Revert Dockerfile to `debian:12` for AWS-compatible release builds (`078c439f5`)
- Pin renovate to block Debian major bumps (`9cd4bedff`)
- Fix email-domain deletion silently failing on `org/edit` (`ca67f409b`)

## Test plan
- [x] Already manually verified on prod-bound build
- [x] `mix compile --warnings-as-errors`, `mix test`, credo, dialyzer all pass via pre-commit hooks
- [x] Email-domain deletion confirmed working locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)