### PR TITLE
fix(surfconext): set confirmed_at instead of verified_at on signup

### DIFF
--- a/core/lib/core/surfconext.ex
+++ b/core/lib/core/surfconext.ex
@@ -42,7 +42,7 @@ defmodule Core.SurfConext do
         fullname: fullname
       },
       creator: true,
-      verified_at: NaiveDateTime.utc_now()
+      confirmed_at: NaiveDateTime.utc_now()
     }
 
     user = User.sso_changeset(%User{}, sso_info)

--- a/core/test/core/surfconext/plug_test.exs
+++ b/core/test/core/surfconext/plug_test.exs
@@ -117,8 +117,8 @@ defmodule Core.SurfConext.CallbackController.Test do
       assert redirected_to(conn) == "/user/onboarding"
 
       assert [user] = Core.Repo.all(Systems.Account.User)
-      assert user.verified_at != nil
-      assert user.confirmed_at == nil
+      assert user.verified_at == nil
+      assert user.confirmed_at != nil
       assert user.creator == true
     end
 


### PR DESCRIPTION
## Summary

SURFconext registrations were auto-marked as **verified**. Per FX#9990458967, accounts should be auto-**activated** (confirmed_at set) but not auto-verified — verification is a manual admin step.

Change: in \`Core.SurfConext.register_user/1\`, swap \`verified_at: NaiveDateTime.utc_now()\` for \`confirmed_at: NaiveDateTime.utc_now()\`. Test in \`plug_test.exs\` updated to match (was asserting the opposite of the intended behaviour).

## Test plan

- [ ] On staging (once merged + deployed), creating a new account via SURFconext lands the user as Activated but **not** Verified in the admin UI.
- [x] \`test/core/surfconext\` passes locally (10/10).
- [x] Full pre-commit test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)