### PR TITLE
fix(support): close-ticket button border + nil profile handling

### DIFF
--- a/core/systems/support/overview_tab.ex
+++ b/core/systems/support/overview_tab.ex
@@ -35,6 +35,21 @@ defmodule Systems.Support.OverviewTab do
          } = ticket,
          _socket
        ) do
+    build_item(ticket, title, subtitle, photo_url, features, updated_at)
+  end
+
+  defp to_view_model(
+         %Support.TicketModel{
+           updated_at: updated_at,
+           title: title,
+           user: %{email: email, features: features}
+         } = ticket,
+         _socket
+       ) do
+    build_item(ticket, title, email, nil, features, updated_at)
+  end
+
+  defp build_item(ticket, title, subtitle, photo_url, features, updated_at) do
     gender = gender(features)
 
     quick_summery =

--- a/core/systems/support/ticket_page_builder.ex
+++ b/core/systems/support/ticket_page_builder.ex
@@ -21,6 +21,7 @@ defmodule Systems.Support.TicketPageBuilder do
       face: %{
         type: :secondary,
         label: dgettext("eyra-admin", "close.ticket.button"),
+        border_color: "border-delete",
         text_color: "text-delete"
       }
     }
@@ -49,13 +50,22 @@ defmodule Systems.Support.TicketPageBuilder do
          user: %{
            email: email,
            creator: creator,
-           profile: %{
-             fullname: fullname,
-             photo_url: photo_url
-           },
+           profile: %{fullname: fullname, photo_url: photo_url},
            features: features
          }
        }) do
+    build_member(id, title, email, creator, fullname, photo_url, features)
+  end
+
+  defp to_member(%{
+         id: id,
+         title: title,
+         user: %{email: email, creator: creator, features: features}
+       }) do
+    build_member(id, title, email, creator, email, nil, features)
+  end
+
+  defp build_member(id, title, email, creator, fullname, photo_url, features) do
     role =
       if creator do
         dgettext("eyra-admin", "role.creator")


### PR DESCRIPTION
## Summary

- **Close-ticket button border** (FX#9990775121): set `border_color: \"border-delete\"` on the close-ticket button face so the border matches its red text instead of defaulting to `border-primary` (which produced red text inside a blue outline).
- **Nil profile / features on ticket views**: added fallback function clauses in `Systems.Support.OverviewTab.to_view_model/2` and `Systems.Support.TicketPageBuilder.to_member/1` for tickets whose user has `profile: nil` / `features: nil`. A freshly-confirmed creator can file a ticket before completing their profile, and the strict pattern match was crashing `/support/ticket` and `/support/ticket/:id`. Falls back to using the user's email as the displayed name, with the default avatar.

## Test plan

- [ ] On `/support/ticket/:id`, the **Close ticket** button has a red border (matching the red text).
- [ ] Sign up as a fresh creator, immediately file a support ticket (without completing profile/features). `/support/ticket` (overview) and `/support/ticket/:id` (detail) both render without `FunctionClauseError`; the new ticket shows the user's email as the displayed name.
- [ ] Existing tickets from users with a complete profile still render with `profile.fullname` and `profile.photo_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)