### PR TITLE
fix(tests): mark Manual.ViewBuilderTest async to avoid sandbox race

### DIFF
--- a/core/test/systems/manual/view_builder_test.exs
+++ b/core/test/systems/manual/view_builder_test.exs
@@ -1,5 +1,13 @@
 defmodule Systems.Manual.ViewBuilderTest do
-  use Core.DataCase
+  # `async: true` runs each test in Ecto's ownership mode instead of the
+  # shared mode DataCase defaults to. The test only does synchronous DB
+  # inserts + pure view-model building — no signals, no LiveView, no
+  # spawned processes — so it's safe to isolate. Without this, the test
+  # was racing other non-async DataCase tests on the global shared sandbox
+  # owner registration, producing intermittent
+  # `DBConnection.ConnectionError{message: "client #PID<…> exited"}`
+  # during setup. (FX#9998325274)
+  use Core.DataCase, async: true
 
   alias Systems.Manual
 


### PR DESCRIPTION
## Summary

\`Systems.Manual.ViewBuilderTest\` only does synchronous DB inserts + pure view-model building (no signals, no LiveView, no spawned processes). Marking it \`async: true\` runs it in Ecto's ownership mode instead of the global \`{:shared, self()}\` fallback DataCase uses by default — which was racing other concurrent non-async tests on the global shared owner slot and producing intermittent \`DBConnection.ConnectionError{message: "client #PID<…> exited"}\` during setup (seen on PR #1569 CI).

FX#9998325274.

Broader follow-up to install the \`Phoenix.Ecto.SQL.Sandbox\` plug so other tests can drop the shared-mode fallback: FX#9998394990.

## Test plan

- [x] \`mix test test/systems/manual/view_builder_test.exs\` → 4/4 in 0.1s.
- [x] Pre-commit full suite green.
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)