### PR TITLE
ci(claude-review): switch to manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,41 +1,31 @@
 name: Claude Code Review
 
+# Manual-only. To run a review, open the Actions tab in GitHub, pick this
+# workflow, and click "Run workflow" with the PR number.
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: string
 
 jobs:
   claude-review:
-    if: |
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
-      github.event_name == 'pull_request_review_comment'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
     steps:
-      - name: Check for @claude mention
-        id: check-mention
-        run: |
-          if echo "${{ github.event.comment.body }}" | grep -qi "@claude"; then
-            echo "mentioned=true" >> $GITHUB_OUTPUT
-          else
-            echo "mentioned=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout
-        if: steps.check-mention.outputs.mentioned == 'true'
         uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 
       - name: Run Claude Review
-        if: steps.check-mention.outputs.mentioned == 'true'
         uses: anthropics/claude-code-action@v1.0.150
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trigger_phrase: "@claude"
+          prompt: "Review PR #${{ github.event.inputs.pr_number }}"
           timeout_minutes: 10


### PR DESCRIPTION
## Summary

Currently `Claude Code Review` triggers on every `issue_comment` and `pull_request_review_comment`, then greps the body for \`@claude\` to decide whether to actually run. Non-matching comments no-op, but every PR comment still queues a workflow run and produces log noise in the Actions tab.

Switches the workflow to \`workflow_dispatch\` only. Reviews are now triggered manually from the Actions tab → "Run workflow", with the PR number as input.

Net diff: 1 file, +9 / −19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)