### PR TITLE
fix(affiliate): reject "null" and "undefined" participant identifiers

### DIFF
--- a/core/systems/affiliate/controller.ex
+++ b/core/systems/affiliate/controller.ex
@@ -159,6 +159,8 @@ defmodule Systems.Affiliate.Controller do
 
   def valid_id?(nil), do: false
   def valid_id?("participant_id"), do: false
+  def valid_id?("null"), do: false
+  def valid_id?("undefined"), do: false
 
   def valid_id?(id) do
     String.length(id) <= @id_max_lenght and Regex.match?(@id_valid_regex, id)

--- a/core/test/systems/affiliate/controller_test.exs
+++ b/core/test/systems/affiliate/controller_test.exs
@@ -1,0 +1,51 @@
+defmodule Systems.Affiliate.ControllerTest do
+  use ExUnit.Case, async: true
+
+  alias Systems.Affiliate.Controller
+
+  describe "valid_id?/1" do
+    test "rejects nil" do
+      refute Controller.valid_id?(nil)
+    end
+
+    test "rejects \"participant_id\" placeholder" do
+      refute Controller.valid_id?("participant_id")
+    end
+
+    test "rejects \"null\" string" do
+      refute Controller.valid_id?("null")
+    end
+
+    test "rejects \"undefined\" string" do
+      refute Controller.valid_id?("undefined")
+    end
+
+    test "rejects empty string" do
+      refute Controller.valid_id?("")
+    end
+
+    test "rejects identifiers longer than 64 characters" do
+      refute Controller.valid_id?(String.duplicate("a", 65))
+    end
+
+    test "rejects identifiers containing whitespace" do
+      refute Controller.valid_id?("foo bar")
+    end
+
+    test "rejects identifiers containing special characters" do
+      refute Controller.valid_id?("foo@bar")
+    end
+
+    test "accepts alphanumeric identifier" do
+      assert Controller.valid_id?("abc123")
+    end
+
+    test "accepts identifier with underscores and hyphens" do
+      assert Controller.valid_id?("foo_bar-baz")
+    end
+
+    test "accepts 36-character UUID-like identifier" do
+      assert Controller.valid_id?("550e8400e29b41d4a716446655440000")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- External panels that build the affiliate URL in JavaScript can land participants on `/a/:sqid?p=null` when the participant variable was unset and got coerced to a string (`String(null)` → "null"). Today `valid_id?` accepts those because they pass the regex and length check, silently registering ghost affiliate users with identifier "null" and polluting logs with `participant="null"`.
- Two such ghost accounts already exist in prod (affiliate 180 / assignment 494, affiliate 136 / assignment 89). The 99 `participant="null"` entries in [Feldspar #9977150712](https://3.basecamp.com/5734045/buckets/36111585/todos/9977150712) trace back to one of these.
- Reject `"null"` and `"undefined"` alongside the existing `"participant_id"` placeholder so these requests get a 403 instead.

## Test plan
- [x] Atomic unit tests for `Systems.Affiliate.Controller.valid_id?/1` (rejects nil, "participant_id", "null", "undefined", "", >64 chars, whitespace, special chars; accepts alphanumeric, underscore/hyphen, 36-char UUID)
- [ ] Confirm in dev that `/a/:sqid?p=null` now returns 403 instead of creating an affiliate user

🤖 Generated with [Claude Code](https://claude.com/claude-code)