### PR TITLE
feat(smoke): smoke test suite for production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ dialyzer: FORCE
 .PHONY: test
 test: test/core test/banking_proxy
 test/core: FORCE
-	cd core && $(if $(FEATURE_TEST_SESSION),FEATURE_TEST_SESSION=$(FEATURE_TEST_SESSION),) mix test.all
+	cd core && $(if $(FEATURE_TEST_SESSION),FEATURE_TEST_SESSION=$(FEATURE_TEST_SESSION),) mix test.ci
 test/banking_proxy: FORCE
 	cd banking_proxy && mix test
 

--- a/core/config/runtime.aws.exs
+++ b/core/config/runtime.aws.exs
@@ -26,12 +26,16 @@ if config_env() == :prod do
     config :core, Frameworks.UserCheck, api_key: usercheck_api_key
   end
 
-  # Allow enabling of features from an environment variable
+  # Allow enabling of features from an environment variable.
+  # :e2e is explicitly excluded on prod — it gates test-only endpoints
+  # (/api/e2e/bootstrap, /api/e2e/setup, /api/e2e/activate_user) that must
+  # never be reachable on production.
   config :core,
          :features,
          System.get_env("ENABLED_APP_FEATURES", "")
          |> String.split(~r"\s*,\s*")
          |> Enum.map(&String.to_atom/1)
+         |> Enum.reject(&(&1 == :e2e))
          |> Enum.map(&{&1, true})
 
   config :core,

--- a/core/mix.exs
+++ b/core/mix.exs
@@ -177,6 +177,7 @@ defmodule Core.MixProject do
       "test.ci": ["test.exs", "test.js"],
       "test.e2e": ["seed", "cmd ./test/e2e/run.sh"],
       "test.smoke": "cmd ./test/smoke/run.sh",
+      # Usage: mix test.smoke dev | staging | test1 | test2 | prod
       seed: "cmd ./scripts/seed",
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],

--- a/core/mix.exs
+++ b/core/mix.exs
@@ -2,7 +2,7 @@ defmodule Core.MixProject do
   use Mix.Project
 
   def cli do
-    [preferred_envs: ["test.all": :test]]
+    [preferred_envs: ["test.ci": :test]]
   end
 
   def project do
@@ -174,8 +174,9 @@ defmodule Core.MixProject do
       "lfs.pull": "cmd git lfs pull",
       "test.exs": ["ecto.create --quiet", "ecto.migrate", "test"],
       "test.js": "cmd cd ./assets && npm test",
-      "test.all": ["test.exs", "test.js"],
+      "test.ci": ["test.exs", "test.js"],
       "test.e2e": ["seed", "cmd ./test/e2e/run.sh"],
+      "test.smoke": "cmd ./test/smoke/run.sh",
       seed: "cmd ./scripts/seed",
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],

--- a/core/test/smoke/features.spec.ts
+++ b/core/test/smoke/features.spec.ts
@@ -8,7 +8,8 @@ import { test, expect } from '@playwright/test';
  * the :e2e feature to be enabled on prod.
  */
 
-const REQUIRED_FEATURES = ['panl', 'panl_post_launch', 'password_sign_in'];
+const REQUIRED_FEATURES = ['panl', 'password_sign_in'];
+const FORBIDDEN_FEATURES = ['e2e'];  // must never be enabled on prod
 
 test('deployed app exposes expected feature flags', async ({ request }) => {
   const response = await request.get('/api/e2e/features');
@@ -21,5 +22,9 @@ test('deployed app exposes expected feature flags', async ({ request }) => {
 
   for (const feature of REQUIRED_FEATURES) {
     expect(features, `Expected feature "${feature}" to be enabled`).toContain(feature);
+  }
+
+  for (const feature of FORBIDDEN_FEATURES) {
+    expect(features, `Feature "${feature}" must NOT be enabled on prod`).not.toContain(feature);
   }
 });

--- a/core/test/smoke/features.spec.ts
+++ b/core/test/smoke/features.spec.ts
@@ -3,30 +3,25 @@ import { test, expect } from '@playwright/test';
 /**
  * Smoke test: verify the deployed app exposes exactly the expected feature flags.
  *
- * Any deviation — feature added or removed — is a signal that the deployment
- * is misconfigured. On prod this is a hard failure; on pre-prod envs it is a
- * signal (handled by the workflow, not this spec).
+ * Any deviation is a signal that the deployment is misconfigured.
+ * On prod/staging this is a hard failure; on pre-prod it is informational.
  *
- * Uses /api/e2e/features which is intentionally ungated — available on all
- * environments including prod.
+ * Rules:
+ * - prod, staging:       must match PROD_FEATURES exactly
+ * - dev, test1, test2:   must match PRE_PROD_FEATURES exactly (test2 is the reference)
  */
 
-const EXPECTED_FEATURES: Record<string, string[]> = {
-  prod: [
-    'debug',
-    'leaderboard',
-    'member_google_sign_in',
-    'panl',
-    'password_sign_in',
-  ],
-  staging: [
-    'debug',
-    'e2e',
-    'leaderboard',
-    'member_google_sign_in',
-    'panl',
-    'password_sign_in',
-  ],
+const PROD_FEATURES = [
+  'debug',
+  'leaderboard',
+  'member_google_sign_in',
+  'panl',
+  'password_sign_in',
+].sort();
+
+const EXPECTED: Record<string, string[]> = {
+  prod: PROD_FEATURES,
+  staging: [...PROD_FEATURES, 'e2e'].sort(),  // prod + e2e so E2E suite can run against staging
   dev: [
     'e2e',
     'leaderboard',
@@ -36,7 +31,7 @@ const EXPECTED_FEATURES: Record<string, string[]> = {
     'panl_post_launch',
     'password_sign_in',
     'surfconext_sign_in',
-  ],
+  ].sort(),
   test1: [
     'e2e',
     'leaderboard',
@@ -44,7 +39,7 @@ const EXPECTED_FEATURES: Record<string, string[]> = {
     'onyx',
     'panl',
     'password_sign_in',
-  ],
+  ].sort(),
   test2: [
     'e2e',
     'leaderboard',
@@ -53,11 +48,11 @@ const EXPECTED_FEATURES: Record<string, string[]> = {
     'panl',
     'panl_post_launch',
     'password_sign_in',
-  ],
+  ].sort(),
 };
 
 const env = process.env.SMOKE_ENV || 'prod';
-const expected = (EXPECTED_FEATURES[env] ?? EXPECTED_FEATURES['prod']).sort();
+const expected = EXPECTED[env] ?? PROD_FEATURES;
 
 test(`deployed app (${env}) has exactly the expected feature flags`, async ({ request }) => {
   const response = await request.get('/api/e2e/features');

--- a/core/test/smoke/features.spec.ts
+++ b/core/test/smoke/features.spec.ts
@@ -19,36 +19,24 @@ const PROD_FEATURES = [
   'password_sign_in',
 ].sort();
 
+// test2 is the reference for pre-prod environments.
+// dev and test1 deviating from this is a known signal.
+const PRE_PROD_FEATURES = [
+  'e2e',
+  'leaderboard',
+  'member_google_sign_in',
+  'onyx',
+  'panl',
+  'panl_post_launch',
+  'password_sign_in',
+].sort();
+
 const EXPECTED: Record<string, string[]> = {
-  prod: PROD_FEATURES,
+  prod:    PROD_FEATURES,
   staging: [...PROD_FEATURES, 'e2e'].sort(),  // prod + e2e so E2E suite can run against staging
-  dev: [
-    'e2e',
-    'leaderboard',
-    'member_google_sign_in',
-    'onyx',
-    'panl',
-    'panl_post_launch',
-    'password_sign_in',
-    'surfconext_sign_in',
-  ].sort(),
-  test1: [
-    'e2e',
-    'leaderboard',
-    'member_google_sign_in',
-    'onyx',
-    'panl',
-    'password_sign_in',
-  ].sort(),
-  test2: [
-    'e2e',
-    'leaderboard',
-    'member_google_sign_in',
-    'onyx',
-    'panl',
-    'panl_post_launch',
-    'password_sign_in',
-  ].sort(),
+  dev:     PRE_PROD_FEATURES,
+  test1:   PRE_PROD_FEATURES,
+  test2:   PRE_PROD_FEATURES,
 };
 
 const env = process.env.SMOKE_ENV || 'prod';

--- a/core/test/smoke/features.spec.ts
+++ b/core/test/smoke/features.spec.ts
@@ -20,6 +20,8 @@ const EXPECTED_FEATURES: Record<string, string[]> = {
     'password_sign_in',
   ],
   staging: [
+    'debug',
+    'e2e',
     'leaderboard',
     'member_google_sign_in',
     'panl',
@@ -36,8 +38,10 @@ const EXPECTED_FEATURES: Record<string, string[]> = {
     'surfconext_sign_in',
   ],
   test1: [
+    'e2e',
     'leaderboard',
     'member_google_sign_in',
+    'onyx',
     'panl',
     'password_sign_in',
   ],

--- a/core/test/smoke/features.spec.ts
+++ b/core/test/smoke/features.spec.ts
@@ -3,28 +3,56 @@ import { test, expect } from '@playwright/test';
 /**
  * Smoke test: verify the deployed app exposes the expected feature flags.
  *
- * Uses /api/e2e/features which is intentionally ungated (available on all
- * environments) so smoke tests can discover the feature set without needing
+ * Uses /api/e2e/features which is intentionally ungated — available on all
+ * environments so smoke tests can discover the feature set without needing
  * the :e2e feature to be enabled on prod.
  */
 
-const REQUIRED_FEATURES = ['panl', 'password_sign_in'];
-const FORBIDDEN_FEATURES = ['e2e'];  // must never be enabled on prod
+type FeatureConfig = {
+  required: string[];
+  forbidden: string[];
+};
 
-test('deployed app exposes expected feature flags', async ({ request }) => {
+const FEATURE_CONFIG: Record<string, FeatureConfig> = {
+  prod: {
+    required: ['panl', 'password_sign_in'],
+    forbidden: ['e2e'],
+  },
+  staging: {
+    required: ['panl', 'password_sign_in'],
+    forbidden: ['e2e'],
+  },
+  dev: {
+    required: ['e2e', 'panl', 'panl_post_launch', 'password_sign_in'],
+    forbidden: [],
+  },
+  test1: {
+    required: ['panl', 'password_sign_in'],
+    forbidden: [],
+  },
+  test2: {
+    required: ['panl', 'password_sign_in'],
+    forbidden: [],
+  },
+};
+
+const env = process.env.SMOKE_ENV || 'prod';
+const config = FEATURE_CONFIG[env] ?? FEATURE_CONFIG['prod'];
+
+test(`deployed app (${env}) exposes expected feature flags`, async ({ request }) => {
   const response = await request.get('/api/e2e/features');
 
   expect(response.status()).toBe(200);
 
   const { features } = await response.json() as { features: string[] };
 
-  console.log(`[SMOKE] Enabled features: ${features.join(', ')}`);
+  console.log(`[SMOKE] ${env} features: ${features.join(', ')}`);
 
-  for (const feature of REQUIRED_FEATURES) {
-    expect(features, `Expected feature "${feature}" to be enabled`).toContain(feature);
+  for (const feature of config.required) {
+    expect(features, `Expected feature "${feature}" to be enabled on ${env}`).toContain(feature);
   }
 
-  for (const feature of FORBIDDEN_FEATURES) {
-    expect(features, `Feature "${feature}" must NOT be enabled on prod`).not.toContain(feature);
+  for (const feature of config.forbidden) {
+    expect(features, `Feature "${feature}" must NOT be enabled on ${env}`).not.toContain(feature);
   }
 });

--- a/core/test/smoke/features.spec.ts
+++ b/core/test/smoke/features.spec.ts
@@ -1,58 +1,70 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Smoke test: verify the deployed app exposes the expected feature flags.
+ * Smoke test: verify the deployed app exposes exactly the expected feature flags.
+ *
+ * Any deviation — feature added or removed — is a signal that the deployment
+ * is misconfigured. On prod this is a hard failure; on pre-prod envs it is a
+ * signal (handled by the workflow, not this spec).
  *
  * Uses /api/e2e/features which is intentionally ungated — available on all
- * environments so smoke tests can discover the feature set without needing
- * the :e2e feature to be enabled on prod.
+ * environments including prod.
  */
 
-type FeatureConfig = {
-  required: string[];
-  forbidden: string[];
-};
-
-const FEATURE_CONFIG: Record<string, FeatureConfig> = {
-  prod: {
-    required: ['panl', 'password_sign_in'],
-    forbidden: ['e2e'],
-  },
-  staging: {
-    required: ['panl', 'password_sign_in'],
-    forbidden: ['e2e'],
-  },
-  dev: {
-    required: ['e2e', 'panl', 'panl_post_launch', 'password_sign_in'],
-    forbidden: [],
-  },
-  test1: {
-    required: ['panl', 'password_sign_in'],
-    forbidden: [],
-  },
-  test2: {
-    required: ['panl', 'password_sign_in'],
-    forbidden: [],
-  },
+const EXPECTED_FEATURES: Record<string, string[]> = {
+  prod: [
+    'debug',
+    'leaderboard',
+    'member_google_sign_in',
+    'panl',
+    'password_sign_in',
+  ],
+  staging: [
+    'leaderboard',
+    'member_google_sign_in',
+    'panl',
+    'password_sign_in',
+  ],
+  dev: [
+    'e2e',
+    'leaderboard',
+    'member_google_sign_in',
+    'onyx',
+    'panl',
+    'panl_post_launch',
+    'password_sign_in',
+    'surfconext_sign_in',
+  ],
+  test1: [
+    'leaderboard',
+    'member_google_sign_in',
+    'panl',
+    'password_sign_in',
+  ],
+  test2: [
+    'e2e',
+    'leaderboard',
+    'member_google_sign_in',
+    'onyx',
+    'panl',
+    'panl_post_launch',
+    'password_sign_in',
+  ],
 };
 
 const env = process.env.SMOKE_ENV || 'prod';
-const config = FEATURE_CONFIG[env] ?? FEATURE_CONFIG['prod'];
+const expected = (EXPECTED_FEATURES[env] ?? EXPECTED_FEATURES['prod']).sort();
 
-test(`deployed app (${env}) exposes expected feature flags`, async ({ request }) => {
+test(`deployed app (${env}) has exactly the expected feature flags`, async ({ request }) => {
   const response = await request.get('/api/e2e/features');
 
   expect(response.status()).toBe(200);
 
   const { features } = await response.json() as { features: string[] };
+  const actual = [...features].sort();
 
-  console.log(`[SMOKE] ${env} features: ${features.join(', ')}`);
+  console.log(`[SMOKE] ${env} actual:   ${actual.join(', ')}`);
+  console.log(`[SMOKE] ${env} expected: ${expected.join(', ')}`);
 
-  for (const feature of config.required) {
-    expect(features, `Expected feature "${feature}" to be enabled on ${env}`).toContain(feature);
-  }
-
-  for (const feature of config.forbidden) {
-    expect(features, `Feature "${feature}" must NOT be enabled on ${env}`).not.toContain(feature);
-  }
+  expect(actual).toEqual(expected);
 });

--- a/core/test/smoke/features.spec.ts
+++ b/core/test/smoke/features.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test: verify the deployed app exposes the expected feature flags.
+ *
+ * Uses /api/e2e/features which is intentionally ungated (available on all
+ * environments) so smoke tests can discover the feature set without needing
+ * the :e2e feature to be enabled on prod.
+ */
+
+const REQUIRED_FEATURES = ['panl', 'panl_post_launch', 'password_sign_in'];
+
+test('deployed app exposes expected feature flags', async ({ request }) => {
+  const response = await request.get('/api/e2e/features');
+
+  expect(response.status()).toBe(200);
+
+  const { features } = await response.json() as { features: string[] };
+
+  console.log(`[SMOKE] Enabled features: ${features.join(', ')}`);
+
+  for (const feature of REQUIRED_FEATURES) {
+    expect(features, `Expected feature "${feature}" to be enabled`).toContain(feature);
+  }
+});

--- a/core/test/smoke/package-lock.json
+++ b/core/test/smoke/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "smoke",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "smoke",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/core/test/smoke/package.json
+++ b/core/test/smoke/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "smoke",
+  "version": "1.0.0",
+  "description": "Smoke tests — run after prod deploy to verify critical paths",
+  "scripts": {
+    "smoke": "npx playwright test --project=chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/core/test/smoke/playwright.config.ts
+++ b/core/test/smoke/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 30000,
+  use: {
+    baseURL: process.env.SMOKE_BASE_URL || 'https://eyra-next-dev.fly.dev',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/core/test/smoke/run.sh
+++ b/core/test/smoke/run.sh
@@ -33,4 +33,5 @@ esac
 echo "=== Smoke tests against $ENV ($BASE_URL) ==="
 
 export SMOKE_BASE_URL="$BASE_URL"
+export SMOKE_ENV="$ENV"
 exec npx playwright test "$@"

--- a/core/test/smoke/run.sh
+++ b/core/test/smoke/run.sh
@@ -1,16 +1,36 @@
 #!/usr/bin/env bash
-# Run smoke tests against a target environment.
+# Run smoke tests against a named environment.
 #
 # Usage:
-#   ./run.sh                                        # dev (default)
-#   SMOKE_BASE_URL=https://eyra-next-prod.fly.dev ./run.sh
+#   ./run.sh dev              # https://eyra-next-dev.fly.dev
+#   ./run.sh staging          # https://eyra-next-staging.fly.dev
+#   ./run.sh test1            # https://eyra-next-test1.fly.dev
+#   ./run.sh test2            # https://eyra-next-test2.fly.dev
+#   ./run.sh prod             # https://eyra-next-prod.fly.dev (TODO: AWS URL)
+#   ./run.sh dev --headed     # pass extra args to playwright
 
 set -e
 
 cd "$(dirname "$0")"
 
-BASE_URL="${SMOKE_BASE_URL:-https://eyra-next-dev.fly.dev}"
-echo "=== Smoke tests against $BASE_URL ==="
+# First arg is env name only if it doesn't start with '-'
+if [[ "${1:-}" =~ ^(dev|staging|test1|test2|prod)$ ]]; then
+  ENV="$1"
+  shift
+else
+  ENV="prod"
+fi
+
+case "$ENV" in
+  dev)      BASE_URL="https://eyra-next-dev.fly.dev" ;;
+  staging)  BASE_URL="https://eyra-next-staging.fly.dev" ;;
+  test1)    BASE_URL="https://eyra-next-test1.fly.dev" ;;
+  test2)    BASE_URL="https://eyra-next-test2.fly.dev" ;;
+  prod)     BASE_URL="https://next.eyra.co" ;;
+  *)        echo "Unknown environment: $ENV"; echo "Usage: $0 [dev|staging|test1|test2|prod]"; exit 1 ;;
+esac
+
+echo "=== Smoke tests against $ENV ($BASE_URL) ==="
 
 export SMOKE_BASE_URL="$BASE_URL"
 exec npx playwright test "$@"

--- a/core/test/smoke/run.sh
+++ b/core/test/smoke/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run smoke tests against a target environment.
+#
+# Usage:
+#   ./run.sh                                        # dev (default)
+#   SMOKE_BASE_URL=https://eyra-next-prod.fly.dev ./run.sh
+
+set -e
+
+cd "$(dirname "$0")"
+
+BASE_URL="${SMOKE_BASE_URL:-https://eyra-next-dev.fly.dev}"
+echo "=== Smoke tests against $BASE_URL ==="
+
+export SMOKE_BASE_URL="$BASE_URL"
+exec npx playwright test "$@"

--- a/core/test/smoke/test-results/.last-run.json
+++ b/core/test/smoke/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
## What

A minimal, separate Playwright test suite that runs after a prod deploy to verify critical paths are working. Completely separate from E2E — no fixture setup, no shared test accounts, no destructive writes.

## Structure

```
core/test/smoke/
├── playwright.config.ts  — reads SMOKE_BASE_URL (derived from env name)
├── run.sh                — maps named env to URL; prod is default
├── features.spec.ts      — first smoke spec
└── package.json
```

## Running

```bash
mix test.smoke            # prod (next.eyra.co) — default
mix test.smoke dev        # eyra-next-dev.fly.dev
mix test.smoke staging    # eyra-next-staging.fly.dev
mix test.smoke test1      # eyra-next-test1.fly.dev
mix test.smoke test2      # eyra-next-test2.fly.dev
```

## First spec: feature flags (exact match)

Calls `/api/e2e/features` (ungated, available on all environments) and asserts the exact feature set for each environment:

| Env | Rule |
|---|---|
| **prod** | `PROD_FEATURES` — the reference |
| **staging** | `PROD_FEATURES + e2e` — mirrors prod, E2E suite can run against it |
| **dev, test1, test2** | `PRE_PROD_FEATURES` — test2 is the reference |

Any deviation — feature added or removed — is a signal that the deployment is misconfigured. On prod this is a hard failure; on pre-prod it is informational.

## Security: :e2e stripped from prod

`runtime.aws.exs` explicitly removes `:e2e` from the feature set even if it appears in `ENABLED_APP_FEATURES`. The smoke test also asserts this via the exact match (prod features do not include `e2e`).

## Fly env secrets aligned

During development of this PR, all Fly environments were aligned to their expected feature sets:
- **dev**: removed `surfconext_sign_in` (was an extra)
- **test1**: added `panl_post_launch` + `leaderboard` (were missing)

## Alias cleanup

| Alias | Runs | When |
|---|---|---|
| `mix test` | Elixir tests | during development |
| `mix test.ci` | Elixir + JS frontend tests | pre-commit / CI |
| `mix test.e2e` | E2E browser tests | after dev/staging deploy |
| `mix test.smoke` | Smoke tests | after prod deploy |

`test.all` removed — no scenario where all run together. Makefile updated to call `test.ci`.