### PR TITLE
feat(account): Oban cron worker to prune expired auth codes

### DIFF
--- a/core/config/dev.exs
+++ b/core/config/dev.exs
@@ -120,7 +120,9 @@ config :core, Oban,
        # Fail pending pay-in transactions older than 15 minutes
        {"* * * * *", Systems.Budget.PayInExpirationWorker},
        # Reconcile pay-in/payout state against the payment provider daily
-       {"0 3 * * *", Systems.Payment.ReconciliationWorker}
+       {"0 3 * * *", Systems.Payment.ReconciliationWorker},
+       # Prune auth codes past their validity window every hour
+       {"0 * * * *", Systems.Account.AuthCodeCleanupWorker}
      ]}
   ]
 

--- a/core/config/runtime.aws.exs
+++ b/core/config/runtime.aws.exs
@@ -98,6 +98,11 @@ if config_env() == :prod do
           "payment_reconciliation" ->
             {Oban.Plugins.Cron, crontab: [{"0 3 * * *", Systems.Payment.ReconciliationWorker}]}
 
+          # Prunes auth_codes older than the validity window
+          # Add "auth_code_cleanup" to ENABLED_OBAN_PLUGINS to enable
+          "auth_code_cleanup" ->
+            {Oban.Plugins.Cron, crontab: [{"0 * * * *", Systems.Account.AuthCodeCleanupWorker}]}
+
           _ ->
             nil
         end

--- a/core/config/runtime.fly.exs
+++ b/core/config/runtime.fly.exs
@@ -102,6 +102,9 @@ if config_env() == :prod do
           "payment_reconciliation" ->
             {Oban.Plugins.Cron, crontab: [{"0 3 * * *", Systems.Payment.ReconciliationWorker}]}
 
+          "auth_code_cleanup" ->
+            {Oban.Plugins.Cron, crontab: [{"0 * * * *", Systems.Account.AuthCodeCleanupWorker}]}
+
           _ ->
             nil
         end

--- a/core/systems/account/_public.ex
+++ b/core/systems/account/_public.ex
@@ -451,6 +451,17 @@ defmodule Systems.Account.Public do
     Rate.Public.RateLimitError -> {:error, :rate_limited}
   end
 
+  @doc """
+  Deletes auth codes that are past their validity window.
+
+  Codes older than the validity window can no longer satisfy `active_query/1`,
+  so the rows are dead weight. Returns the number of rows deleted.
+  """
+  def cleanup_expired_auth_codes do
+    {deleted_count, _} = Repo.delete_all(Account.AuthCodeModel.expired_query())
+    deleted_count
+  end
+
   def verify_otp(email, code) when is_binary(email) and is_binary(code) do
     case Account.AuthCodeModel.active_query(email) |> Repo.one() do
       nil ->

--- a/core/systems/account/auth_code.ex
+++ b/core/systems/account/auth_code.ex
@@ -51,6 +51,12 @@ defmodule Systems.Account.AuthCodeModel do
     )
   end
 
+  def expired_query do
+    from(t in __MODULE__,
+      where: t.inserted_at <= ago(@validity_in_minutes, "minute")
+    )
+  end
+
   defp generate_code do
     min = Integer.pow(10, @code_length - 1)
     max = Integer.pow(10, @code_length) - 1

--- a/core/systems/account/auth_code_cleanup_worker.ex
+++ b/core/systems/account/auth_code_cleanup_worker.ex
@@ -1,0 +1,28 @@
+defmodule Systems.Account.AuthCodeCleanupWorker do
+  @moduledoc """
+  Scheduled Oban worker that prunes auth_codes past their validity window.
+
+  `Account.Public.generate_otp/1` deletes prior codes for the same email when a
+  new one is requested, but codes for emails that never come back accumulate.
+  After the validity window they are filtered out by `active_query/1`, so this
+  worker removes those rows to keep the table bounded.
+  """
+  use Oban.Worker,
+    priority: 3,
+    max_attempts: 1
+
+  require Logger
+
+  alias Systems.Account
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    deleted_count = Account.Public.cleanup_expired_auth_codes()
+
+    if deleted_count > 0 do
+      Logger.info("[Account.AuthCodeCleanupWorker] Deleted #{deleted_count} expired auth_codes")
+    end
+
+    :ok
+  end
+end

--- a/core/test/systems/account/auth_code_cleanup_worker_test.exs
+++ b/core/test/systems/account/auth_code_cleanup_worker_test.exs
@@ -1,0 +1,79 @@
+defmodule Systems.Account.AuthCodeCleanupWorkerTest do
+  use Core.DataCase, async: true
+  use Oban.Testing, repo: Core.Repo
+
+  import Ecto.Query
+
+  alias Core.Repo
+  alias Systems.Account
+  alias Systems.Account.AuthCodeCleanupWorker
+  alias Systems.Account.AuthCodeModel
+
+  @validity_in_minutes 10
+
+  defp insert_auth_code(email, minutes_ago) do
+    {_code, auth_code} = AuthCodeModel.build(email, nil)
+    inserted = Repo.insert!(auth_code)
+
+    ts =
+      NaiveDateTime.utc_now()
+      |> NaiveDateTime.add(-minutes_ago * 60, :second)
+      |> NaiveDateTime.truncate(:second)
+
+    from(t in AuthCodeModel, where: t.id == ^inserted.id)
+    |> Repo.update_all(set: [inserted_at: ts])
+
+    Repo.get!(AuthCodeModel, inserted.id)
+  end
+
+  defp auth_code_count do
+    Repo.aggregate(AuthCodeModel, :count)
+  end
+
+  describe "perform/1" do
+    test "deletes auth codes older than the validity window" do
+      insert_auth_code("expired@example.com", @validity_in_minutes + 1)
+
+      assert :ok = perform_job(AuthCodeCleanupWorker, %{})
+      assert auth_code_count() == 0
+    end
+
+    test "keeps auth codes inside the validity window" do
+      insert_auth_code("fresh@example.com", 1)
+
+      assert :ok = perform_job(AuthCodeCleanupWorker, %{})
+      assert auth_code_count() == 1
+    end
+
+    test "deletes only expired rows when both exist" do
+      fresh = insert_auth_code("fresh@example.com", 1)
+      insert_auth_code("expired@example.com", @validity_in_minutes + 1)
+
+      assert :ok = perform_job(AuthCodeCleanupWorker, %{})
+
+      remaining = Repo.all(AuthCodeModel)
+      assert length(remaining) == 1
+      assert hd(remaining).id == fresh.id
+    end
+
+    test "returns :ok when there is nothing to delete" do
+      assert :ok = perform_job(AuthCodeCleanupWorker, %{})
+    end
+  end
+
+  describe "Account.Public.cleanup_expired_auth_codes/0" do
+    test "returns the number of rows deleted" do
+      insert_auth_code("expired-1@example.com", @validity_in_minutes + 1)
+      insert_auth_code("expired-2@example.com", @validity_in_minutes + 5)
+      insert_auth_code("fresh@example.com", 1)
+
+      assert Account.Public.cleanup_expired_auth_codes() == 2
+    end
+
+    test "returns 0 when nothing is expired" do
+      insert_auth_code("fresh@example.com", 1)
+
+      assert Account.Public.cleanup_expired_auth_codes() == 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Systems.Account.AuthCodeCleanupWorker` that prunes `auth_codes` rows past the validity window. `Account.Public.generate_otp/1` already clears prior codes when the same email comes back, so this only matters for emails that never return — those rows are dead weight after expiring out of `active_query/1`.
- New `Account.Public.cleanup_expired_auth_codes/0` + `AuthCodeModel.expired_query/0` express the prune in the Public API / model rather than baking SQL into the worker.
- Hourly cron on prod, gated by adding `"auth_code_cleanup"` to `ENABLED_OBAN_PLUGINS` (mirrors `data_donation_cleanup`). Always-on hourly cron in dev.

Follow-up to PR #1554 raised in review by Joeri. Issue: https://3.basecamp.com/5734045/buckets/35926565/todos/9985926926

## Test plan

- [ ] CI green
- [ ] After merge + enabling `auth_code_cleanup` in prod's `ENABLED_OBAN_PLUGINS`, confirm `auth_codes` row count stays bounded under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)