### PR TITLE
Fix FunctionClauseError when toggling admin user filters

### DIFF
--- a/core/systems/admin/account_view.ex
+++ b/core/systems/admin/account_view.ex
@@ -81,12 +81,10 @@ defmodule Systems.Admin.AccountView do
     }
   end
 
+  # Selector (embedded LV without Fabric) falls back to send(self(), {event, payload}),
+  # which arrives here as handle_info — see Frameworks.Pixel.Selector.send_parent_event/3.
   @impl true
-  def handle_event(
-        "active_item_ids",
-        %{active_item_ids: active_filters, source: %{name: :account_filters}},
-        socket
-      ) do
+  def handle_info({"active_item_ids", %{active_item_ids: active_filters}}, socket) do
     {
       :noreply,
       socket


### PR DESCRIPTION
The admin AccountView is an :embedded_live_view (LiveNest, no Fabric). The Selector component's send_parent_event/3 checks for :fabric in assigns and falls back to plain send(self(), {event, payload}), which arrives as handle_info — not handle_event.

The previous clause was a handle_event with a :source key that the fallback payload never includes, so it could never match and any filter toggle crashed the LiveView.

Replace with a handle_info/2 clause matching the fallback message shape.

# Pull request

## Basecamp link

...

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have not added superfluous logging
- [ ] I have added QA steps to the Basecamp ticket
- [ ] Security
  - [ ] I have considered the security implications of my changes
- [ ] Privacy
  - [ ] I have considered the privacy implications of my changes
  - [ ] I have checked new log messages for PII
  - [ ] I have added no unnecessary logging
