### PR TITLE
fix(tests): sign_in waits for destination LiveView to be phx-connected

### DIFF
--- a/core/test/support/feature_case.ex
+++ b/core/test/support/feature_case.ex
@@ -61,8 +61,14 @@ defmodule CoreWeb.FeatureCase do
     # can navigate (e.g. visit("/user/onboarding")) before the auth session
     # cookie is set and get bounced back to /user/signin — a race that surfaces
     # as flaky "element not found" failures under load. Waiting for the sign-in
-    # form to disappear confirms we've landed on the authenticated page.
+    # form to disappear confirms we've landed on the authenticated page,
+    # and waiting for the destination LiveView's phx-connected class confirms
+    # the post-login page has finished mounting before the caller proceeds.
+    # Without the second wait, a follow-up visit/2 can interrupt the in-flight
+    # navigation and leave chromedriver mid-load, producing HTTPoison :timeout
+    # failures on the next Wallaby request.
     |> refute_has(css("[data-testid='signin-form']"))
+    |> assert_has(css("[data-phx-main].phx-connected"))
   end
 
   @doc """


### PR DESCRIPTION
## Summary
Extends the post-login wait added in #1535. The previous fix's `refute_has(signin-form)` confirms the redirect *kicked off* but not that the destination LiveView *finished mounting*. A caller doing `sign_in(...) |> visit("/some/path")` can fire the visit mid-mount on the home page, leaving chromedriver in a partially-loaded state and producing intermittent `HTTPoison :timeout` failures on the next Wallaby HTTP call.

Adding `assert_has([data-phx-main].phx-connected)` at the end of `sign_in` matches the documented pattern (`test/CLAUDE.md` "Waiting for LiveView to be Ready").

## Repro that surfaced this
Today on PR #1554's CI run:

```
test/features/onboarding_test.exs:73
** (RuntimeError) Wallaby had an internal issue with HTTPoison:
%HTTPoison.Error{reason: :timeout, id: nil}
code: |> visit("/user/onboarding")
```

Re-running the same commit passed — i.e. timing-dependent, not deterministic. This change makes it deterministic.

## Test plan
- [x] Pre-commit: format, compile, full suite, credo, dialyzer
- [ ] Eyes-on: confirm the wait doesn't make existing sign_in callers significantly slower (the assert should fire as soon as `phx-connected` lands, which is the moment they were *implicitly* waiting on already)

🤖 Generated with [Claude Code](https://claude.com/claude-code)