### PR TITLE
feat(account): route OTP-registered users through terms & privacy

### DIFF
--- a/core/systems/account/_public.ex
+++ b/core/systems/account/_public.ex
@@ -163,8 +163,8 @@ defmodule Systems.Account.Public do
     get!(user_id) |> confirmed?()
   end
 
-  def sso_user?(%User{hashed_password: "no-password-set"}), do: true
-  def sso_user?(%User{}), do: false
+  def passwordless?(%User{hashed_password: "no-password-set"}), do: true
+  def passwordless?(%User{}), do: false
 
   def show_profile_menu_item?(user), do: internal?(user)
 
@@ -246,25 +246,19 @@ defmodule Systems.Account.Public do
   end
 
   @doc """
-  Registers a new user from just an email (OTP-only auth flow). Generates
-  a random password the user can never use to sign in (they always come
-  through OTP), and marks the account confirmed since email ownership is
-  already proven by the OTP verification.
+  Registers a new user from just an email (OTP-only auth flow). Creates a
+  passwordless account (`hashed_password: "no-password-set"`) with email
+  ownership marked as verified (the OTP code itself proves possession of
+  the inbox). The account stays unconfirmed until the user accepts terms
+  & privacy in the onboarding step.
   """
   def register_user_with_email(email) when is_binary(email) do
-    password = random_password()
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
 
     %User{}
-    |> User.registration_changeset(%{email: email, password: password, creator: false})
-    |> Ecto.Changeset.put_change(:confirmed_at, now)
+    |> User.sso_changeset(%{email: email, creator: false, verified_at: now})
+    |> User.validate_email()
     |> Repo.insert()
-  end
-
-  defp random_password do
-    # Must satisfy User.validate_password: ≥12 chars, lower + upper + (digit|punct).
-    suffix = :crypto.strong_rand_bytes(24) |> Base.url_encode64() |> binary_part(0, 24)
-    "Aa1" <> suffix
   end
 
   @doc """

--- a/core/systems/account/onboarding_page_builder.ex
+++ b/core/systems/account/onboarding_page_builder.ex
@@ -53,7 +53,7 @@ defmodule Systems.Account.OnboardingPageBuilder do
       Account.Public.activated?(user) ->
         steps
 
-      Account.Public.sso_user?(user) ->
+      Account.Public.passwordless?(user) ->
         [:terms_and_privacy | steps]
 
       true ->

--- a/core/test/systems/account/_public_test.exs
+++ b/core/test/systems/account/_public_test.exs
@@ -119,6 +119,45 @@ defmodule Systems.Account.PublicTest do
     end
   end
 
+  describe "register_user_with_email/1" do
+    test "creates a passwordless user" do
+      email = Faker.Internet.email()
+
+      {:ok, user} = Account.Public.register_user_with_email(email)
+
+      assert user.email == email
+      assert user.hashed_password == "no-password-set"
+      assert Account.Public.passwordless?(user)
+    end
+
+    test "does not set confirmed_at (terms acceptance will)" do
+      {:ok, user} = Account.Public.register_user_with_email(Faker.Internet.email())
+
+      assert is_nil(user.confirmed_at)
+      refute Account.Public.activated?(user)
+    end
+
+    test "marks email as verified (OTP code proved possession)" do
+      {:ok, user} = Account.Public.register_user_with_email(Faker.Internet.email())
+
+      assert %NaiveDateTime{} = user.verified_at
+    end
+
+    test "validates email format" do
+      {:error, changeset} = Account.Public.register_user_with_email("not-an-email")
+
+      assert "must have the @ sign and no spaces" in errors_on(changeset).email
+    end
+
+    test "rejects duplicate email" do
+      %{email: email} = Factories.insert!(:member)
+
+      {:error, changeset} = Account.Public.register_user_with_email(email)
+
+      assert "has already been taken" in errors_on(changeset).email
+    end
+  end
+
   describe "sso_changeset/2" do
     test "returns error changeset when email already exists" do
       # Create existing user with email

--- a/core/test/systems/account/onboarding_page_builder_test.exs
+++ b/core/test/systems/account/onboarding_page_builder_test.exs
@@ -146,7 +146,7 @@ defmodule Systems.Account.OnboardingPageBuilderTest do
     end
   end
 
-  describe "view_model/2 with unactivated SSO user" do
+  describe "view_model/2 with unactivated passwordless user (SSO)" do
     setup do
       {:ok, user} =
         %Account.User{}
@@ -189,7 +189,36 @@ defmodule Systems.Account.OnboardingPageBuilderTest do
       assert vm.continue_button == nil
     end
 
-    test "no activate_account step for SSO users (terms step activates them)", %{user: user} do
+    test "no activate_account step (terms step activates them)", %{user: user} do
+      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
+
+      refute :activate_account in vm.steps
+    end
+  end
+
+  describe "view_model/2 with unactivated passwordless user (OTP)" do
+    setup do
+      email = "otp-#{System.unique_integer([:positive])}@example.com"
+      {:ok, user} = Account.Public.register_user_with_email(email)
+      user = Core.Repo.preload(user, [:features, :profile])
+
+      %{user: user}
+    end
+
+    test "first step is terms_and_privacy", %{user: user} do
+      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
+
+      assert vm.current_step == :terms_and_privacy
+      assert hd(vm.steps) == :terms_and_privacy
+    end
+
+    test "step_view is TermsAndPrivacyView", %{user: user} do
+      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
+
+      assert vm.step_view.implementation == Account.TermsAndPrivacyView
+    end
+
+    test "no activate_account step (terms step activates them)", %{user: user} do
       vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
 
       refute :activate_account in vm.steps


### PR DESCRIPTION
## Summary

- `register_user_with_email` no longer pre-confirms OTP users or stores a random bcrypt hash. Uses `sso_changeset` with `hashed_password: "no-password-set"` and `verified_at: now` (OTP code itself proves email possession). `confirmed_at` stays nil until terms acceptance.
- Renames `Account.Public.sso_user?` to `passwordless?`. The predicate's job is "needs to accept terms"; that's now true for both SSO and OTP users.
- Only call site is `OnboardingPageBuilder.build_steps/1` — updated in the same commit.

Resulting OTP signup flow:
`/user/auth/redeem` → `register_user_with_email` → `log_in_user(first_time: true)` → `/user/onboarding` → `:terms_and_privacy` → `TermsAndPrivacyView` activates the user on continue → `:profile` (+ `:features` for Panl).

Closes https://3.basecamp.com/5734045/buckets/35926565/todos/9972272464

## Test plan

- [x] `mix test test/systems/account test/bundles/next/account` — 222/222 pass
- [x] credo + dialyzer + format clean
- [ ] Manual: with `:otp` flag on, sign up a new email at `/user/auth`, complete OTP, verify the user lands on terms & privacy first (not directly at home)
- [ ] Manual: confirm existing SSO users still hit terms & privacy after this rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)