### PR TITLE
test(e2e): add Request Payout spec (UC-OPP-06)

### DIFF
--- a/core/frameworks/pixel/components/confirmation_modal.ex
+++ b/core/frameworks/pixel/components/confirmation_modal.ex
@@ -37,12 +37,14 @@ defmodule Frameworks.Pixel.ConfirmationModal do
        ) do
     confirm = %{
       action: confirm_action || %{type: :send, target: myself, event: "confirm"},
-      face: %{type: :primary, label: confirm_label}
+      face: %{type: :primary, label: confirm_label},
+      testid: "confirmation-modal-confirm-button"
     }
 
     cancel = %{
       action: %{type: :send, target: myself, event: "cancel"},
-      face: %{type: :secondary, label: cancel_label}
+      face: %{type: :secondary, label: cancel_label},
+      testid: "confirmation-modal-cancel-button"
     }
 
     assign(socket, buttons: [confirm, cancel])

--- a/core/test/e2e/request_payout.spec.ts
+++ b/core/test/e2e/request_payout.spec.ts
@@ -40,11 +40,11 @@ async function clickAddItemButton(page: any) {
  * No fixtures are used. The full flow is exercised end-to-end through the UI.
  *
  * Wait pattern: per `core/test/e2e/CLAUDE.md`, we wait on a target-page
- * `data-testid` via `expect(...).toBeVisible()` (auto-polling) after each
- * navigation, rather than on `.phx-connected` of the source page. The few
- * `waitForTimeout` calls left in this spec are load-bearing — debounced form
- * persistence (BudgetForm, FeaturesForm) and one consent → CrewPage re-render
- * that the parent view model recomputes asynchronously.
+ * `data-testid` (or specific class transition) via `expect(...).toBeVisible()`
+ * / `expect(...).not.toHaveClass(...)` (auto-polling) after each action,
+ * rather than on `.phx-connected` of the source page. No `waitForTimeout`
+ * calls — debounced form state, async server recomputes, and selector save
+ * acks all surface as observable destination signals we can poll on.
  *
  * Prerequisites:
  *   - Local server (mix phx.server) on http://localhost:4000
@@ -156,16 +156,15 @@ test.describe('Request Payout (UC-OPP-06)', () => {
 
     const rewardInput = researcherPage.locator("[data-testid='budget-form-reward-input']");
     await rewardInput.fill(SUBJECT_REWARD);
-    // BudgetForm has a 1000ms phx-change debounce on the fee form + server roundtrip.
-    await researcherPage.waitForTimeout(1500);
 
     const slotsInput = researcherPage.locator("[data-testid='budget-form-slots-input']");
     await slotsInput.fill(SUBJECT_COUNT);
-    // 300ms debounce on slots + brief settle.
-    await researcherPage.waitForTimeout(500);
 
+    // Confirm button is disabled (cursor-not-allowed) until BudgetForm's
+    // phx-change debounces fire and the server enables it. Polling on the
+    // class transition is the replacement for hardcoded debounce sleeps.
     const confirmBtn = researcherPage.locator("[data-testid='budget-form-confirm-button']");
-    await expect(confirmBtn).toBeVisible({ timeout: 3000 });
+    await expect(confirmBtn).not.toHaveClass(/cursor-not-allowed/, { timeout: 5000 });
     await confirmBtn.click();
     await researcherPage.waitForURL(/\/payment\/local\/[a-f0-9-]+$/, { timeout: 10000 });
 
@@ -236,8 +235,6 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     await participantPage.locator('[data-tab-id="features"]').first().click();
     await expect(participantPage.locator('[data-testid="features-view"]')).toBeVisible({ timeout: 5000 });
     await participantPage.locator("[data-testid='selector-item-man']").click();
-    // phx-change save on the selector — give the server a moment to persist.
-    await participantPage.waitForTimeout(500);
 
     await participantPage.goto(promotionPath);
 
@@ -254,8 +251,8 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     const consentAcceptButton = participantPage.locator("[data-testid='consent-accept-button']");
     if (await consentAcceptButton.isVisible({ timeout: 5000 })) {
       await consentAcceptButton.click();
-      // consent → publish_event(:accept) → parent recomputes view model → CrewPage re-renders.
-      await participantPage.waitForTimeout(2000);
+      // The next isVisible() poll on activate-account-check-button below catches
+      // the CrewPage re-render after the consent event propagates.
     }
 
     if (await participantPage.locator("[data-testid='activate-account-check-button']").isVisible({ timeout: 3000 })) {

--- a/core/test/e2e/request_payout.spec.ts
+++ b/core/test/e2e/request_payout.spec.ts
@@ -1,0 +1,372 @@
+import { test, expect } from '@playwright/test';
+import { missingFeaturesReason } from './lib/features';
+import { activateLocalPayment, snapshotCardTestids, pickNewCardTestid } from './lib';
+
+const ADD_ITEM_SELECTOR = "[data-testid='create-first-item-button'],[data-testid='add-item-button'],[phx-click='create_item']";
+
+async function clickAddItemButton(page: any) {
+  await page.waitForSelector(ADD_ITEM_SELECTOR, { timeout: 10000 });
+  const createFirst = page.locator("[data-testid='create-first-item-button']");
+  const addItem = page.locator("[data-testid='add-item-button']");
+  const byEvent = page.locator("[phx-click='create_item']");
+  if (await createFirst.isVisible()) {
+    await createFirst.click();
+  } else if (await addItem.isVisible()) {
+    await addItem.click();
+  } else {
+    await byEvent.click();
+  }
+}
+
+/**
+ * Request Payout E2E Test (UC-OPP-06)
+ *
+ * Verifies the happy path of a participant requesting a payout after
+ * receiving an approved reward:
+ *   1. Researcher creates a questionnaire study, assigns a budget (≥ €5),
+ *      completes payment via the local simulator (UC-OPP-01 setup).
+ *   2. Participant logs in (separate browser context), completes the task —
+ *      reward flips to :pending_approval.
+ *   3. Researcher approves the reward via the PayoutModal (UC-OPP-05 step).
+ *   4. Participant navigates to the home page, sees the approved balance in
+ *      the rewards-summary widget, clicks "Uitbetalen" (payout-button).
+ *   5. Because the fresh participant is not yet known at the Payment Provider,
+ *      Next returns {:error, {:kyc_required, url}} — the KYC handoff modal
+ *      (UC-OPP-06.A1) appears with a confirm button that would redirect to OPP.
+ *      The test verifies the modal is visible; it does not follow the external
+ *      OPP link (that requires a pre-verified sandbox account and is covered by
+ *      manual testing).
+ *
+ * No fixtures are used. The full flow is exercised end-to-end through the UI.
+ *
+ * Prerequisites:
+ *   - Local server (mix phx.server) on http://localhost:4000
+ *   - ENABLED_APP_FEATURES contains "panl", "e2e", and "panl_post_launch"
+ *   - PAYMENT_PROVIDER unset or "local"
+ *   - Researcher account: e2e-researcher@eyra.co (seeded by /api/e2e/setup)
+ */
+
+const SKIP_REASON = missingFeaturesReason('panl', 'panl_post_launch');
+
+const RESEARCHER_EMAIL = process.env.E2E_RESEARCHER_EMAIL || 'e2e-researcher@eyra.co';
+const RESEARCHER_PASSWORD = process.env.E2E_RESEARCHER_PASSWORD || 'asdf;lkjASDF0987';
+
+const PARTICIPANT_PASSWORD = process.env.E2E_PARTICIPANT_PASSWORD || 'TestPassword123!';
+function generateParticipantEmail(): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 8);
+  return `test_payout_${timestamp}_${random}@test.example.com`;
+}
+
+// Must be ≥ €5 (500 cents) to pass the payout threshold check (SF-OPP-06).
+const SUBJECT_COUNT = '10';
+const SUBJECT_REWARD = '5.00';
+const AIM_OF_STUDY = 'E2E request payout test';
+
+const CONNECTED_SELECTOR = '[data-phx-main].phx-connected';
+
+test.describe('Request Payout (UC-OPP-06)', () => {
+  test.skip(SKIP_REASON !== '', SKIP_REASON);
+
+  test('participant sees payout handoff modal after researcher approves reward', async ({ browser }) => {
+    test.setTimeout(240000); // 4 min — full flow with two browser contexts.
+
+    const researcherContext = await browser.newContext();
+    const participantContext = await browser.newContext();
+    const researcherPage = await researcherContext.newPage();
+    const participantPage = await participantContext.newPage();
+
+    researcherPage.on('console', msg => {
+      if (msg.type() === 'error') console.log(`[RESEARCHER BROWSER ERROR] ${msg.text()}`);
+    });
+    participantPage.on('console', msg => {
+      if (msg.type() === 'error') console.log(`[PARTICIPANT BROWSER ERROR] ${msg.text()}`);
+    });
+
+    let assignmentId: string;
+
+    // =========================================================================
+    // PHASE 1 — Researcher creates study, assigns budget, completes payment
+    // =========================================================================
+
+    console.log('[TEST] === Phase 1: Researcher setup ===');
+
+    await researcherPage.goto('/user/signin');
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await researcherPage.locator("[data-testid='signin-tab-creator']").click();
+    await researcherPage.waitForTimeout(300);
+    await researcherPage.locator("#account_signin-tab_panel_creator [data-testid='signin-email-input']").fill(RESEARCHER_EMAIL);
+    await researcherPage.locator("#account_signin-tab_panel_creator [data-testid='signin-password-input']").fill(RESEARCHER_PASSWORD);
+    await researcherPage.locator("#account_signin-tab_panel_creator [data-testid='signin-submit-button']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 15000 });
+    await researcherPage.waitForTimeout(1000);
+    await activateLocalPayment(researcherPage);
+
+    const projectTestidsBefore = await snapshotCardTestids(researcherPage);
+
+    const createFirstProject = researcherPage.locator("[data-testid='create-first-project-button']");
+    const createNewProject = researcherPage.locator("[data-testid='create-project-button']");
+    if (await createFirstProject.isVisible({ timeout: 3000 })) {
+      await createFirstProject.click();
+    } else {
+      await createNewProject.click();
+    }
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    const newProjectTestid = await pickNewCardTestid(researcherPage, projectTestidsBefore);
+    console.log(`[TEST] Created project: ${newProjectTestid}`);
+    await researcherPage.locator(`[data-testid='${newProjectTestid}']`).click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await researcherPage.waitForTimeout(500);
+
+    const itemTestidsBefore = await snapshotCardTestids(researcherPage);
+
+    console.log('[TEST] Creating questionnaire study');
+    await clickAddItemButton(researcherPage);
+
+    await researcherPage.waitForSelector("[data-testid='selector-item-questionnaire']", { timeout: 10000 });
+    await researcherPage.locator("[data-testid='selector-item-questionnaire']").click();
+    await researcherPage.waitForTimeout(300);
+    await researcherPage.locator("[data-testid='create-item-button']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await researcherPage.waitForTimeout(500);
+
+    const newItemTestid = await pickNewCardTestid(researcherPage, itemTestidsBefore);
+    console.log(`[TEST] Created item: ${newItemTestid}`);
+    const newCard = researcherPage.locator(`[data-testid='${newItemTestid}']`);
+    await newCard.scrollIntoViewIfNeeded();
+    await newCard.click();
+    await researcherPage.waitForURL(/\/assignment\/\d+\/content/, { timeout: 15000 });
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    const assignmentUrl = researcherPage.url();
+    assignmentId = assignmentUrl.match(/\/assignment\/(\d+)/)![1];
+    console.log(`[TEST] Inside assignment ${assignmentId}`);
+
+    console.log('[TEST] Adding Instruction Manual to workflow');
+    await researcherPage.waitForSelector("[data-testid='assignment-tab-workflow']", { timeout: 10000 });
+    await researcherPage.locator("[data-testid='assignment-tab-workflow']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await researcherPage.waitForTimeout(500);
+    await expect(researcherPage.locator("[data-testid='add-library-item-manual']")).toBeVisible({ timeout: 5000 });
+    await researcherPage.locator("[data-testid='add-library-item-manual']").click();
+    await researcherPage.waitForTimeout(1000);
+
+    await researcherPage.waitForSelector("[data-testid='assignment-tab-participants']", { timeout: 10000 });
+    await researcherPage.locator("[data-testid='assignment-tab-participants']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await researcherPage.waitForTimeout(500);
+
+    const addBudgetBtn = researcherPage.locator("[data-testid='pay-add-participants-button']");
+    await expect(addBudgetBtn).toBeVisible({ timeout: 5000 });
+    await addBudgetBtn.click();
+
+    const aimInput = researcherPage.locator("[data-testid='budget-form-aim-input']");
+    await expect(aimInput).toBeVisible({ timeout: 5000 });
+    await aimInput.fill(AIM_OF_STUDY);
+
+    const rewardInput = researcherPage.locator("[data-testid='budget-form-reward-input']");
+    await rewardInput.fill(SUBJECT_REWARD);
+    await researcherPage.waitForTimeout(1500);
+
+    const slotsInput = researcherPage.locator("[data-testid='budget-form-slots-input']");
+    await slotsInput.fill(SUBJECT_COUNT);
+    await researcherPage.waitForTimeout(500);
+
+    const confirmBtn = researcherPage.locator("[data-testid='budget-form-confirm-button']");
+    await expect(confirmBtn).toBeVisible({ timeout: 3000 });
+    await confirmBtn.click();
+    await researcherPage.waitForURL(/\/payment\/local\/[a-f0-9-]+$/, { timeout: 10000 });
+
+    await researcherPage.locator("[data-testid='local-payment-complete-button']").click();
+    await researcherPage.waitForURL(/\/assignment\/\d+\/content/, { timeout: 10000 });
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    await researcherPage.locator("[data-testid='assignment-tab-participants']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await expect(researcherPage.locator("[data-testid='transaction-card-completed']")).toBeVisible({ timeout: 5000 });
+
+    console.log('[TEST] Creating and publishing advert');
+    const createAdvertButton = researcherPage.locator("[data-testid='create-advert-button']");
+    const gotoAdvertButton = researcherPage.locator("[data-testid='goto-advert-button']");
+    if (await createAdvertButton.isVisible({ timeout: 3000 })) {
+      await createAdvertButton.scrollIntoViewIfNeeded();
+      await createAdvertButton.click();
+      await expect(gotoAdvertButton).toBeVisible({ timeout: 10000 });
+    }
+
+    await expect(researcherPage.locator("[data-testid='publish-button']")).toBeVisible({ timeout: 5000 });
+    await researcherPage.locator("[data-testid='publish-button']").click();
+    await expect(researcherPage.locator("[data-testid='retract-button']")).toBeVisible({ timeout: 10000 });
+
+    await researcherPage.locator("[data-testid='goto-advert-button']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    await expect(researcherPage.locator("[data-testid='advert-publish-button']")).toBeVisible({ timeout: 5000 });
+    await researcherPage.locator("[data-testid='advert-publish-button']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    const inviteLinkText = await researcherPage.locator(
+      "text=/https?:\\/\\/[^/]+\\/promotion\\/\\d+/"
+    ).first().textContent({ timeout: 5000 });
+    const promotionPath = inviteLinkText && inviteLinkText.match(/\/promotion\/\d+/)?.[0];
+    if (!promotionPath) throw new Error(`Could not extract promotion path from invite link text: ${inviteLinkText}`);
+    console.log(`[TEST] Promotion path: ${promotionPath}`);
+
+    // =========================================================================
+    // PHASE 2 — Participant signs up, completes task → reward :pending_approval
+    // =========================================================================
+
+    console.log('[TEST] === Phase 2: Participant flow ===');
+
+    const participantEmail = generateParticipantEmail();
+    console.log(`[TEST] Signing up participant: ${participantEmail}`);
+
+    await participantPage.goto('/user/signup/participant?post_signup_action=add_to_panl');
+    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    await participantPage.locator('#signup_form input[name="user[email]"]').fill(participantEmail);
+    await participantPage.locator('#signup_form input[name="user[password]"]').fill(PARTICIPANT_PASSWORD);
+    await participantPage.locator("[data-selector-item='next_privacy_policy_accepted'] .selector-icon-inactive").click();
+    await participantPage.locator("[data-selector-item='panl_privacy_policy_accepted'] .selector-icon-inactive").click();
+    await participantPage.locator('#signup_form button[type="submit"]').click();
+
+    await participantPage.waitForURL('**/user/onboarding', { timeout: 5000 });
+    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 5000 });
+
+    await expect(participantPage.locator('[data-testid="profile-view"]')).toBeVisible({ timeout: 3000 });
+    await participantPage.locator('[data-testid="onboarding-continue"]').click();
+
+    await expect(participantPage.locator('[data-testid="features-view"]')).toBeVisible({ timeout: 3000 });
+    await participantPage.locator('[data-testid="onboarding-continue"]').click();
+
+    await expect(participantPage.locator('[data-testid="activate-account-view"]')).toBeVisible({ timeout: 3000 });
+    await Promise.all([
+      participantPage.waitForURL('**/', { timeout: 5000 }),
+      participantPage.locator('[data-testid="onboarding-continue"]').click()
+    ]);
+
+    console.log('[TEST] Filling participant features (gender)');
+    await participantPage.goto('/user/profile');
+    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await participantPage.locator('[data-tab-id="features"]').first().click();
+    await expect(participantPage.locator('[data-testid="features-view"]')).toBeVisible({ timeout: 5000 });
+    await participantPage.locator("[data-testid='selector-item-man']").click();
+    await participantPage.waitForTimeout(500);
+
+    await participantPage.goto(promotionPath);
+    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    await expect(participantPage.locator("[data-testid='promotion-apply-button-hero']")).toBeVisible({ timeout: 5000 });
+    await participantPage.locator("[data-testid='promotion-apply-button-hero']").click();
+    await participantPage.waitForURL(/\/assignment\/\d+(\/.*)?$/, { timeout: 10000 });
+    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    for (let i = 0; i < 10; i++) {
+      const onboardingContinue = participantPage.locator("[data-testid='assignment-onboarding-continue-button']");
+      if (!(await onboardingContinue.isVisible({ timeout: 2000 }))) break;
+      await onboardingContinue.click();
+      await participantPage.waitForTimeout(500);
+    }
+
+    const consentAcceptButton = participantPage.locator("[data-testid='consent-accept-button']");
+    if (await consentAcceptButton.isVisible({ timeout: 5000 })) {
+      await consentAcceptButton.click();
+      await participantPage.waitForTimeout(2000);
+      await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    }
+
+    if (await participantPage.locator("[data-testid='activate-account-check-button']").isVisible({ timeout: 3000 })) {
+      console.log(`[TEST] Activating account via E2E API for ${participantEmail}`);
+      const activateResponse = await fetch(`${process.env.E2E_BASE_URL || 'http://localhost:4000'}/api/e2e/activate_user`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: participantEmail })
+      });
+      if (!activateResponse.ok) {
+        throw new Error(`Failed to activate user: ${activateResponse.status} - ${await activateResponse.text()}`);
+      }
+      await participantPage.goto(`/assignment/${assignmentId}`);
+      await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    }
+
+    console.log('[TEST] Participant completes Instruction Manual');
+    await expect(participantPage.locator("[data-testid^='chapter-list-item-']").first()).toBeVisible({ timeout: 5000 });
+    await participantPage.locator("[data-testid^='chapter-list-item-']").first().click();
+    await participantPage.waitForTimeout(500);
+
+    for (let i = 0; i < 20; i++) {
+      const next = participantPage.locator("[data-testid='manual-chapter-next-button']");
+      if (await next.isVisible({ timeout: 1000 })) {
+        await next.click();
+        await participantPage.waitForTimeout(300);
+        continue;
+      }
+      const done = participantPage.locator("[data-testid='manual-chapter-done-button']");
+      if (await done.isVisible({ timeout: 1000 })) {
+        await done.click();
+        break;
+      }
+      break;
+    }
+
+    await expect(participantPage.locator("[data-testid='finished-view']")).toBeVisible({ timeout: 15000 });
+    console.log('[TEST] Participant task completed (reward now :pending_approval)');
+
+    // =========================================================================
+    // PHASE 3 — Researcher approves the reward
+    // =========================================================================
+
+    console.log('[TEST] === Phase 3: Researcher approves reward ===');
+
+    await researcherPage.goto(`/assignment/${assignmentId}/content?tab=participants`);
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await expect(researcherPage.locator("[data-testid='pending-approvals-cta']")).toBeVisible({ timeout: 5000 });
+    await researcherPage.locator("[data-testid='pending-approvals-cta']").click();
+
+    await expect(researcherPage.locator("[data-testid='payout-modal']")).toBeVisible({ timeout: 5000 });
+    const waitingCount = researcherPage.locator("[data-testid='payout-waiting-count']");
+    await expect(waitingCount).not.toHaveText('0');
+
+    await researcherPage.locator("[data-testid='pay-out-all-button']").click();
+    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+    await expect(researcherPage.locator("[data-testid='payout-empty']")).toBeVisible({ timeout: 5000 });
+    console.log('[TEST] Reward approved — participant wallet now has approved balance');
+
+    // =========================================================================
+    // PHASE 4 — Participant requests payout → KYC handoff modal (UC-OPP-06.A1)
+    // =========================================================================
+
+    console.log('[TEST] === Phase 4: Participant requests payout ===');
+
+    // Navigate to home page where the rewards-summary widget is shown.
+    await participantPage.goto('/');
+    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
+
+    // Rewards summary must be visible with a non-zero approved balance.
+    await expect(participantPage.locator("[data-testid='rewards-summary']")).toBeVisible({ timeout: 5000 });
+    await expect(participantPage.locator("[data-testid='approved-column']")).toBeVisible({ timeout: 3000 });
+
+    // Payout button appears only when approved_cents > 0.
+    const payoutButton = participantPage.locator("[data-testid='payout-button']");
+    await expect(payoutButton).toBeVisible({ timeout: 5000 });
+    console.log('[TEST] Payout button visible — clicking');
+    await payoutButton.click();
+
+    // Fresh participant is not known at the Payment Provider →
+    // prepare_payout/1 returns {:error, {:kyc_required, url}} →
+    // KYC handoff modal (UC-OPP-06.A1) is shown.
+    // The confirm button would redirect to OPP KYC onboarding.
+    await expect(participantPage.locator("[data-testid='confirmation-modal-confirm-button']")).toBeVisible({ timeout: 5000 });
+    await expect(participantPage.locator("[data-testid='confirmation-modal-cancel-button']")).toBeVisible({ timeout: 3000 });
+    console.log('[TEST] KYC handoff modal visible — UC-OPP-06.A1 confirmed');
+
+    // Dismiss the modal so we leave the page in a clean state.
+    await participantPage.locator("[data-testid='confirmation-modal-cancel-button']").click();
+    await expect(participantPage.locator("[data-testid='confirmation-modal-confirm-button']")).not.toBeVisible({ timeout: 3000 });
+
+    console.log('[TEST] Request Payout (UC-OPP-06) test completed successfully');
+
+    await researcherContext.close();
+    await participantContext.close();
+  });
+});

--- a/core/test/e2e/request_payout.spec.ts
+++ b/core/test/e2e/request_payout.spec.ts
@@ -39,6 +39,13 @@ async function clickAddItemButton(page: any) {
  *
  * No fixtures are used. The full flow is exercised end-to-end through the UI.
  *
+ * Wait pattern: per `core/test/e2e/CLAUDE.md`, we wait on a target-page
+ * `data-testid` via `expect(...).toBeVisible()` (auto-polling) after each
+ * navigation, rather than on `.phx-connected` of the source page. The few
+ * `waitForTimeout` calls left in this spec are load-bearing — debounced form
+ * persistence (BudgetForm, FeaturesForm) and one consent → CrewPage re-render
+ * that the parent view model recomputes asynchronously.
+ *
  * Prerequisites:
  *   - Local server (mix phx.server) on http://localhost:4000
  *   - ENABLED_APP_FEATURES contains "panl", "e2e", and "panl_post_launch"
@@ -62,8 +69,6 @@ function generateParticipantEmail(): string {
 const SUBJECT_COUNT = '10';
 const SUBJECT_REWARD = '5.00';
 const AIM_OF_STUDY = 'E2E request payout test';
-
-const CONNECTED_SELECTOR = '[data-phx-main].phx-connected';
 
 test.describe('Request Payout (UC-OPP-06)', () => {
   test.skip(SKIP_REASON !== '', SKIP_REASON);
@@ -92,14 +97,11 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     console.log('[TEST] === Phase 1: Researcher setup ===');
 
     await researcherPage.goto('/user/signin');
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     await researcherPage.locator("[data-testid='signin-tab-creator']").click();
-    await researcherPage.waitForTimeout(300);
+    await expect(researcherPage.locator("#account_signin-tab_panel_creator [data-testid='signin-email-input']")).toBeVisible({ timeout: 5000 });
     await researcherPage.locator("#account_signin-tab_panel_creator [data-testid='signin-email-input']").fill(RESEARCHER_EMAIL);
     await researcherPage.locator("#account_signin-tab_panel_creator [data-testid='signin-password-input']").fill(RESEARCHER_PASSWORD);
     await researcherPage.locator("#account_signin-tab_panel_creator [data-testid='signin-submit-button']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 15000 });
-    await researcherPage.waitForTimeout(1000);
     await activateLocalPayment(researcherPage);
 
     const projectTestidsBefore = await snapshotCardTestids(researcherPage);
@@ -111,25 +113,19 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     } else {
       await createNewProject.click();
     }
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     const newProjectTestid = await pickNewCardTestid(researcherPage, projectTestidsBefore);
     console.log(`[TEST] Created project: ${newProjectTestid}`);
     await researcherPage.locator(`[data-testid='${newProjectTestid}']`).click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
-    await researcherPage.waitForTimeout(500);
 
     const itemTestidsBefore = await snapshotCardTestids(researcherPage);
 
     console.log('[TEST] Creating questionnaire study');
     await clickAddItemButton(researcherPage);
 
-    await researcherPage.waitForSelector("[data-testid='selector-item-questionnaire']", { timeout: 10000 });
+    await expect(researcherPage.locator("[data-testid='selector-item-questionnaire']")).toBeVisible({ timeout: 10000 });
     await researcherPage.locator("[data-testid='selector-item-questionnaire']").click();
-    await researcherPage.waitForTimeout(300);
     await researcherPage.locator("[data-testid='create-item-button']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
-    await researcherPage.waitForTimeout(500);
 
     const newItemTestid = await pickNewCardTestid(researcherPage, itemTestidsBefore);
     console.log(`[TEST] Created item: ${newItemTestid}`);
@@ -137,24 +133,18 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     await newCard.scrollIntoViewIfNeeded();
     await newCard.click();
     await researcherPage.waitForURL(/\/assignment\/\d+\/content/, { timeout: 15000 });
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     const assignmentUrl = researcherPage.url();
     assignmentId = assignmentUrl.match(/\/assignment\/(\d+)/)![1];
     console.log(`[TEST] Inside assignment ${assignmentId}`);
 
     console.log('[TEST] Adding Instruction Manual to workflow');
-    await researcherPage.waitForSelector("[data-testid='assignment-tab-workflow']", { timeout: 10000 });
+    await expect(researcherPage.locator("[data-testid='assignment-tab-workflow']")).toBeVisible({ timeout: 10000 });
     await researcherPage.locator("[data-testid='assignment-tab-workflow']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
-    await researcherPage.waitForTimeout(500);
     await expect(researcherPage.locator("[data-testid='add-library-item-manual']")).toBeVisible({ timeout: 5000 });
     await researcherPage.locator("[data-testid='add-library-item-manual']").click();
-    await researcherPage.waitForTimeout(1000);
 
-    await researcherPage.waitForSelector("[data-testid='assignment-tab-participants']", { timeout: 10000 });
+    await expect(researcherPage.locator("[data-testid='assignment-tab-participants']")).toBeVisible({ timeout: 10000 });
     await researcherPage.locator("[data-testid='assignment-tab-participants']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
-    await researcherPage.waitForTimeout(500);
 
     const addBudgetBtn = researcherPage.locator("[data-testid='pay-add-participants-button']");
     await expect(addBudgetBtn).toBeVisible({ timeout: 5000 });
@@ -166,10 +156,12 @@ test.describe('Request Payout (UC-OPP-06)', () => {
 
     const rewardInput = researcherPage.locator("[data-testid='budget-form-reward-input']");
     await rewardInput.fill(SUBJECT_REWARD);
+    // BudgetForm has a 1000ms phx-change debounce on the fee form + server roundtrip.
     await researcherPage.waitForTimeout(1500);
 
     const slotsInput = researcherPage.locator("[data-testid='budget-form-slots-input']");
     await slotsInput.fill(SUBJECT_COUNT);
+    // 300ms debounce on slots + brief settle.
     await researcherPage.waitForTimeout(500);
 
     const confirmBtn = researcherPage.locator("[data-testid='budget-form-confirm-button']");
@@ -179,10 +171,8 @@ test.describe('Request Payout (UC-OPP-06)', () => {
 
     await researcherPage.locator("[data-testid='local-payment-complete-button']").click();
     await researcherPage.waitForURL(/\/assignment\/\d+\/content/, { timeout: 10000 });
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     await researcherPage.locator("[data-testid='assignment-tab-participants']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     await expect(researcherPage.locator("[data-testid='transaction-card-completed']")).toBeVisible({ timeout: 5000 });
 
     console.log('[TEST] Creating and publishing advert');
@@ -199,11 +189,9 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     await expect(researcherPage.locator("[data-testid='retract-button']")).toBeVisible({ timeout: 10000 });
 
     await researcherPage.locator("[data-testid='goto-advert-button']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     await expect(researcherPage.locator("[data-testid='advert-publish-button']")).toBeVisible({ timeout: 5000 });
     await researcherPage.locator("[data-testid='advert-publish-button']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     const inviteLinkText = await researcherPage.locator(
       "text=/https?:\\/\\/[^/]+\\/promotion\\/\\d+/"
@@ -222,7 +210,6 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     console.log(`[TEST] Signing up participant: ${participantEmail}`);
 
     await participantPage.goto('/user/signup/participant?post_signup_action=add_to_panl');
-    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     await participantPage.locator('#signup_form input[name="user[email]"]').fill(participantEmail);
     await participantPage.locator('#signup_form input[name="user[password]"]').fill(PARTICIPANT_PASSWORD);
@@ -231,7 +218,6 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     await participantPage.locator('#signup_form button[type="submit"]').click();
 
     await participantPage.waitForURL('**/user/onboarding', { timeout: 5000 });
-    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 5000 });
 
     await expect(participantPage.locator('[data-testid="profile-view"]')).toBeVisible({ timeout: 3000 });
     await participantPage.locator('[data-testid="onboarding-continue"]').click();
@@ -247,32 +233,29 @@ test.describe('Request Payout (UC-OPP-06)', () => {
 
     console.log('[TEST] Filling participant features (gender)');
     await participantPage.goto('/user/profile');
-    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     await participantPage.locator('[data-tab-id="features"]').first().click();
     await expect(participantPage.locator('[data-testid="features-view"]')).toBeVisible({ timeout: 5000 });
     await participantPage.locator("[data-testid='selector-item-man']").click();
+    // phx-change save on the selector — give the server a moment to persist.
     await participantPage.waitForTimeout(500);
 
     await participantPage.goto(promotionPath);
-    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     await expect(participantPage.locator("[data-testid='promotion-apply-button-hero']")).toBeVisible({ timeout: 5000 });
     await participantPage.locator("[data-testid='promotion-apply-button-hero']").click();
     await participantPage.waitForURL(/\/assignment\/\d+(\/.*)?$/, { timeout: 10000 });
-    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     for (let i = 0; i < 10; i++) {
       const onboardingContinue = participantPage.locator("[data-testid='assignment-onboarding-continue-button']");
       if (!(await onboardingContinue.isVisible({ timeout: 2000 }))) break;
       await onboardingContinue.click();
-      await participantPage.waitForTimeout(500);
     }
 
     const consentAcceptButton = participantPage.locator("[data-testid='consent-accept-button']");
     if (await consentAcceptButton.isVisible({ timeout: 5000 })) {
       await consentAcceptButton.click();
+      // consent → publish_event(:accept) → parent recomputes view model → CrewPage re-renders.
       await participantPage.waitForTimeout(2000);
-      await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     }
 
     if (await participantPage.locator("[data-testid='activate-account-check-button']").isVisible({ timeout: 3000 })) {
@@ -286,19 +269,16 @@ test.describe('Request Payout (UC-OPP-06)', () => {
         throw new Error(`Failed to activate user: ${activateResponse.status} - ${await activateResponse.text()}`);
       }
       await participantPage.goto(`/assignment/${assignmentId}`);
-      await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     }
 
     console.log('[TEST] Participant completes Instruction Manual');
     await expect(participantPage.locator("[data-testid^='chapter-list-item-']").first()).toBeVisible({ timeout: 5000 });
     await participantPage.locator("[data-testid^='chapter-list-item-']").first().click();
-    await participantPage.waitForTimeout(500);
 
     for (let i = 0; i < 20; i++) {
       const next = participantPage.locator("[data-testid='manual-chapter-next-button']");
       if (await next.isVisible({ timeout: 1000 })) {
         await next.click();
-        await participantPage.waitForTimeout(300);
         continue;
       }
       const done = participantPage.locator("[data-testid='manual-chapter-done-button']");
@@ -319,7 +299,6 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     console.log('[TEST] === Phase 3: Researcher approves reward ===');
 
     await researcherPage.goto(`/assignment/${assignmentId}/content?tab=participants`);
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     await expect(researcherPage.locator("[data-testid='pending-approvals-cta']")).toBeVisible({ timeout: 5000 });
     await researcherPage.locator("[data-testid='pending-approvals-cta']").click();
 
@@ -328,7 +307,6 @@ test.describe('Request Payout (UC-OPP-06)', () => {
     await expect(waitingCount).not.toHaveText('0');
 
     await researcherPage.locator("[data-testid='pay-out-all-button']").click();
-    await researcherPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
     await expect(researcherPage.locator("[data-testid='payout-empty']")).toBeVisible({ timeout: 5000 });
     console.log('[TEST] Reward approved — participant wallet now has approved balance');
 
@@ -340,7 +318,6 @@ test.describe('Request Payout (UC-OPP-06)', () => {
 
     // Navigate to home page where the rewards-summary widget is shown.
     await participantPage.goto('/');
-    await participantPage.waitForSelector(CONNECTED_SELECTOR, { timeout: 10000 });
 
     // Rewards summary must be visible with a non-zero approved balance.
     await expect(participantPage.locator("[data-testid='rewards-summary']")).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
## Wat er is aangepast

### 1. ConfirmationModal — testids op confirm/cancel knoppen
`core/frameworks/pixel/components/confirmation_modal.ex`

De confirm- en cancel-knoppen in de `ConfirmationModal` hadden geen `data-testid`. Zonder testid kan Playwright de knoppen niet vinden (onze E2E-conventie: altijd selecteren op `data-testid`). Toegevoegd:
- `testid: "confirmation-modal-confirm-button"`
- `testid: "confirmation-modal-cancel-button"`

Dit geldt voor alle plekken waar `ConfirmationModal` wordt gebruikt (ook `content_page_form` en `gdpr_form`).

### 2. Nieuwe spec: `request_payout.spec.ts` (UC-OPP-06)
`core/test/e2e/request_payout.spec.ts`

Zelfstandige E2E test voor de participant payout-flow in vier fasen:
1. Researcher maakt studie aan met ≥ €5 reward en publiceert een advert
2. Verse participant meldt zich aan (PaNL), rondt de Instruction Manual taak af → reward wordt `:pending_approval`
3. Researcher keurt het reward goed via de PayoutModal
4. Participant navigeert naar de homepagina, ziet het goedgekeurde saldo in de rewards-summary widget, klikt op "Uitbetalen"

## Wat deze test dekt

Fase 4 loopt altijd via het **UC-OPP-06.A1 (KYC) pad**: een verse participant is nog niet bekend bij de Payment Provider, waardoor `Fund.Public.prepare_payout/1` `{:error, {:kyc_required, url}}` teruggeeft en de KYC handoff-modal verschijnt. De test verifieert:
- `[data-testid="rewards-summary"]` en `[data-testid="payout-button"]` zijn zichtbaar na het goedkeuren van het reward
- `[data-testid="confirmation-modal-confirm-button"]` verschijnt na het klikken op de payout-knop
- De modal kan worden gesloten via de cancel-knop

## Wat deze test NIET dekt — en waarom

Het **MS (main success) pad** — waarbij de participant al bekend is bij OPP, de daadwerkelijke transfer en withdrawal worden uitgevoerd, en OPP een webhook terugstuurt naar Next — kan niet worden geautomatiseerd:

- Het vereist een participant die vooraf geverifieerd is op de OPP sandbox (handmatig door een developer met sandbox-toegang)
- Het betreft een round-trip via een externe Payment Provider met een inkomende webhook; dit is gedekt door unit tests en wordt eenmalig handmatig geverifieerd per omgeving
- Automatisering in CI vereist sandbox-toegang die niet beschikbaar is in alle testomgevingen

**Handmatige verificatie van het MS-pad** moet eenmalig worden gedaan op de dev/sandbox-omgeving met een vooraf geverifieerde participant, voordat UC-OPP-06 als afgerond kan worden beschouwd.

## Test uitkomst lokaal
```
✓ Request Payout (UC-OPP-06) › participant sees payout handoff modal after researcher approves reward (21.6s)
1 passed (24.2s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)