### PR TITLE
fix(e2e): ship local payment simulator to dev via ENABLE_E2E_SUPPORT flag

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -28,11 +28,15 @@ ARG BUNDLE
 ARG VERSION
 ARG PLATFORM=fly
 ARG FORCE_SSL=true
+# Compiles E2E support facilities (e.g. local payment simulator) into the
+# build. Non-production only.
+ARG ENABLE_E2E_SUPPORT=false
 
 ENV BUNDLE=$BUNDLE
 ENV VERSION=$VERSION
 ENV PLATFORM=$PLATFORM
 ENV FORCE_SSL=$FORCE_SSL
+ENV ENABLE_E2E_SUPPORT=$ENABLE_E2E_SUPPORT
 
 COPY mix.exs .
 RUN mix deps.get

--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -117,6 +117,13 @@ config :core,
   },
   tool_directors: [:assignment]
 
+# Generic compile-time flag for E2E support facilities baked into the build
+# (e.g. the local payment simulator routes /payment/local/...). Off by default
+# so production never compiles in these stubs; enabled for :dev/:test (see
+# dev.exs/test.exs) and for non-production release builds via the
+# ENABLE_E2E_SUPPORT build arg.
+config :core, :enable_e2e_support, System.get_env("ENABLE_E2E_SUPPORT", "false") == "true"
+
 config :core, Systems.Payment.Provider.OPP,
   base_url: "https://api-sandbox.onlinebetaalplatform.nl/v1",
   partner_fee_percentage: 0

--- a/core/config/dev.exs
+++ b/core/config/dev.exs
@@ -165,6 +165,9 @@ config :core, :content, backend: Systems.Content.LocalFS
 
 config :core, :feldspar, backend: Systems.Feldspar.LocalFS
 
+# Compile in E2E support facilities (e.g. local payment simulator).
+config :core, :enable_e2e_support, true
+
 try do
   import_config "dev.secret.exs"
 rescue

--- a/core/config/test.exs
+++ b/core/config/test.exs
@@ -14,6 +14,9 @@ config :core,
 
 config :core, Systems.Payment.Provider.OPP, notification_secret: "test_notification_secret"
 
+# Compile in E2E support facilities (e.g. local payment simulator).
+config :core, :enable_e2e_support, true
+
 # Print only errors during test
 config :logger, level: :error
 

--- a/core/fly.dev.toml
+++ b/core/fly.dev.toml
@@ -11,6 +11,10 @@ org = 'eyra'
     # VERSION and PLATFORM are passed from GitHub Actions workflow
     BUNDLE = 'next'
     FORCE_SSL = 'false'
+    # Compile in E2E support facilities (e.g. the local payment simulator) so
+    # the E2E suite can run on the dev server. Compiled out of production
+    # builds.
+    ENABLE_E2E_SUPPORT = 'true'
 
 [env]
   # Phoenix configuration

--- a/core/systems/payment/_routes.ex
+++ b/core/systems/payment/_routes.ex
@@ -6,10 +6,12 @@ defmodule Systems.Payment.Routes do
         post("/webhook/:provider", Controller, :webhook)
       end
 
-      # The local provider is a dev-only stub that auto-completes pay-ins.
-      # Compile it out of prod builds entirely so it can't be reached even
-      # if PAYMENT_PROVIDER is misconfigured at runtime.
-      if Mix.env() != :prod do
+      # The local provider is a dev/test stub that auto-completes pay-ins.
+      # It is compiled out unless :enable_e2e_support is set at build time,
+      # so it can't be reached even if PAYMENT_PROVIDER is misconfigured at
+      # runtime. Enabled for :dev/:test and for non-production release builds
+      # via the ENABLE_E2E_SUPPORT build arg (see config/config.exs).
+      if Application.compile_env(:core, :enable_e2e_support, false) do
         scope "/payment/local", Systems.Payment.Provider do
           pipe_through([:browser])
           get("/:uid", LocalController, :pay)


### PR DESCRIPTION
## Why

E2E Tests on the Fly **dev** server (`eyra-next-dev`) were failing. Investigating run [#26627800115](https://github.com/eyra/mono/actions/runs/26627800115) surfaced **two** independent root causes:

### 1. Service key mismatch (fixed outside this PR — secret only)
Global setup failed with `403 Invalid service key`. The GitHub Actions `SERVICE_LOGIN_KEY` secret (last set 2026-03-02) no longer matched the value deployed on the Fly servers (all four apps share the same key).
**Resolution:** updated the `SERVICE_LOGIN_KEY` GitHub secret to match the live value. No code change. Recorded here so the full root cause is documented.

### 2. Local payment simulator compiled out of the dev build (this PR)
With auth fixed, 6 payment specs failed with `/payment/local` -> **404**.

The simulator routes were gated on `Mix.env() != :prod`. Every Fly image is built with `MIX_ENV=prod`, so the routes were stripped from the dev server — even though the app defaults to the `local` payment provider and redirects pay-ins to `/payment/local/...`. The provider was active, but the route it points at did not exist.

## What

Replace the compile-time `Mix.env()` guard with a generic compile-time flag **`:enable_e2e_support`** (build arg / env `ENABLE_E2E_SUPPORT`):

- **default OFF** -> production never compiles in the stub (same safety guarantee as before)
- **ON for `:dev` and `:test`** -> preserves existing local + ExUnit behavior
- **ON for the dev Fly image** via `fly.dev.toml` build arg -> simulator ships to `eyra-next-dev`

Production (AWS) builds omit the flag, so the simulator stays compiled out and unreachable there.

## Files
- `core/systems/payment/_routes.ex` — guard now `Application.compile_env(:core, :enable_e2e_support, false)`
- `core/config/config.exs` — flag default (reads `ENABLE_E2E_SUPPORT`, default false)
- `core/config/dev.exs`, `core/config/test.exs` — flag on
- `core/Dockerfile` — `ARG`/`ENV ENABLE_E2E_SUPPORT` before compile
- `core/fly.dev.toml` — `ENABLE_E2E_SUPPORT = 'true'`

## Validated
Adhoc deploy of `eyra-next-dev` (v118) with this change confirmed: `enable_e2e_support: true` baked in, and `/payment/local/:uid`, `/complete`, `/fail` present in the deployed router. The original 404 is gone.

## Out of scope
After this fix + the secret update, the same 6 specs still fail for **unrelated** reasons (a server 500 during study/assignment setup, missing UI selectors, multi-transaction redirect timeouts). Those are product/test issues to be triaged separately.
