### PR TITLE
fix(tests): deterministic feature-test sign-in + parallel-session isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ dialyzer: FORCE
 .PHONY: test
 test: test/core test/banking_proxy
 test/core: FORCE
-	cd core && mix test.all
+	cd core && FEATURE_TEST_SESSION=$(FEATURE_TEST_SESSION) mix test.all
 test/banking_proxy: FORCE
 	cd banking_proxy && mix test
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ dialyzer: FORCE
 .PHONY: test
 test: test/core test/banking_proxy
 test/core: FORCE
-	cd core && FEATURE_TEST_SESSION=$(FEATURE_TEST_SESSION) mix test.all
+	cd core && $(if $(FEATURE_TEST_SESSION),FEATURE_TEST_SESSION=$(FEATURE_TEST_SESSION),) mix test.all
 test/banking_proxy: FORCE
 	cd banking_proxy && mix test
 

--- a/core/config/test.exs
+++ b/core/config/test.exs
@@ -1,8 +1,21 @@
 import Config
 
+# Feature tests run a real HTTP server on a fixed port and share a database via
+# Wallaby's shared-sandbox mode, so concurrent runs (e.g. multiple developer or
+# agent sessions) collide on both resources. FEATURE_TEST_SESSION gives each
+# session an isolated HTTP port and database. Unset (0) reproduces the default
+# port (4002) and database (core_test), so normal single-session runs are
+# unchanged.
+feature_test_session = System.get_env("FEATURE_TEST_SESSION", "0") |> String.to_integer()
+feature_test_port = 4002 + feature_test_session
+feature_test_base_url = "http://localhost:#{feature_test_port}"
+
+feature_test_db_suffix =
+  if feature_test_session == 0, do: "", else: to_string(feature_test_session)
+
 config :core,
   name: "Next [test]",
-  base_url: "http://localhost:4002",
+  base_url: feature_test_base_url,
   upload_path: "/tmp"
 
 # Selectical test configuration
@@ -41,10 +54,10 @@ config :bcrypt_elixir, :log_rounds, 1
 config :core, Core.Repo,
   username: System.get_env("POSTGRES_USER", "postgres"),
   password: System.get_env("POSTGRES_PASS", "postgres"),
-  database: "core_test",
+  database: "core_test#{feature_test_db_suffix}",
   hostname: System.get_env("POSTGRES_HOST", "localhost"),
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 10,
+  pool_size: 33,
   queue_target: 5000
 
 # Reduce password hashing impact on test duration
@@ -59,14 +72,14 @@ config :core, :paper,
   ris_stream_chunk_size: 1_024
 
 config :core, CoreWeb.Endpoint,
-  http: [port: 4002],
+  http: [port: feature_test_port],
   force_ssl: false,
   server: true
 
 # Wallaby configuration
 config :wallaby,
   otp_app: :core,
-  base_url: "http://localhost:4002",
+  base_url: feature_test_base_url,
   driver: Wallaby.Chrome,
   screenshot_dir: "tmp/wallaby_screenshots",
   screenshot_on_failure: true,

--- a/core/config/test.exs
+++ b/core/config/test.exs
@@ -6,7 +6,13 @@ import Config
 # session an isolated HTTP port and database. Unset (0) reproduces the default
 # port (4002) and database (core_test), so normal single-session runs are
 # unchanged.
-feature_test_session = System.get_env("FEATURE_TEST_SESSION", "0") |> String.to_integer()
+feature_test_session =
+  System.get_env("FEATURE_TEST_SESSION", "0")
+  |> case do
+    "" -> 0
+    n -> String.to_integer(n)
+  end
+
 feature_test_port = 4002 + feature_test_session
 feature_test_base_url = "http://localhost:#{feature_test_port}"
 

--- a/core/test/support/feature_case.ex
+++ b/core/test/support/feature_case.ex
@@ -56,6 +56,13 @@ defmodule CoreWeb.FeatureCase do
     |> fill_in(css("[data-testid='signin-email-input']"), with: user.email)
     |> fill_in(css("[data-testid='signin-password-input']"), with: password)
     |> click(css("[data-testid='signin-submit-button']"))
+    # Block until login actually completes. Submitting posts to /user/session
+    # and redirects away from the sign-in form. Without waiting here, a caller
+    # can navigate (e.g. visit("/user/onboarding")) before the auth session
+    # cookie is set and get bounced back to /user/signin — a race that surfaces
+    # as flaky "element not found" failures under load. Waiting for the sign-in
+    # form to disappear confirms we've landed on the authenticated page.
+    |> refute_has(css("[data-testid='signin-form']"))
   end
 
   @doc """


### PR DESCRIPTION
## What

Three feature-test reliability fixes that emerged from investigating the E2E
failures on the Fly dev server (root cause analysis in #1534).

### 1. `sign_in/3` synchronises on login completing
Adds `refute_has(css("[data-testid='signin-form']"))` after the submit click.
The form submits via a real HTTP POST to `/user/session` which redirects
asynchronously — without waiting, a caller that immediately `visit`s another
page could race the auth cookie and land unauthenticated, producing flaky
"element not found" failures under full-suite CPU load.

### 2. `FEATURE_TEST_SESSION` — per-session port + database isolation
Multiple concurrent feature-test runners (developer sessions, AI agent
sessions) previously collided on port `4002` and the `core_test` database.
`FEATURE_TEST_SESSION=N` now selects an isolated port (`4002+N`) and database
(`core_testN`). Unset (default `0`) reproduces the previous behaviour exactly.

`Makefile` forwards the variable into `mix test.all` so the pre-commit hook
respects the value set in the committing shell — fixing the bug where the hook
always ran on the default port regardless of the env var.

### 3. `pool_size` raised from 10 → 33
With 14 CPU schedulers, ExUnit runs up to 14 async test modules concurrently,
each requiring a sandbox connection. The previous pool of 10 was guaranteed to
exhaust under full-suite load, causing `DBConnection.ConnectionError` timeouts.
33 (2 × schedulers + headroom) covers two concurrent sessions within
Postgres's `max_connections: 100` (66/100 used, 34 left for the app).

## Verified
- Two concurrent sessions (`FEATURE_TEST_SESSION=1` features + `FEATURE_TEST_SESSION=2` unit) both 0 failures.
- All hooks passed (format / compile / test / credo / dialyzer) with `FEATURE_TEST_SESSION=1`.
