### PR TITLE
feat(account): OTP infrastructure (model, mailer, Public API, rate limiting)

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -155,7 +155,8 @@ config :core, :rate,
     [service: :feldspar_data_donation, limit: 1, unit: :byte, window: :day, scope: :local],
     [service: :feldspar_log, limit: 60, unit: :call, window: :minute, scope: :local],
     [service: :signup, limit: 5, unit: :call, window: :minute, scope: :local],
-    [service: :recruit, limit: 5, unit: :call, window: :minute, scope: :local]
+    [service: :recruit, limit: 5, unit: :call, window: :minute, scope: :local],
+    [service: :otp_request, limit: 3, unit: :call, window: :minute, scope: :local]
   ]
 
 config :core, ecto_repos: [Core.Repo]

--- a/core/config/test.exs
+++ b/core/config/test.exs
@@ -135,7 +135,8 @@ config :core, :rate,
   quotas: [
     [service: :feldspar_data_donation, limit: 100, unit: :call, window: :minute, scope: :local],
     [service: :feldspar_log, limit: 100, unit: :call, window: :minute, scope: :local],
-    [service: :signup, limit: 100, unit: :call, window: :minute, scope: :local]
+    [service: :signup, limit: 100, unit: :call, window: :minute, scope: :local],
+    [service: :otp_request, limit: 3, unit: :call, window: :minute, scope: :local]
   ]
 
 try do

--- a/core/priv/repo/migrations/20260608120000_create_auth_codes.exs
+++ b/core/priv/repo/migrations/20260608120000_create_auth_codes.exs
@@ -1,0 +1,16 @@
+defmodule Core.Repo.Migrations.CreateAuthCodes do
+  use Ecto.Migration
+
+  def change do
+    create table(:auth_codes) do
+      add(:code_hash, :binary, null: false)
+      add(:email, :string, null: false)
+      add(:attempts, :integer, null: false, default: 0)
+      add(:user_id, references(:users, on_delete: :delete_all))
+
+      timestamps(updated_at: false)
+    end
+
+    create(index(:auth_codes, [:email]))
+  end
+end

--- a/core/systems/account/_public.ex
+++ b/core/systems/account/_public.ex
@@ -411,6 +411,41 @@ defmodule Systems.Account.Public do
     :ok
   end
 
+  ## OTP
+
+  def generate_otp(email) when is_binary(email) do
+    Repo.delete_all(from(t in Account.AuthCodeModel, where: t.email == ^email))
+
+    user = get_user_by_email(email)
+    {code, token} = Account.AuthCodeModel.build(email, user && user.id)
+    Repo.insert!(token)
+
+    Account.UserNotifier.deliver_otp(email, code)
+    :ok
+  end
+
+  def verify_otp(email, code) when is_binary(email) and is_binary(code) do
+    case Account.AuthCodeModel.active_query(email) |> Repo.one() do
+      nil ->
+        {:error, :not_found}
+
+      token ->
+        case Account.AuthCodeModel.verify(token, code) do
+          :ok ->
+            Repo.delete!(token)
+            user = token.user_id && get_user!(token.user_id)
+            {:ok, user}
+
+          {:error, reason} ->
+            token
+            |> Ecto.Changeset.change(attempts: token.attempts + 1)
+            |> Repo.update!()
+
+            {:error, reason}
+        end
+    end
+  end
+
   ## Confirmation
 
   @doc """

--- a/core/systems/account/_public.ex
+++ b/core/systems/account/_public.ex
@@ -12,6 +12,7 @@ defmodule Systems.Account.Public do
   alias Systems.Account
   alias Systems.Account.User
   alias Systems.Affiliate
+  alias Systems.Rate
 
   def create_profile!(user_id) do
     %Account.UserProfileModel{user_id: user_id}
@@ -414,6 +415,8 @@ defmodule Systems.Account.Public do
   ## OTP
 
   def generate_otp(email) when is_binary(email) do
+    Rate.Public.request_permission(:otp_request, email, 1)
+
     Repo.delete_all(from(t in Account.AuthCodeModel, where: t.email == ^email))
 
     user = get_user_by_email(email)
@@ -422,6 +425,8 @@ defmodule Systems.Account.Public do
 
     Account.UserNotifier.deliver_otp(email, code)
     :ok
+  rescue
+    Rate.Public.RateLimitError -> {:error, :rate_limited}
   end
 
   def verify_otp(email, code) when is_binary(email) and is_binary(code) do

--- a/core/systems/account/auth_code.ex
+++ b/core/systems/account/auth_code.ex
@@ -1,0 +1,61 @@
+defmodule Systems.Account.AuthCodeModel do
+  use Ecto.Schema
+  import Ecto.Query
+
+  @hash_algorithm :sha256
+  @validity_in_minutes 10
+  @max_attempts 5
+  @code_length 6
+
+  schema "auth_codes" do
+    field(:code_hash, :binary)
+    field(:email, :string)
+    field(:attempts, :integer, default: 0)
+    belongs_to(:user, Systems.Account.User)
+
+    timestamps(updated_at: false)
+  end
+
+  def build(email, user_id) do
+    code = generate_code()
+
+    auth_code = %__MODULE__{
+      code_hash: hash_code(code),
+      email: email,
+      attempts: 0,
+      user_id: user_id
+    }
+
+    {code, auth_code}
+  end
+
+  def verify(%__MODULE__{attempts: attempts}, _code) when attempts >= @max_attempts do
+    {:error, :max_attempts}
+  end
+
+  def verify(%__MODULE__{code_hash: code_hash}, code) do
+    if :crypto.hash(@hash_algorithm, code) == code_hash do
+      :ok
+    else
+      {:error, :invalid}
+    end
+  end
+
+  def active_query(email) do
+    from(t in __MODULE__,
+      where: t.email == ^email,
+      where: t.inserted_at > ago(@validity_in_minutes, "minute"),
+      where: t.attempts < @max_attempts,
+      order_by: [desc: t.inserted_at],
+      limit: 1
+    )
+  end
+
+  defp generate_code do
+    :rand.uniform(round(:math.pow(10, @code_length)))
+    |> Integer.to_string()
+    |> String.pad_leading(@code_length, "0")
+  end
+
+  defp hash_code(code), do: :crypto.hash(@hash_algorithm, code)
+end

--- a/core/systems/account/auth_code.ex
+++ b/core/systems/account/auth_code.ex
@@ -46,7 +46,7 @@ defmodule Systems.Account.AuthCodeModel do
       where: t.email == ^email,
       where: t.inserted_at > ago(@validity_in_minutes, "minute"),
       where: t.attempts < @max_attempts,
-      order_by: [desc: t.inserted_at],
+      order_by: [desc: t.id],
       limit: 1
     )
   end

--- a/core/systems/account/auth_code.ex
+++ b/core/systems/account/auth_code.ex
@@ -52,9 +52,13 @@ defmodule Systems.Account.AuthCodeModel do
   end
 
   defp generate_code do
-    :rand.uniform(round(:math.pow(10, @code_length)))
+    min = Integer.pow(10, @code_length - 1)
+    max = Integer.pow(10, @code_length) - 1
+
+    random_int = :crypto.strong_rand_bytes(4) |> :binary.decode_unsigned()
+
+    (min + rem(random_int, max - min + 1))
     |> Integer.to_string()
-    |> String.pad_leading(@code_length, "0")
   end
 
   defp hash_code(code), do: :crypto.hash(@hash_algorithm, code)

--- a/core/systems/account/user_notifier.ex
+++ b/core/systems/account/user_notifier.ex
@@ -8,6 +8,14 @@ defmodule Systems.Account.UserNotifier do
   end
 
   @doc """
+  Deliver OTP sign-in code to the given email address.
+  """
+  def deliver_otp(email, code) do
+    Email.Factory.otp_sign_in(email, code)
+    |> deliver_later()
+  end
+
+  @doc """
   Deliver instructions to confirm account.
   """
   def deliver_confirmation_instructions(user, url) do

--- a/core/systems/email/email/otp_sign_in.html.eex
+++ b/core/systems/email/email/otp_sign_in.html.eex
@@ -1,0 +1,11 @@
+<h1>Your sign-in code</h1>
+
+Use the code below to sign in to Next. It expires in 10 minutes.
+<br /><br />
+<strong style="font-size: 32px; letter-spacing: 8px;"><%= @code %></strong>
+<br /><br />
+If you did not request this code, you can safely ignore this email.
+<br /><br />
+Kind regards,
+<br /><br />
+The Eyra team

--- a/core/systems/email/email/otp_sign_in.text.eex
+++ b/core/systems/email/email/otp_sign_in.text.eex
@@ -1,0 +1,11 @@
+Your sign-in code
+
+Use the code below to sign in to Next. It expires in 10 minutes.
+
+<%= @code %>
+
+If you did not request this code, you can safely ignore this email.
+
+Kind regards,
+
+The Eyra team

--- a/core/systems/email/email_html.ex
+++ b/core/systems/email/email_html.ex
@@ -10,6 +10,14 @@ defmodule Systems.Email.EmailHTML do
   # Returns whatever the embedded templates return (safe tuples for HTML, strings for text)
   # bamboo_phoenix will handle the normalization
 
+  def otp_sign_in("html", assigns) do
+    otp_sign_in_html(assigns)
+  end
+
+  def otp_sign_in("text", assigns) do
+    otp_sign_in_text(assigns)
+  end
+
   def account_confirmation_instructions("html", assigns) do
     account_confirmation_instructions_html(assigns)
   end

--- a/core/systems/email/factory.ex
+++ b/core/systems/email/factory.ex
@@ -17,6 +17,12 @@ defmodule Systems.Email.Factory do
     mail_user(email) |> assign(:user, user)
   end
 
+  def otp_sign_in(email, code) when is_binary(email) do
+    mail_user(email)
+    |> subject("Your sign-in code")
+    |> render(:otp_sign_in, code: code)
+  end
+
   def account_confirmation_instructions(user, url) do
     mail_user(user)
     |> subject("Activate your account")

--- a/core/test/systems/account/auth_code_test.exs
+++ b/core/test/systems/account/auth_code_test.exs
@@ -16,7 +16,7 @@ defmodule Systems.Account.AuthCodeTest do
       assert String.match?(code, ~r/^\d{6}$/)
     end
 
-    test "code is padded to 6 digits" do
+    test "code is always 6 digits, never more, never less" do
       codes =
         for _ <- 1..100 do
           {code, _} = AuthCodeModel.build("user@example.com", nil)
@@ -24,6 +24,7 @@ defmodule Systems.Account.AuthCodeTest do
         end
 
       assert Enum.all?(codes, &(String.length(&1) == 6))
+      assert Enum.all?(codes, &String.match?(&1, ~r/^\d{6}$/))
     end
 
     test "stores hashed code, not plaintext" do

--- a/core/test/systems/account/auth_code_test.exs
+++ b/core/test/systems/account/auth_code_test.exs
@@ -6,6 +6,10 @@ defmodule Systems.Account.AuthCodeTest do
   alias Systems.Account
   alias Systems.Account.AuthCodeModel
 
+  defp unique_email(prefix) do
+    "#{prefix}-#{System.unique_integer([:positive])}@example.com"
+  end
+
   describe "AuthCodeModel.build/2" do
     test "generates a 6-digit code" do
       {code, _auth_code} = AuthCodeModel.build("user@example.com", nil)
@@ -141,6 +145,38 @@ defmodule Systems.Account.AuthCodeTest do
 
       auth_code = Repo.one(AuthCodeModel.active_query("brand-new@example.com"))
       assert auth_code.user_id == nil
+    end
+  end
+
+  describe "Account.Public.generate_otp/1 rate limiting" do
+    test "permits requests under the per-email limit" do
+      email = unique_email("under-limit")
+
+      assert :ok = Account.Public.generate_otp(email)
+      assert :ok = Account.Public.generate_otp(email)
+      assert :ok = Account.Public.generate_otp(email)
+    end
+
+    test "returns {:error, :rate_limited} after exceeding the per-email limit" do
+      email = unique_email("over-limit")
+
+      Account.Public.generate_otp(email)
+      Account.Public.generate_otp(email)
+      Account.Public.generate_otp(email)
+
+      assert {:error, :rate_limited} = Account.Public.generate_otp(email)
+    end
+
+    test "tracks limits per email independently" do
+      email_exhausted = unique_email("exhausted")
+      email_fresh = unique_email("fresh")
+
+      Account.Public.generate_otp(email_exhausted)
+      Account.Public.generate_otp(email_exhausted)
+      Account.Public.generate_otp(email_exhausted)
+      assert {:error, :rate_limited} = Account.Public.generate_otp(email_exhausted)
+
+      assert :ok = Account.Public.generate_otp(email_fresh)
     end
   end
 

--- a/core/test/systems/account/auth_code_test.exs
+++ b/core/test/systems/account/auth_code_test.exs
@@ -1,0 +1,209 @@
+defmodule Systems.Account.AuthCodeTest do
+  use Core.DataCase, async: true
+
+  alias Core.Factories
+  alias Core.Repo
+  alias Systems.Account
+  alias Systems.Account.AuthCodeModel
+
+  describe "AuthCodeModel.build/2" do
+    test "generates a 6-digit code" do
+      {code, _auth_code} = AuthCodeModel.build("user@example.com", nil)
+      assert String.match?(code, ~r/^\d{6}$/)
+    end
+
+    test "code is padded to 6 digits" do
+      codes =
+        for _ <- 1..100 do
+          {code, _} = AuthCodeModel.build("user@example.com", nil)
+          code
+        end
+
+      assert Enum.all?(codes, &(String.length(&1) == 6))
+    end
+
+    test "stores hashed code, not plaintext" do
+      {code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      refute auth_code.code_hash == code
+    end
+
+    test "sets email on the auth code" do
+      {_code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      assert auth_code.email == "user@example.com"
+    end
+
+    test "sets user_id when provided" do
+      user = Factories.insert!(:member)
+      {_code, auth_code} = AuthCodeModel.build(user.email, user.id)
+      assert auth_code.user_id == user.id
+    end
+
+    test "accepts nil user_id for new registrations" do
+      {_code, auth_code} = AuthCodeModel.build("new@example.com", nil)
+      assert auth_code.user_id == nil
+    end
+
+    test "starts with zero attempts" do
+      {_code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      assert auth_code.attempts == 0
+    end
+  end
+
+  describe "AuthCodeModel.verify/2" do
+    test "returns :ok for correct code" do
+      {code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      assert :ok = AuthCodeModel.verify(auth_code, code)
+    end
+
+    test "returns {:error, :invalid} for wrong code" do
+      {code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      wrong_code = if code == "000000", do: "000001", else: "000000"
+      assert {:error, :invalid} = AuthCodeModel.verify(auth_code, wrong_code)
+    end
+
+    test "returns {:error, :max_attempts} when attempts exhausted" do
+      {code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      exhausted = %{auth_code | attempts: 5}
+      assert {:error, :max_attempts} = AuthCodeModel.verify(exhausted, code)
+    end
+
+    test "returns {:error, :max_attempts} before checking code when attempts exhausted" do
+      {_code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      exhausted = %{auth_code | attempts: 5}
+      assert {:error, :max_attempts} = AuthCodeModel.verify(exhausted, "correct-irrelevant")
+    end
+  end
+
+  describe "AuthCodeModel.active_query/1" do
+    test "finds a recently inserted auth code" do
+      {_code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+      Repo.insert!(auth_code)
+
+      result = AuthCodeModel.active_query("user@example.com") |> Repo.one()
+      assert result != nil
+      assert result.email == "user@example.com"
+    end
+
+    test "returns nil for unknown email" do
+      result = AuthCodeModel.active_query("unknown@example.com") |> Repo.one()
+      assert result == nil
+    end
+
+    test "returns nil when max attempts reached" do
+      {_code, auth_code} = AuthCodeModel.build("user@example.com", nil)
+
+      Repo.insert!(%{auth_code | attempts: 5})
+
+      result = AuthCodeModel.active_query("user@example.com") |> Repo.one()
+      assert result == nil
+    end
+
+    test "returns most recent code when multiple exist" do
+      {_code1, auth_code1} = AuthCodeModel.build("user@example.com", nil)
+      {_code2, auth_code2} = AuthCodeModel.build("user@example.com", nil)
+
+      inserted1 = Repo.insert!(auth_code1)
+      inserted2 = Repo.insert!(auth_code2)
+
+      result = AuthCodeModel.active_query("user@example.com") |> Repo.one()
+      assert result.id == inserted2.id
+      assert result.id != inserted1.id
+    end
+  end
+
+  describe "Account.Public.generate_otp/1" do
+    test "inserts an auth code for the email" do
+      email = "new@example.com"
+      Account.Public.generate_otp(email)
+
+      assert Repo.one(AuthCodeModel.active_query(email)) != nil
+    end
+
+    test "replaces existing auth code" do
+      email = "user@example.com"
+      Account.Public.generate_otp(email)
+      Account.Public.generate_otp(email)
+
+      count = Repo.aggregate(from(t in AuthCodeModel, where: t.email == ^email), :count)
+      assert count == 1
+    end
+
+    test "links user_id when account exists" do
+      user = Factories.insert!(:member)
+      Account.Public.generate_otp(user.email)
+
+      auth_code = Repo.one(AuthCodeModel.active_query(user.email))
+      assert auth_code.user_id == user.id
+    end
+
+    test "leaves user_id nil when no account exists" do
+      Account.Public.generate_otp("brand-new@example.com")
+
+      auth_code = Repo.one(AuthCodeModel.active_query("brand-new@example.com"))
+      assert auth_code.user_id == nil
+    end
+  end
+
+  describe "Account.Public.verify_otp/2" do
+    test "returns {:ok, user} for correct code when account exists" do
+      user = Factories.insert!(:member)
+      {code, auth_code} = AuthCodeModel.build(user.email, user.id)
+      Repo.insert!(auth_code)
+
+      assert {:ok, returned_user} = Account.Public.verify_otp(user.email, code)
+      assert returned_user.id == user.id
+    end
+
+    test "returns {:ok, nil} for correct code when no account exists" do
+      email = "new@example.com"
+      Repo.delete_all(from(t in AuthCodeModel, where: t.email == ^email))
+      {code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(auth_code)
+
+      assert {:ok, nil} = Account.Public.verify_otp(email, code)
+    end
+
+    test "returns {:error, :invalid} for wrong code" do
+      email = "user@example.com"
+      {code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(auth_code)
+      wrong_code = if code == "000000", do: "000001", else: "000000"
+
+      assert {:error, :invalid} = Account.Public.verify_otp(email, wrong_code)
+    end
+
+    test "increments attempts on wrong code" do
+      email = "user@example.com"
+      {code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(auth_code)
+      wrong_code = if code == "000000", do: "000001", else: "000000"
+
+      Account.Public.verify_otp(email, wrong_code)
+
+      updated = Repo.one(AuthCodeModel.active_query(email))
+      assert updated.attempts == 1
+    end
+
+    test "returns {:error, :not_found} when no active code exists" do
+      assert {:error, :not_found} = Account.Public.verify_otp("nobody@example.com", "123456")
+    end
+
+    test "deletes auth code after successful verification" do
+      email = "user@example.com"
+      {code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(auth_code)
+
+      Account.Public.verify_otp(email, code)
+
+      assert Repo.one(AuthCodeModel.active_query(email)) == nil
+    end
+
+    test "returns {:error, :max_attempts} after 5 wrong attempts" do
+      email = "user@example.com"
+      {code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(%{auth_code | attempts: 5})
+
+      assert {:error, :not_found} = Account.Public.verify_otp(email, code)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Backend-only infrastructure for OTP-based authentication. Dormant until the email-first auth UI lands (see #9925221233). Closes the implementation scope of [Flux #9925221307](https://app.basecamp.com/5734045/buckets/35926565/todos/9925221307).

### What's in this PR

- **`Systems.Account.AuthCodeModel`** — `auth_codes` schema with hashed 6-digit code, email, attempts counter, optional user link. 10-minute TTL, 5 wrong attempts max per code.
- **`Account.Public.generate_otp/1`** — produces a new code, deletes any active prior code for the email, sends the OTP email.
- **`Account.Public.verify_otp/2`** — checks the code, deletes on success, increments attempts on wrong code, returns `{:ok, user_or_nil}` (existing user vs. new registration).
- **Mailer** — `Systems.Account.UserNotifier.deliver_otp/2` plus HTML/text templates with the code prominently displayed.
- **Rate limiting** — new `:otp_request` quota (3 calls per minute per email) via `Systems.Rate.Public`. `generate_otp/1` returns `{:error, :rate_limited}` when exceeded. Protects against email-bombing a specific user's inbox; complements per-IP nginx limits (separately tracked in #9981702460).
- **Tests** — 29 atomic tests covering build, verify, query, generate, verify, and rate limiting.

### What's NOT in this PR

- OTP verification UI page — lives in #9925221233 (email-first + verify pages).
- Post-verification routing (sign-in vs. registration) — split between #9925221233 and #9972272464.
- nginx-level per-IP rate limit zones — separately tracked in #9981702460.

## Test plan
- [x] `mix test test/systems/account/auth_code_test.exs` (29 tests, 0 failures)
- [x] Pre-commit hooks: format, compile, test, credo, dialyzer
- [ ] Reviewer: confirm the rate limit quota (3/minute per email) is sensible

🤖 Generated with [Claude Code](https://claude.com/claude-code)