### PR TITLE
refactor(signal): centralize :signal_test handler in Signal.LiveFeature

### DIFF
--- a/core/frameworks/signal/_live_feature.ex
+++ b/core/frameworks/signal/_live_feature.ex
@@ -1,0 +1,15 @@
+defmodule Frameworks.Signal.LiveFeature do
+  @moduledoc """
+  Swallows the `{:signal_test, _}` message that `Frameworks.Signal.TestRecorder`
+  sends back to the dispatching process during tests with `isolate_signals/1`.
+
+  Without this stub, any LiveView that dispatches a signal from its own process
+  would crash with `no function clause matching` in the test environment.
+  """
+
+  defmacro __using__(_opts \\ []) do
+    quote do
+      def handle_info({:signal_test, _}, socket), do: {:noreply, socket}
+    end
+  end
+end

--- a/core/lib/core_web.ex
+++ b/core/lib/core_web.ex
@@ -110,6 +110,7 @@ defmodule CoreWeb do
       use Fabric.LiveView
       use Fabric.ModalPresenter
       use Frameworks.Pixel.ModalView
+      use Frameworks.Signal.LiveFeature
 
       # Import LiveView helpers (live_render, live_component, live_patch, etc)
       import Phoenix.LiveView.Helpers
@@ -136,6 +137,7 @@ defmodule CoreWeb do
       use LiveNest, :routed_live_view
       use LiveNest, :single_modal_presenter_strategy
       use Frameworks.Pixel.ModalView
+      use Frameworks.Signal.LiveFeature
 
       # Import LiveView helpers (live_render, live_component, live_patch, etc)
       import Phoenix.LiveView.Helpers
@@ -163,6 +165,7 @@ defmodule CoreWeb do
 
       # Flash support for embedded views (handles :show_flash and :hide_flash messages)
       use Frameworks.Pixel.Flash
+      use Frameworks.Signal.LiveFeature
 
       # UserState LiveFeature provides publish_user_state_change
       use Frameworks.UserState.LiveFeature

--- a/core/systems/account/features_view.ex
+++ b/core/systems/account/features_view.ex
@@ -38,11 +38,6 @@ defmodule Systems.Account.FeaturesView do
   end
 
   @impl true
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
-  @impl true
   def handle_event(
         event,
         %{"features_model" => attrs},

--- a/core/systems/assignment/crew_task_single_view.ex
+++ b/core/systems/assignment/crew_task_single_view.ex
@@ -54,11 +54,6 @@ defmodule Systems.Assignment.CrewTaskSingleView do
     {:noreply, socket |> complete_task()}
   end
 
-  @impl true
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
   # Private
 
   defp complete_task(%{assigns: %{work_item: {_workflow_item, task}}} = socket)

--- a/core/systems/assignment/crew_work_view.ex
+++ b/core/systems/assignment/crew_work_view.ex
@@ -149,11 +149,6 @@ defmodule Systems.Assignment.CrewWorkView do
   end
 
   @impl true
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
-  @impl true
   def render(assigns) do
     ~H"""
       <div id="crew_work_view" class="w-full h-full flex flex-col relative">

--- a/core/systems/assignment/onboarding_view.ex
+++ b/core/systems/assignment/onboarding_view.ex
@@ -39,11 +39,6 @@ defmodule Systems.Assignment.OnboardingView do
   end
 
   @impl true
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
-  @impl true
   def render(assigns) do
     ~H"""
       <div>

--- a/core/systems/content/composer.ex
+++ b/core/systems/content/composer.ex
@@ -33,11 +33,6 @@ defmodule Systems.Content.Composer do
       def handle_event("inform_ok", _params, socket) do
         {:noreply, socket |> assign(dialog: nil)}
       end
-
-      @impl true
-      def handle_info({:signal_test, _}, socket) do
-        {:noreply, socket}
-      end
     end
   end
 
@@ -66,11 +61,6 @@ defmodule Systems.Content.Composer do
       @impl true
       def handle_event("inform_ok", _params, socket) do
         {:noreply, socket |> assign(dialog: nil)}
-      end
-
-      @impl true
-      def handle_info({:signal_test, _}, socket) do
-        {:noreply, socket}
       end
     end
   end

--- a/core/systems/lab/public_page.ex
+++ b/core/systems/lab/public_page.ex
@@ -44,10 +44,6 @@ defmodule Systems.Lab.PublicPage do
     {:noreply, socket |> assign(:reservation, nil)}
   end
 
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
   # data(reservation, :any, default: nil)
   @impl true
   def render(assigns) do

--- a/core/systems/onyx/browser_view.ex
+++ b/core/systems/onyx/browser_view.ex
@@ -3,6 +3,7 @@ defmodule Systems.Onyx.BrowserView do
   use LiveNest, :embedded_live_view
   use CoreWeb.UI
   use Frameworks.Pixel
+  use Frameworks.Signal.LiveFeature
 
   use Gettext, backend: CoreWeb.Gettext
 

--- a/core/systems/onyx/concept_tab.ex
+++ b/core/systems/onyx/concept_tab.ex
@@ -3,6 +3,7 @@ defmodule Systems.Onyx.ConceptTab do
   use LiveNest, :embedded_live_view
   use CoreWeb.UI
   use Frameworks.Pixel
+  use Frameworks.Signal.LiveFeature
 
   alias Frameworks.Pixel.Grid
 

--- a/core/systems/promotion/landing_page.ex
+++ b/core/systems/promotion/landing_page.ex
@@ -113,10 +113,6 @@ defmodule Systems.Promotion.LandingPage do
     {:noreply, socket |> assign(dialog: nil)}
   end
 
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
   defp grid_cols(1), do: "grid-cols-1 sm:grid-cols-1"
   defp grid_cols(2), do: "grid-cols-1 sm:grid-cols-2"
   defp grid_cols(_), do: "grid-cols-1 sm:grid-cols-3"

--- a/core/systems/zircon/screening/criteria_view.ex
+++ b/core/systems/zircon/screening/criteria_view.ex
@@ -87,10 +87,6 @@ defmodule Systems.Zircon.Screening.CriteriaView do
   end
 
   @impl true
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
   def handle_info({:handle_auto_save_done, _}, socket) do
     {:noreply, socket |> assign_criteria_elements()}
   end

--- a/core/systems/zircon/screening/import_view.ex
+++ b/core/systems/zircon/screening/import_view.ex
@@ -201,11 +201,6 @@ defmodule Systems.Zircon.Screening.ImportView do
   end
 
   @impl true
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
-  end
-
-  @impl true
   def render(assigns) do
     ~H"""
       <div data-testid="import-view">

--- a/core/systems/zircon/screening/paper_set_view.ex
+++ b/core/systems/zircon/screening/paper_set_view.ex
@@ -4,6 +4,7 @@ defmodule Systems.Zircon.Screening.PaperSetView do
   use Gettext, backend: CoreWeb.Gettext
   use Systems.Observatory.LiveFeature
   use CoreWeb.UI
+  use Frameworks.Signal.LiveFeature
 
   import Systems.Zircon.HTML, only: [paper_set_table: 1]
   import Frameworks.Pixel.Paginator, only: [paginator: 1]
@@ -73,11 +74,6 @@ defmodule Systems.Zircon.Screening.PaperSetView do
       |> assign(page_index: 0, query: query, query_string: query_string)
       |> update_view_model()
     }
-  end
-
-  @impl true
-  def handle_info({:signal_test, _}, socket) do
-    {:noreply, socket}
   end
 
   @impl true


### PR DESCRIPTION
## Summary

- `Frameworks.Signal.TestRecorder` sends `{:signal_test, _}` back to the dispatching process when tests use `isolate_signals/1`. Any LiveView that dispatches a signal from its own process needs a no-op `handle_info` clause to avoid `FunctionClauseError` in tests.
- Move that stub into a single `Frameworks.Signal.LiveFeature` `use` macro, wired into all three CoreWeb LiveView macros (`live_view`, `routed_live_view`, `embedded_live_view`) plus the three views that bypass CoreWeb (`Onyx.BrowserView`, `Onyx.ConceptTab`, `Zircon.Screening.PaperSetView`).
- Removes 11 duplicate definitions across LiveViews.

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix test --warnings-as-errors` — 2139 tests, 0 failures
- [x] pre-commit hooks (format, compile, test, credo, dialyzer) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)