### PR TITLE
[Feldspar] Fix allow_upload key collision with multiple tasks

### DIFF
--- a/core/frameworks/pixel/components/file_selector.ex
+++ b/core/frameworks/pixel/components/file_selector.ex
@@ -27,7 +27,7 @@ defmodule Frameworks.Pixel.FileSelector do
       end
 
     upload_in_progress =
-      case assigns[:uploads][:file].entries do
+      case assigns[:uploads][assigns[:file_key]].entries do
         [first_entry | _] -> first_entry.progress != 100
         _ -> false
       end
@@ -54,11 +54,11 @@ defmodule Frameworks.Pixel.FileSelector do
 
             <div>
               <%= if @upload_in_progress do %>
-                <%= if @uploads[:file].entries do %>
+                <%= if @uploads[@file_key].entries do %>
                   <LoadingSpinner.progress_spinner progress={Enum.at(@uploads[@file_key].entries, 0).progress} />
                 <% end %>
               <% else %>
-              <label for={@uploads.file.ref}>
+              <label for={@uploads[@file_key].ref}>
                 <Button.Face.primary label={@button_label} bg_color="bg-tertiary" text_color="text-grey1" />
               </label>
               <% end %>
@@ -70,7 +70,7 @@ defmodule Frameworks.Pixel.FileSelector do
 
         </div>
         <div class="hidden">
-          <.live_file_input upload={@uploads.file} />
+          <.live_file_input upload={@uploads[@file_key]} />
         </div>
 
       </.form>

--- a/core/lib/core_web/file_uploader.ex
+++ b/core/lib/core_web/file_uploader.ex
@@ -29,8 +29,10 @@ defmodule CoreWeb.FileUploader do
     quote do
       @behaviour CoreWeb.FileUploader
 
-      # Skip init if it already has been called
-      def init_file_uploader(%{assigns: %{uploads: _uploads}} = socket, _key), do: socket
+      # Skip init if this key is already registered
+      def init_file_uploader(%{assigns: %{uploads: uploads}} = socket, key)
+          when is_map_key(uploads, key),
+          do: socket
 
       def init_file_uploader(socket, key) do
         socket

--- a/core/systems/feldspar/tool_form.ex
+++ b/core/systems/feldspar/tool_form.ex
@@ -27,19 +27,21 @@ defmodule Systems.Feldspar.ToolForm do
     placeholder = dgettext("eyra-feldspar", "zip-select-placeholder")
     select_button = dgettext("eyra-feldspar", "zip-select-file-button")
     replace_button = dgettext("eyra-feldspar", "zip-replace-file-button")
+    upload_key = :"file_#{id}"
 
     {
       :ok,
       socket
       |> assign(
         id: id,
+        upload_key: upload_key,
         label: label,
         placeholder: placeholder,
         select_button: select_button,
         replace_button: replace_button,
         entity: entity
       )
-      |> init_file_uploader(:file)
+      |> init_file_uploader(upload_key)
     }
   end
 
@@ -64,11 +66,15 @@ defmodule Systems.Feldspar.ToolForm do
     socket
   end
 
-  defp has_upload_error(%{assigns: %{uploads: %{file: %{errors: [_ | _]}}}}), do: true
-  defp has_upload_error(_), do: false
+  defp has_upload_error(%{assigns: %{uploads: uploads, upload_key: key}}) do
+    match?(%{errors: [_ | _]}, uploads[key])
+  end
 
-  defp has_upload_error(%{assigns: %{uploads: %{file: %{errors: errors}}}}, error_type) do
-    Enum.find(errors, fn {_, type} -> type === error_type end) != nil
+  defp has_upload_error(%{assigns: %{uploads: uploads, upload_key: key}}, error_type) do
+    case uploads[key] do
+      %{errors: errors} -> Enum.any?(errors, fn {_, type} -> type === error_type end)
+      _ -> false
+    end
   end
 
   # Saving
@@ -91,6 +97,7 @@ defmodule Systems.Feldspar.ToolForm do
         replace_button={@replace_button}
         select_button={@select_button}
         uploads={@uploads}
+        file_key={@upload_key}
         target={@myself}
       />
     </div>

--- a/core/test/systems/feldspar/tool_form_test.exs
+++ b/core/test/systems/feldspar/tool_form_test.exs
@@ -1,0 +1,53 @@
+defmodule Systems.Feldspar.ToolFormTest do
+  use CoreWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Systems.Feldspar
+
+  # Wrapper that mounts two ToolForm components in the same LiveView.
+  # Before the fix, this crashed: "existing upload for file already allowed
+  # in another component" because both called allow_upload(:file).
+  defmodule TwoToolFormsView do
+    use Phoenix.LiveView
+
+    def mount(_params, %{"tool1" => tool1, "tool2" => tool2}, socket) do
+      {:ok, assign(socket, tool1: tool1, tool2: tool2)}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <.live_component module={Feldspar.ToolForm} id="form_1" entity={@tool1} />
+      <.live_component module={Feldspar.ToolForm} id="form_2" entity={@tool2} />
+      """
+    end
+  end
+
+  describe "multiple ToolForm components in the same LiveView" do
+    test "two instances with different ids render without crashing", %{conn: conn} do
+      tool1 = Factories.insert!(:feldspar_tool)
+      tool2 = Factories.insert!(:feldspar_tool)
+      conn = conn |> Map.put(:request_path, "/feldspar/tool_form")
+
+      assert {:ok, _view, html} =
+               live_isolated(conn, TwoToolFormsView,
+                 session: %{"tool1" => tool1, "tool2" => tool2}
+               )
+
+      assert html =~ "form_1_file_selector_form"
+      assert html =~ "form_2_file_selector_form"
+    end
+
+    test "each instance gets an upload key scoped to its id", %{conn: conn} do
+      tool = Factories.insert!(:feldspar_tool)
+      conn = conn |> Map.put(:request_path, "/feldspar/tool_form")
+
+      # The file input name is derived from the upload key (file_<id>).
+      # If the key were the global :file, the name would be "file" instead.
+      assert {:ok, _view, html} =
+               live_isolated(conn, TwoToolFormsView, session: %{"tool1" => tool, "tool2" => tool})
+
+      assert html =~ "file_form_1"
+      assert html =~ "file_form_2"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Each `ToolForm` LiveComponent now uses `:"file_#{id}"` as its upload key instead of the hardcoded `:file`
- Updated `FileSelector` to use the configurable `file_key` attr (it already had the attr but had 3 hardcoded `:file` refs inside)
- Tightened the `init_file_uploader` guard in `CoreWeb.FileUploader` to check the specific key (`is_map_key(uploads, key)`) rather than "any uploads in assigns"
- Added regression test: two `ToolForm` components in the same LiveView now render without crashing

## Root cause

When a researcher uploads zip files for multiple Feldspar tasks in one workflow, all `ToolForm` components on the page call `allow_upload(:file)` with the same key. Phoenix LiveView crashes on the second registration: *"existing upload for file already allowed in another component"*. This triggered a reconnect loop on assignment 550 (WHAT-IF Data donation, 5 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)