### PR TITLE
Add :unverified filter to admin user list

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-enums.po
@@ -494,3 +494,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr "Nicht verifiziert"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-enums.po
@@ -493,3 +493,7 @@ msgstr "External"
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr "Recent"
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr "Unverified"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-enums.po
@@ -494,3 +494,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr "No verificado"

--- a/core/priv/gettext/eyra-enums.pot
+++ b/core/priv/gettext/eyra-enums.pot
@@ -493,3 +493,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-enums.po
@@ -494,3 +494,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr "Non verificato"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-enums.po
@@ -494,3 +494,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr "Nepatvirtinta"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-enums.po
@@ -493,3 +493,7 @@ msgstr "Extern"
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr "Recent"
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr "Niet geverifieerd"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-enums.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-enums.po
@@ -494,3 +494,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org_member_filters.recent"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "admin_user_filters.unverified"
+msgstr "Neverificat"

--- a/core/systems/admin/account_view_builder.ex
+++ b/core/systems/admin/account_view_builder.ex
@@ -107,6 +107,9 @@ defmodule Systems.Admin.AccountViewBuilder do
   defp matches_filter?(%Account.User{verified_at: verified_at}, :verified),
     do: verified_at != nil
 
+  defp matches_filter?(%Account.User{verified_at: verified_at}, :unverified),
+    do: verified_at == nil
+
   defp matches_filter?(%Account.User{creator: creator}, :creator) when not is_nil(creator),
     do: creator
 

--- a/core/systems/admin/user_filters.ex
+++ b/core/systems/admin/user_filters.ex
@@ -1,3 +1,4 @@
 defmodule Systems.Admin.UserFilters do
-  use Core.Enums.Base, {:admin_user_filters, [:creator, :verified, :affiliate, :in_pool]}
+  use Core.Enums.Base,
+      {:admin_user_filters, [:creator, :verified, :unverified, :affiliate, :in_pool]}
 end

--- a/core/test/systems/admin/account_view_builder_test.exs
+++ b/core/test/systems/admin/account_view_builder_test.exs
@@ -66,6 +66,20 @@ defmodule Systems.Admin.AccountViewBuilderTest do
       refute non_creator.email in emails
     end
 
+    test "filters by :unverified filter", %{
+      creator_verified: creator_verified,
+      creator_unverified: creator_unverified,
+      non_creator: non_creator
+    } do
+      items = AccountViewBuilder.build_user_items([:unverified], [])
+
+      emails = Enum.map(items, & &1.email)
+
+      refute creator_verified.email in emails
+      assert creator_unverified.email in emails
+      assert non_creator.email in emails
+    end
+
     test "filters by search query" do
       user =
         Factories.insert!(:member, %{


### PR DESCRIPTION
Resolves FX#9941567314.

## Summary

Adds an Unverified filter chip on the admin user list, so admins can find users whose \`verified_at\` is nil — typically signups that never completed any onboarding action — and reach out to ask why.

## Changes

- \`Systems.Admin.UserFilters\`: add \`:unverified\` to the enum
- \`Systems.Admin.AccountViewBuilder\`: \`matches_filter?(:unverified)\` clause matches users with \`verified_at == nil\`
- Translations across EN / NL / DE / IT / ES / LT / RO

Combines as AND with other filters (current behavior); selecting \`:verified + :unverified\` returns nothing as expected.

## Test plan

- [x] \`mix test test/systems/admin/account_view_builder_test.exs\` — 11 tests, 0 failures
- [ ] On staging: filter chip shows "Unverified" and only lists users without verified_at

🤖 Generated with [Claude Code](https://claude.com/claude-code)