### PR TITLE
fix(ci): destroy stale release command machines before dev deploy

### DIFF
--- a/.github/workflows/fly-deploy-dev.yml
+++ b/.github/workflows/fly-deploy-dev.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Destroy stopped release machines
+        run: |
+          flyctl machines list --app eyra-next-dev --json \
+            | jq -r '.[] | select(.state == "stopped") | select(.config.metadata.fly_release_command == "1") | .id' \
+            | xargs -r -I {} flyctl machines destroy {} --app eyra-next-dev --force
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+
       - name: Deploy to Fly.io
         run: |
           flyctl deploy --remote-only -c fly.dev.toml \


### PR DESCRIPTION
## Summary

- Fly.io stops (not destroys) the release command machine after each predeploy run
- On the next deploy, if the stopped machine fails to wake up, the deploy fails hard
- Add a pre-deploy step that destroys any stopped release command machines before deploying, so Fly always gets a fresh machine

## Test plan
- [ ] Trigger a deploy to dev and verify it succeeds without needing a retry