### PR TITLE
Fix mobile data-donation start page overlap; enable natural page scroll

### DIFF
--- a/core/assets/tailwind.config.js
+++ b/core/assets/tailwind.config.js
@@ -147,6 +147,7 @@ module.exports = {
       },
       minHeight: {
         "wysiwyg-editor": "512px",
+        viewport: "calc(var(--vh, 1vh) * 100)",
       },
       // maxHeight.dropdown comes from Prism preset
       maxHeight: {

--- a/core/lib/core_web/controllers/layouts/stripped/html.ex
+++ b/core/lib/core_web/controllers/layouts/stripped/html.ex
@@ -23,15 +23,15 @@ defmodule CoreWeb.Layouts.Stripped.Html do
     ~H"""
     <div class="flex flex-row">
       <div class="flex-1">
-        <div id="main-content" class="flex flex-col w-full h-viewport">
+        <div id="main-content" class="flex flex-col w-full min-h-viewport md:h-viewport">
             <div class="flex-wrap lg:hidden">
               <Navigation.mobile_navbar {@menus.mobile_navbar} />
             </div>
             <div class="flex-wrap hidden lg:flex">
               <Navigation.desktop_navbar {@menus.desktop_navbar} />
             </div>
-          <div class="flex-1">
-            <div class="flex flex-col h-full border-t border-b border-grey4">
+          <div class="flex-1 flex flex-col">
+            <div class="flex-1 flex flex-col border-t border-b border-grey4">
               <%= render_slot(@header) %>
               <%= if @title do %>
                 <div class="flex-none">

--- a/core/systems/feldspar/tool_view.ex
+++ b/core/systems/feldspar/tool_view.ex
@@ -113,7 +113,7 @@ defmodule Systems.Feldspar.ToolView do
         <% end %>
         <div
           data-testid="start-container"
-          class={"absolute inset-0 items-center justify-center #{if @started and @initialized, do: "hidden", else: "flex"}"}
+          class={"w-full h-full flex-col items-center justify-center py-8 #{if @started and @initialized, do: "hidden", else: "flex"}"}
         >
           <Area.sheet>
             <div class="flex flex-col gap-8 items-center px-8">


### PR DESCRIPTION
Resolves FX#9809627365.

## The bug

On mobile in the data-donation flow, the Feldspar tool start page rendered the platform icon clipped under the hero and the Continue button overlapping the footer. Root cause: the start-container used \`absolute inset-0\` with \`items-center\` on a fixed-height parent — when the content stack was taller than the container, vertical centering split the overflow above and below.

## What changed

| File | Change |
|---|---|
| \`core/lib/core_web/controllers/layouts/stripped/html.ex\` | \`#main-content\`: \`h-viewport\` → \`min-h-viewport md:h-viewport\`. Inner content frame: \`h-full\` → \`flex-1\`, parent wrapped in \`flex flex-col\`. |
| \`core/systems/feldspar/tool_view.ex\` | start-container: \`absolute inset-0\` → \`w-full h-full flex flex-col items-center justify-center py-8\` (flow layout). |
| \`core/assets/tailwind.config.js\` | Added \`min-h-viewport\` utility (parallels existing \`h-viewport\`). |

## Behavior

- **Mobile (< md):** page grows naturally with content; header, content frame and footer all scroll together when content overflows.
- **Desktop (≥ md):** unchanged — kiosk-style layout, content fills exactly the viewport.

## Scope of impact

- Stripped layout: every page using \`<.stripped>\` gets the new mobile scroll behavior. Pages that already fit are unchanged on desktop and remain visually identical on mobile when content is short.
- Feldspar tool view: also used inside multi-task crew modals; flow layout still works there (modals provide their own bounds).
- Other layouts (workspace, website, app): untouched.

## Test plan

- [x] 414×896 viewport: footer no longer oversized, icon not clipped, Continue button not overlapping footer
- [x] 375×667: overflow now scrolls the whole page
- [x] Desktop ≥ md: kiosk layout preserved
- [ ] Sanity check on a couple of non-feldspar stripped pages (signup, onboarding, leaderboard) on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)