### PR TITLE
Milestone 25.1 — Affiliate URL hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@
 * Removed - This notes any features that have been deleted and removed from the software
 * Security - This acts as an invitation to users who want to upgrade and avoid any software vulnerabilities
 
-## \#25 Unreleased
+## \#25.1 2026-06-14
+* Fixed - Affiliate URLs with `?p=null` or `?p=undefined` now return 403 instead of silently creating ghost affiliate users (came from external panels coercing an empty JS variable to the string "null")
+* Fixed - 403 page and other status pages showed raw msgids ("page.title" / "403.body") instead of translated text on DE / ES / IT / LT / RO
+
+## \#25 2026-06-10
 * Fixed - "Participants waiting for pay out" banner on the Participants tab was lost in the milestone 23 refactor; restored with correct copy
 * Fixed - Pay-out modal translations (payout.*) were wiped in the SURFconext-auth merge; EN and NL strings restored
 * Added - Pay-out Overview tab now shows a list of completed payouts instead of the "coming soon" placeholder

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Leider haben Sie keinen Zugriff auf diese Seite. Wenn Sie meinen, dass dies ein Fehler unsererseits ist, melden Sie es uns bitte per E-Mail an <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Entschuldigung"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Lamentablemente, no tienes acceso a esta página. Si crees que es un error por nuestra parte, te agradeceríamos que nos lo reportaras enviando un correo a <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Lo sentimos"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Purtroppo non hai accesso a questa pagina. Se pensi che si tratti di un errore da parte nostra, ti saremmo grati se ce lo segnalassi inviando un'email a <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Ci dispiace"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Deja, neturite prieigos prie šio puslapio. Jei manote, kad tai mūsų klaida, būtume dėkingi, jei tai praneštumėte el. paštu <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Atsiprašome"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-error.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-error.po
@@ -13,11 +13,11 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "403.body"
-msgstr ""
+msgstr "Din păcate, nu aveți acces la această pagină. Dacă credeți că este o greșeală din partea noastră, vă rugăm să ne anunțați trimițând un email la <span class=\"text-primary underline\"><a href=\"mailto:support@eyra.co?subject=[403] %{status}\">support@eyra.co</a></span>."
 
 #, elixir-autogen, elixir-format
 msgid "page.title"
-msgstr ""
+msgstr "Ne pare rău"
 
 #, elixir-autogen, elixir-format
 msgid "404.body"

--- a/core/systems/affiliate/controller.ex
+++ b/core/systems/affiliate/controller.ex
@@ -159,6 +159,8 @@ defmodule Systems.Affiliate.Controller do
 
   def valid_id?(nil), do: false
   def valid_id?("participant_id"), do: false
+  def valid_id?("null"), do: false
+  def valid_id?("undefined"), do: false
 
   def valid_id?(id) do
     String.length(id) <= @id_max_lenght and Regex.match?(@id_valid_regex, id)

--- a/core/test/systems/affiliate/controller_test.exs
+++ b/core/test/systems/affiliate/controller_test.exs
@@ -1,0 +1,51 @@
+defmodule Systems.Affiliate.ControllerTest do
+  use ExUnit.Case, async: true
+
+  alias Systems.Affiliate.Controller
+
+  describe "valid_id?/1" do
+    test "rejects nil" do
+      refute Controller.valid_id?(nil)
+    end
+
+    test "rejects \"participant_id\" placeholder" do
+      refute Controller.valid_id?("participant_id")
+    end
+
+    test "rejects \"null\" string" do
+      refute Controller.valid_id?("null")
+    end
+
+    test "rejects \"undefined\" string" do
+      refute Controller.valid_id?("undefined")
+    end
+
+    test "rejects empty string" do
+      refute Controller.valid_id?("")
+    end
+
+    test "rejects identifiers longer than 64 characters" do
+      refute Controller.valid_id?(String.duplicate("a", 65))
+    end
+
+    test "rejects identifiers containing whitespace" do
+      refute Controller.valid_id?("foo bar")
+    end
+
+    test "rejects identifiers containing special characters" do
+      refute Controller.valid_id?("foo@bar")
+    end
+
+    test "accepts alphanumeric identifier" do
+      assert Controller.valid_id?("abc123")
+    end
+
+    test "accepts identifier with underscores and hyphens" do
+      assert Controller.valid_id?("foo_bar-baz")
+    end
+
+    test "accepts 36-character UUID-like identifier" do
+      assert Controller.valid_id?("550e8400e29b41d4a716446655440000")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Hotfix release on top of milestone 25:
- #1552 — reject "null" and "undefined" as affiliate participant identifiers (returns 403 instead of creating ghost accounts)
- #1560 — translate the 403 page across DE / ES / IT / LT / RO (was rendering raw msgids)

## Test plan
- [x] Smoke tests against prod (`mix test.smoke prod`) — pass
- [x] Manual verification on prod
- [x] Iris confirmed on staging

Tag: `core_2026-06-14_25.1`