### PR TITLE
fix(smoke): gitignore test-results/ in smoke folder

### DIFF
--- a/core/test/smoke/.gitignore
+++ b/core/test/smoke/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+.DS_Store

--- a/core/test/smoke/test-results/.last-run.json
+++ b/core/test/smoke/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Add `.gitignore` to `core/test/smoke/` to exclude `test-results/`, `node_modules/` and `playwright-report/` — same pattern as `core/test/e2e/.gitignore`.