### PR TITLE
fix(e2e): activate participant via API instead of /sent_emails

### DIFF
--- a/core/frameworks/e2e/_routes.ex
+++ b/core/frameworks/e2e/_routes.ex
@@ -16,6 +16,7 @@ defmodule Frameworks.E2E.Routes do
 
         # Bootstrap creates the service user - no auth required, protected by :e2e feature flag
         post("/bootstrap", Controller, :bootstrap)
+        post("/activate_user", Controller, :activate_user)
       end
 
       scope "/api/e2e", Frameworks.E2E do

--- a/core/frameworks/e2e/controller.ex
+++ b/core/frameworks/e2e/controller.ex
@@ -84,6 +84,33 @@ defmodule Frameworks.E2E.Controller do
     end
   end
 
+  @doc """
+  Directly activates a user account by email. Only available when :e2e feature is enabled.
+  Bypasses the email confirmation flow so E2E tests don't need to read from /sent_emails.
+  """
+  def activate_user(conn, %{"email" => email}) do
+    if feature_enabled?(:e2e) do
+      case Account.Public.get_user_by_email(email) do
+        nil ->
+          conn |> put_status(404) |> json(%{error: "User not found: #{email}"})
+
+        %{confirmed_at: confirmed_at} = user when not is_nil(confirmed_at) ->
+          json(conn, %{status: "already_confirmed", email: user.email})
+
+        user ->
+          now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+          user
+          |> Ecto.Changeset.change(%{confirmed_at: now})
+          |> Repo.update!()
+
+          json(conn, %{status: "confirmed", email: user.email})
+      end
+    else
+      conn |> put_status(403) |> json(%{error: "E2E not available"})
+    end
+  end
+
   def setup(conn, _params) do
     if feature_enabled?(:e2e) do
       case setup_fixtures() do
@@ -148,9 +175,16 @@ defmodule Frameworks.E2E.Controller do
   defp get_or_create_researcher do
     case Account.Public.get_user_by_email(@researcher_email) do
       nil -> create_researcher()
-      user -> user
+      user -> ensure_verified(user)
     end
   end
+
+  defp ensure_verified(%{verified_at: nil} = user) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    user |> Ecto.Changeset.change(%{verified_at: now}) |> Repo.update!()
+  end
+
+  defp ensure_verified(user), do: user
 
   defp create_researcher do
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
@@ -167,7 +201,7 @@ defmodule Frameworks.E2E.Controller do
   defp get_or_create_researcher_b do
     case Account.Public.get_user_by_email(@researcher_b_email) do
       nil -> create_researcher_b()
-      user -> user
+      user -> ensure_verified(user)
     end
   end
 

--- a/core/test/e2e/approve_reward.spec.ts
+++ b/core/test/e2e/approve_reward.spec.ts
@@ -331,37 +331,21 @@ test.describe('Approve Reward (UC-OPP-05)', () => {
       console.log('[TEST] No consent step — skipping');
     }
 
-    // Step 4: Activate account via the email confirmation link.
-    // Phoenix-style mail confirmation assumes the user opens the link in a
-    // separate browser/tab where they are NOT logged in. Visiting the confirm
-    // URL in the participant's logged-in session causes a server-side redirect
-    // (no confirm-button page shown). So we open the link in a CLEAN context
-    // (no cookies → unauthenticated), click the confirm button there, then
-    // close it and reload the participant's assignment view.
+    // Step 4: Activate account via the E2E API endpoint.
+    // Directly confirms the participant without going through the email flow —
+    // works on all environments regardless of mailer adapter.
     if (await participantPage.locator("[data-testid='activate-account-check-button']").isVisible({ timeout: 3000 })) {
-      console.log('[TEST] Participant needs to activate account — fetching link from /sent_emails');
-      await participantPage.goto('/sent_emails');
-      await participantPage.waitForLoadState('domcontentloaded');
-
-      const html = await participantPage.content();
-      const confirmLinkMatch = html.match(/\/user\/onboarding\/confirm\/[A-Za-z0-9_\-]+/);
-      if (!confirmLinkMatch) {
-        throw new Error('Activation link not found in /sent_emails');
+      console.log(`[TEST] Activating account via E2E API for ${participantEmail}`);
+      const activateResponse = await fetch(`${process.env.E2E_BASE_URL || 'http://localhost:4000'}/api/e2e/activate_user`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: participantEmail })
+      });
+      if (!activateResponse.ok) {
+        const body = await activateResponse.text();
+        throw new Error(`Failed to activate user: ${activateResponse.status} - ${body}`);
       }
-      const confirmPath = confirmLinkMatch[0];
-      console.log(`[TEST] Activation URL: ${confirmPath}`);
-
-      // Open the confirm URL in a clean (unauthenticated) browser context.
-      const confirmContext = await browser.newContext();
-      const confirmPage = await confirmContext.newPage();
-      await confirmPage.goto(`http://localhost:4000${confirmPath}`);
-      await confirmPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
-      await expect(confirmPage.locator("[data-testid='account-confirm-button']")).toBeVisible({ timeout: 5000 });
-      console.log('[TEST] Clicking account-confirm-button in clean context');
-      await confirmPage.locator("[data-testid='account-confirm-button']").click();
-      await confirmPage.waitForURL(/\/user\/signin/, { timeout: 10000 });
-      console.log('[TEST] Account activated — redirected to signin');
-      await confirmContext.close();
+      console.log('[TEST] Account activated via E2E API');
 
       // Back to the participant's assignment so the view-router recomputes.
       await participantPage.goto(`/assignment/${assignmentId}`);


### PR DESCRIPTION
## Why

The `approve_reward` test needs to confirm a participant's account after signup. It was doing this by reading from `/sent_emails` (Bamboo's local mailbox viewer), which only works with `Bamboo.LocalAdapter`. On Fly dev, `MailgunAdapter` is used — emails go to real inboxes, so `/sent_emails` is always empty and the test fails.

## What

1. **New endpoint `POST /api/e2e/activate_user`** — directly sets `confirmed_at` on a user by email. Gated by `:e2e` feature flag. No email adapter dependency.

2. **`ensure_verified/1`** — when `get_or_create_researcher` / `get_or_create_researcher_b` returns an existing user, ensures `verified_at` is set. Fixes publishing failures on envs where the fixture account predates `verified_at`.

3. **`approve_reward.spec.ts`** — replaces the `/sent_emails` flow with a single API call to `/api/e2e/activate_user`.

## Verified

- 13/13 passing locally via `mix test.e2e`
- All hooks pass