### PR TITLE
fix(error): translate page.title and 403.body across de/es/it/lt/ro

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Leider haben Sie keinen Zugriff auf diese Seite. Wenn Sie meinen, dass dies ein Fehler unsererseits ist, melden Sie es uns bitte per E-Mail an <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Entschuldigung"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Lamentablemente, no tienes acceso a esta página. Si crees que es un error por nuestra parte, te agradeceríamos que nos lo reportaras enviando un correo a <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Lo sentimos"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Purtroppo non hai accesso a questa pagina. Se pensi che si tratti di un errore da parte nostra, ti saremmo grati se ce lo segnalassi inviando un'email a <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Ci dispiace"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Deja, neturite prieigos prie šio puslapio. Jei manote, kad tai mūsų klaida, būtume dėkingi, jei tai praneštumėte el. paštu <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Atsiprašome"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Din păcate, nu aveți acces la această pagină. Dacă credeți că este o greșeală din partea noastră, vă rugăm să ne anunțați trimițând un email la <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Ne pare rău"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"


### PR DESCRIPTION
## Summary
- Until now only `en` and `nl` had translations for the `page.title` and `403.body` keys in the `eyra-error` gettext domain.
- For users on `de` / `es` / `it` / `lt` / `ro` the 403 page (and other status pages) fell back to the raw msgids — visible as literal text "page.title" and "403.body" on screen.
- Reported by Iris in [Flux #9985757546](https://app.basecamp.com/5734045/buckets/35926565/todos/9985757546) after testing the affiliate `?p=null` → 403 path on a non-Dutch locale.

## Translations
- **de / es / it** — intended to be idiomatic
- **lt / ro** — best effort, may want a native-speaker pass before they ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)