### PR TITLE
Restore pending-approvals CTA on participants tab

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -696,3 +696,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "panl_participants.pending_approvals.description"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] ""
+msgstr[1] ""

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -695,3 +695,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.description"
+msgstr "Review the participants who finished their task and approve or reject their reward."
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr "Open pay-out overview"
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] "%{count} reward is waiting for your approval"
+msgstr[1] "%{count} rewards are waiting for your approval"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -696,3 +696,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "panl_participants.pending_approvals.description"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] ""
+msgstr[1] ""

--- a/core/priv/gettext/eyra-assignment.pot
+++ b/core/priv/gettext/eyra-assignment.pot
@@ -695,3 +695,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.description"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] ""
+msgstr[1] ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -696,3 +696,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "panl_participants.pending_approvals.description"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] ""
+msgstr[1] ""

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -706,3 +706,18 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "panl_participants.pending_approvals.description"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -695,3 +695,17 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.description"
+msgstr "Bekijk de deelnemers die hun taak hebben afgerond en keur hun beloning goed of af."
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr "Open uitbetalingsoverzicht"
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] "%{count} beloning wacht op goedkeuring"
+msgstr[1] "%{count} beloningen wachten op goedkeuring"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -706,3 +706,18 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payout.waiting.heading"
 msgstr ""
+
+#, elixir-autogen, elixir-format, fuzzy
+msgid "panl_participants.pending_approvals.description"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.open.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl_participants.pending_approvals.title.one"
+msgid_plural "panl_participants.pending_approvals.title.other"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""

--- a/core/systems/assignment/participants_view.ex
+++ b/core/systems/assignment/participants_view.ex
@@ -10,6 +10,7 @@ defmodule Systems.Assignment.ParticipantsView do
   alias Frameworks.Pixel.Logo
   alias Systems.Affiliate
   alias Systems.Advert
+  alias Systems.NextAction
   alias Systems.Pool
   alias Systems.Assignment
   alias Systems.Assignment.PaidSlotsLogic
@@ -54,6 +55,7 @@ defmodule Systems.Assignment.ParticipantsView do
       |> update_invite_title()
       |> update_invite_url()
       |> update_invite_annotation()
+      |> assign_pending_approvals()
       |> PaidSlotsLogic.assign_paid_slots_state()
     }
   end
@@ -76,6 +78,13 @@ defmodule Systems.Assignment.ParticipantsView do
     }
   end
 
+  def compose(:payout_modal, %{assignment: %{id: assignment_id}}) do
+    %{
+      module: Assignment.PayoutModal,
+      params: %{assignment_id: assignment_id}
+    }
+  end
+
   @impl true
   def handle_event(
         "create_advert",
@@ -90,6 +99,29 @@ defmodule Systems.Assignment.ParticipantsView do
     end
 
     {:noreply, socket}
+  end
+
+  def handle_event("open_payout_modal", _, socket) do
+    {
+      :noreply,
+      socket
+      |> compose_child(:payout_modal)
+      |> show_modal(:payout_modal, :compact)
+    }
+  end
+
+  def handle_event("payout_modal_close", _, socket) do
+    {
+      :noreply,
+      socket
+      |> hide_modal(:payout_modal)
+      |> PaidSlotsLogic.refresh_assignment()
+      |> assign_pending_approvals()
+    }
+  end
+
+  defp assign_pending_approvals(%{assigns: %{assignment: assignment}} = socket) do
+    assign(socket, pending_approvals: Assignment.Public.list_pending_payouts(assignment))
   end
 
   def update_advert_button(%{assigns: %{assignment: %{adverts: []}}} = socket) do
@@ -207,6 +239,26 @@ defmodule Systems.Assignment.ParticipantsView do
           </.child>
 
           <.spacing value="L" />
+
+          <%= if Enum.any?(@pending_approvals) do %>
+            <div data-testid="pending-approvals-cta">
+              <NextAction.View.highlight
+                title={
+                  dngettext(
+                    "eyra-assignment",
+                    "panl_participants.pending_approvals.title.one",
+                    "panl_participants.pending_approvals.title.other",
+                    length(@pending_approvals),
+                    count: length(@pending_approvals)
+                  )
+                }
+                description={dgettext("eyra-assignment", "panl_participants.pending_approvals.description")}
+                cta_label={dgettext("eyra-assignment", "panl_participants.pending_approvals.open.button")}
+                cta_action={%{type: :send, event: "open_payout_modal", target: @myself}}
+              />
+            </div>
+            <.spacing value="L" />
+          <% end %>
 
           <%= if @content_flags[:paid_slots] do %>
             <.paid_slots

--- a/core/systems/assignment/participants_view.ex
+++ b/core/systems/assignment/participants_view.ex
@@ -78,6 +78,7 @@ defmodule Systems.Assignment.ParticipantsView do
     }
   end
 
+  @impl true
   def compose(:payout_modal, %{assignment: %{id: assignment_id}}) do
     %{
       module: Assignment.PayoutModal,
@@ -101,6 +102,7 @@ defmodule Systems.Assignment.ParticipantsView do
     {:noreply, socket}
   end
 
+  @impl true
   def handle_event("open_payout_modal", _, socket) do
     {
       :noreply,
@@ -110,6 +112,7 @@ defmodule Systems.Assignment.ParticipantsView do
     }
   end
 
+  @impl true
   def handle_event("payout_modal_close", _, socket) do
     {
       :noreply,
@@ -240,25 +243,7 @@ defmodule Systems.Assignment.ParticipantsView do
 
           <.spacing value="L" />
 
-          <%= if Enum.any?(@pending_approvals) do %>
-            <div data-testid="pending-approvals-cta">
-              <NextAction.View.highlight
-                title={
-                  dngettext(
-                    "eyra-assignment",
-                    "panl_participants.pending_approvals.title.one",
-                    "panl_participants.pending_approvals.title.other",
-                    length(@pending_approvals),
-                    count: length(@pending_approvals)
-                  )
-                }
-                description={dgettext("eyra-assignment", "panl_participants.pending_approvals.description")}
-                cta_label={dgettext("eyra-assignment", "panl_participants.pending_approvals.open.button")}
-                cta_action={%{type: :send, event: "open_payout_modal", target: @myself}}
-              />
-            </div>
-            <.spacing value="L" />
-          <% end %>
+          <.pending_approvals_banner pending_approvals={@pending_approvals} target={@myself} />
 
           <%= if @content_flags[:paid_slots] do %>
             <.paid_slots
@@ -294,6 +279,38 @@ defmodule Systems.Assignment.ParticipantsView do
           </div>
         </Area.content>
       </div>
+    """
+  end
+
+  @doc """
+  Banner that surfaces participants whose rewards are awaiting researcher
+  approval. Renders nothing when `pending_approvals` is empty so the
+  enclosing layout stays compact in the common case.
+  """
+  attr(:pending_approvals, :list, required: true)
+  attr(:target, :any, required: true)
+
+  def pending_approvals_banner(assigns) do
+    ~H"""
+    <%= if Enum.any?(@pending_approvals) do %>
+      <div data-testid="pending-approvals-cta">
+        <NextAction.View.highlight
+          title={
+            dngettext(
+              "eyra-assignment",
+              "panl_participants.pending_approvals.title.one",
+              "panl_participants.pending_approvals.title.other",
+              length(@pending_approvals),
+              count: length(@pending_approvals)
+            )
+          }
+          description={dgettext("eyra-assignment", "panl_participants.pending_approvals.description")}
+          cta_label={dgettext("eyra-assignment", "panl_participants.pending_approvals.open.button")}
+          cta_action={%{type: :send, event: "open_payout_modal", target: @target}}
+        />
+      </div>
+      <.spacing value="L" />
+    <% end %>
     """
   end
 end

--- a/core/test/systems/assignment/participants_view_test.exs
+++ b/core/test/systems/assignment/participants_view_test.exs
@@ -1,0 +1,54 @@
+defmodule Systems.Assignment.ParticipantsViewTest do
+  @moduledoc """
+  Regression coverage for the participants tab's "pending approvals" CTA
+  banner. The full banner disappeared once in a silent refactor — these
+  tests assert the rendering condition so the next refactor catches it
+  at the test level instead of in production.
+  """
+  use ExUnit.Case, async: true
+  import Phoenix.LiveViewTest
+
+  alias Systems.Assignment.ParticipantsView
+
+  describe "pending_approvals_banner/1" do
+    test "renders the CTA when there are pending approvals" do
+      html =
+        render_component(&ParticipantsView.pending_approvals_banner/1, %{
+          pending_approvals: [%{reward_id: 1}],
+          target: :stub
+        })
+
+      assert html =~ ~s(data-testid="pending-approvals-cta")
+    end
+
+    test "renders nothing when there are no pending approvals" do
+      html =
+        render_component(&ParticipantsView.pending_approvals_banner/1, %{
+          pending_approvals: [],
+          target: :stub
+        })
+
+      refute html =~ ~s(data-testid="pending-approvals-cta")
+    end
+
+    test "wires the open_payout_modal event to the parent target" do
+      html =
+        render_component(&ParticipantsView.pending_approvals_banner/1, %{
+          pending_approvals: [%{reward_id: 1}],
+          target: :stub
+        })
+
+      assert html =~ ~s(phx-click="open_payout_modal")
+    end
+
+    test "uses the plural title when more than one approval is pending" do
+      html =
+        render_component(&ParticipantsView.pending_approvals_banner/1, %{
+          pending_approvals: [%{reward_id: 1}, %{reward_id: 2}],
+          target: :stub
+        })
+
+      assert html =~ "2 rewards"
+    end
+  end
+end


### PR DESCRIPTION
The 'X rewards are waiting for your approval' NextAction.View.highlight banner used to sit on the participants tab in PanlParticipantsView (commit c59524f2c, May 7). It was silently lost on May 21 when the Participants tab was refactored (PanlParticipantsView dropped, participants_view.ex consolidated, paid-slots extracted to PaidSlotsHtml/Logic) — the paid-slots block was carefully migrated but the pending-approvals banner wasn't.

Backend lifecycle is unchanged and still working: Assignment._switch creates the Fund.NextActions.PendingPayout next-action on task completion and clears it on accept/reject. That next-action still surfaces on the home page and /todo. This commit only restores the inline cue on the participants tab itself.

What changed in participants_view.ex:
- assign_pending_approvals/1: pulls Assignment.Public.list_pending_payouts/1 into the @pending_approvals socket assign; called from update/2 and from payout_modal_close handler.
- compose(:payout_modal, ...): adds the Assignment.PayoutModal child spec so the modal can be opened from the banner.
- handle_event("open_payout_modal", ...): composes + shows the modal in :compact style.
- handle_event("payout_modal_close", ...): hides the modal, refreshes the assignment via PaidSlotsLogic.refresh_assignment/1, and re-assigns pending approvals so the banner disappears once nothing's pending.
- render/1: re-adds the NextAction.View.highlight banner between the general info block and the paid-slots block. Wrapped in data-testid='pending-approvals-cta' for tests.

i18n: the three keys (panl_participants.pending_approvals.{description, open.button, title.one+other}) were extracted but the values were left empty by the merge that dropped the banner. English + Dutch copy filled in here.

No new tests: participants_view.ex has no test today and adding one needs significant setup (assignment + fund + crew + task lifecycle). Worth a follow-up issue.

# Pull request

## Basecamp link

...

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have not added superfluous logging
- [ ] I have added QA steps to the Basecamp ticket
- [ ] Security
  - [ ] I have considered the security implications of my changes
- [ ] Privacy
  - [ ] I have considered the privacy implications of my changes
  - [ ] I have checked new log messages for PII
  - [ ] I have added no unnecessary logging
