### PR TITLE
feat(org): show linked pools on the Org page, mark panel orgs

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-admin.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-admin.po
@@ -116,3 +116,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr ""

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-org.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-org.po
@@ -92,3 +92,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr ""

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-admin.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-admin.po
@@ -115,3 +115,7 @@ msgstr "Admins"
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr "Admins"
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr "Panel"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-org.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-org.po
@@ -91,3 +91,15 @@ msgstr "Would you like to add them to your organisation?"
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr "New members available for %{org_name} (%{domains})"
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr "Pools"
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr "Participants"
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr "Organisation"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-admin.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-admin.po
@@ -116,3 +116,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr ""

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-org.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-org.po
@@ -92,3 +92,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr ""

--- a/core/priv/gettext/eyra-admin.pot
+++ b/core/priv/gettext/eyra-admin.pot
@@ -115,3 +115,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr ""

--- a/core/priv/gettext/eyra-org.pot
+++ b/core/priv/gettext/eyra-org.pot
@@ -91,3 +91,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-admin.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-admin.po
@@ -116,3 +116,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-org.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-org.po
@@ -92,3 +92,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr ""

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-admin.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-admin.po
@@ -117,3 +117,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr ""

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-org.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-org.po
@@ -93,3 +93,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr ""

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-admin.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-admin.po
@@ -115,3 +115,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr "Panel"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-org.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-org.po
@@ -91,3 +91,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr "Pools"
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr "Deelnemers"
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr "Organisatie"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-admin.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-admin.po
@@ -117,3 +117,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "org.admins.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "org.panel.tag"
+msgstr ""

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-org.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-org.po
@@ -93,3 +93,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "domain.match.next_action.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "pools.participants.label"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "content.title"
+msgstr ""

--- a/core/systems/admin/org_view_builder.ex
+++ b/core/systems/admin/org_view_builder.ex
@@ -187,6 +187,7 @@ defmodule Systems.Admin.OrgViewBuilder do
   """
   def build_organisation_item(%Org.NodeModel{id: id} = org, locale, is_admin?) do
     members = Org.Public.list_members(org)
+    pools = Systems.Pool.Public.list_by_orgs([org])
 
     # Admin-only actions
     left_actions =
@@ -217,7 +218,7 @@ defmodule Systems.Admin.OrgViewBuilder do
       item: id,
       title: build_item_title(org, locale),
       description: build_description(members),
-      tags: build_tags(org),
+      tags: build_tags(org, pools),
       left_actions: left_actions,
       right_actions: right_actions
     }
@@ -232,8 +233,13 @@ defmodule Systems.Admin.OrgViewBuilder do
     "#{dgettext("eyra-org", "org.members.label")}: #{member_count}"
   end
 
-  defp build_tags(%{domains: nil}), do: []
-  defp build_tags(%{domains: domains}), do: domains
+  defp build_tags(org, pools) do
+    panel_tag = if Enum.any?(pools), do: [dgettext("eyra-admin", "org.panel.tag")], else: []
+    panel_tag ++ domain_tags(org)
+  end
+
+  defp domain_tags(%{domains: nil}), do: []
+  defp domain_tags(%{domains: domains}), do: domains
 
   defp filter_by_query(organisations, nil), do: organisations
   defp filter_by_query(organisations, []), do: organisations

--- a/core/systems/org/_presenter.ex
+++ b/core/systems/org/_presenter.ex
@@ -16,6 +16,10 @@ defmodule Systems.Org.Presenter do
     Org.MemberViewBuilder.view_model(model, assigns)
   end
 
+  def view_model(Org.PoolsView, model, assigns) do
+    Org.PoolsViewBuilder.view_model(model, assigns)
+  end
+
   def view_model(Org.OwnersView, model, assigns) do
     Org.OwnersViewBuilder.view_model(model, assigns)
   end

--- a/core/systems/org/content_page_builder.ex
+++ b/core/systems/org/content_page_builder.ex
@@ -5,6 +5,7 @@ defmodule Systems.Org.ContentPageBuilder do
   alias Systems.Admin
   alias Systems.Content
   alias Systems.Org
+  alias Systems.Pool
 
   def view_model(
         %{id: node_id, full_name_bundle: full_name_bundle} = node,
@@ -26,7 +27,7 @@ defmodule Systems.Org.ContentPageBuilder do
     assigns_with_context = Map.put(assigns, :live_context, live_context)
 
     %{
-      title: dgettext("eyra-admin", "config.title"),
+      title: dgettext("eyra-org", "content.title"),
       tabs: create_tabs(node, assigns_with_context),
       breadcrumbs: create_breadcrumbs(org_name, is_admin?, governable_orgs),
       show_errors: false,
@@ -57,8 +58,16 @@ defmodule Systems.Org.ContentPageBuilder do
   end
 
   defp create_tabs(node, assigns) do
-    [:users, :node]
+    tab_ids(node)
     |> Enum.map(&create_tab(&1, node, assigns))
+  end
+
+  defp tab_ids(node) do
+    if Pool.Public.list_by_orgs([node]) |> Enum.any?() do
+      [:users, :pools, :node]
+    else
+      [:users, :node]
+    end
   end
 
   defp create_tab(:node, %{id: node_id}, %{live_context: context}) do
@@ -92,6 +101,24 @@ defmodule Systems.Org.ContentPageBuilder do
       ready: true,
       show_errors: false,
       title: dgettext("eyra-org", "user.title"),
+      type: :fullpage,
+      element: element
+    }
+  end
+
+  defp create_tab(:pools, %{id: node_id}, %{live_context: context}) do
+    element =
+      CoreWeb.Live.Element.prepare_live_view(
+        "org_pools_view_#{node_id}",
+        Org.PoolsView,
+        live_context: context
+      )
+
+    %{
+      id: :pools,
+      ready: true,
+      show_errors: false,
+      title: dgettext("eyra-org", "pools.title"),
       type: :fullpage,
       element: element
     }

--- a/core/systems/org/pools_view.ex
+++ b/core/systems/org/pools_view.ex
@@ -1,0 +1,50 @@
+defmodule Systems.Org.PoolsView do
+  @moduledoc """
+  Embedded LiveView for the Pools tab on the Org page.
+
+  Read-only list of pools currently linked to the organisation. Pool ↔ Org
+  links are managed via `Pool.Assembly` / seeds today; an interactive linking
+  UI will be added later via the API/CLI.
+  """
+  use CoreWeb, :embedded_live_view
+
+  alias Frameworks.Pixel.Grid
+  alias Frameworks.Pixel.Text
+  alias Systems.Org
+
+  import Org.ItemView
+
+  def dependencies(), do: [:node_id, :locale]
+
+  def get_model(:not_mounted_at_router, _session, %{assigns: %{node_id: node_id}}) do
+    Org.Public.get_node!(node_id)
+  end
+
+  @impl true
+  def mount(:not_mounted_at_router, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div data-testid="org-pools-view">
+      <Area.content>
+        <Margin.y id={:page_top} />
+        <Text.title2>
+          <%= dgettext("eyra-org", "pools.title") %> <span class="text-primary"><%= @vm.pool_count %></span>
+        </Text.title2>
+        <.spacing value="S" />
+
+        <Grid.dynamic>
+          <%= for pool <- @vm.pools do %>
+            <div data-testid={"pool-item-#{pool.item}"}>
+              <.item_view {pool} />
+            </div>
+          <% end %>
+        </Grid.dynamic>
+      </Area.content>
+    </div>
+    """
+  end
+end

--- a/core/systems/org/pools_view_builder.ex
+++ b/core/systems/org/pools_view_builder.ex
@@ -1,0 +1,37 @@
+defmodule Systems.Org.PoolsViewBuilder do
+  use Gettext, backend: CoreWeb.Gettext
+
+  alias Systems.Fund
+  alias Systems.Pool
+
+  def view_model(node, assigns) do
+    locale = Map.get(assigns, :locale, :en)
+
+    pools =
+      Pool.Public.list_by_orgs(
+        [node],
+        currency: Fund.CurrencyModel.preload_graph(:full)
+      )
+
+    %{
+      pools: Enum.map(pools, &pool_item(&1, locale)),
+      pool_count: length(pools)
+    }
+  end
+
+  defp pool_item(%Pool.Model{id: id, name: name, currency: currency} = pool, locale) do
+    %{
+      item: id,
+      title: name,
+      description: build_description(pool),
+      tags: [Fund.CurrencyModel.title(currency, locale)],
+      left_actions: [],
+      right_actions: []
+    }
+  end
+
+  defp build_description(%Pool.Model{} = pool) do
+    participant_count = length(Pool.Public.list_participants(pool))
+    "#{dgettext("eyra-org", "pools.participants.label")}: #{participant_count}"
+  end
+end

--- a/core/test/systems/org/pools_view_builder_test.exs
+++ b/core/test/systems/org/pools_view_builder_test.exs
@@ -1,0 +1,83 @@
+defmodule Systems.Org.PoolsViewBuilderTest do
+  use Core.DataCase
+  use Gettext, backend: CoreWeb.Gettext
+
+  alias Core.Factories
+  alias Systems.Fund
+  alias Systems.Org
+  alias Systems.Pool
+
+  describe "view_model/2 with no pools linked to the org" do
+    setup do
+      org =
+        Factories.insert!(:org_node, %{
+          identifier: ["pools_view_builder_no_pools_#{System.unique_integer([:positive])}"]
+        })
+
+      %{org: org}
+    end
+
+    test "returns empty pools and pool_count zero", %{org: org} do
+      vm = Org.PoolsViewBuilder.view_model(org, %{locale: :en})
+
+      assert vm.pools == []
+      assert vm.pool_count == 0
+    end
+  end
+
+  describe "view_model/2 with a linked pool" do
+    setup do
+      org =
+        Factories.insert!(:org_node, %{
+          identifier: ["pools_view_builder_with_pool_#{System.unique_integer([:positive])}"]
+        })
+
+      currency =
+        Fund.Factories.create_currency(
+          "pools_view_builder_cur_#{System.unique_integer([:positive])}",
+          :legal,
+          "ƒ",
+          2
+        )
+
+      pool =
+        Pool.Public.create!(
+          "pools_view_builder_pool_#{System.unique_integer([:positive])}",
+          500,
+          currency,
+          org,
+          :citizen
+        )
+
+      %{org: org, pool: pool}
+    end
+
+    test "returns the pool as an item with title and description", %{org: org, pool: pool} do
+      vm = Org.PoolsViewBuilder.view_model(org, %{locale: :en})
+
+      assert vm.pool_count == 1
+      [item] = vm.pools
+      assert item.item == pool.id
+      assert item.title == pool.name
+      assert item.description =~ dgettext("eyra-org", "pools.participants.label")
+    end
+
+    test "description reports the participant count", %{org: org, pool: pool} do
+      participant = Factories.insert!(:member)
+      Pool.Public.add_participant!(pool, participant)
+
+      vm = Org.PoolsViewBuilder.view_model(org, %{locale: :en})
+
+      [item] = vm.pools
+      assert item.description =~ "1"
+    end
+
+    test "currency appears as a tag chip", %{org: org} do
+      vm = Org.PoolsViewBuilder.view_model(org, %{locale: :en})
+
+      [item] = vm.pools
+      assert is_list(item.tags)
+      assert length(item.tags) == 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Shows the Pool ↔ Org link (added to the schema in milestone 26) to Org Admins.

- **Pools tab** on the Org page — lists the org's pools as clickable tiles (participant count + currency chip). Hidden when the org has no linked pool.
- **Header** renamed "Admin" → "Organisation" so Org Admins landing at `/org/node/:id` see where they are.
- **Panel tag** on the Admin org list — orgs with one or more pools now show a "Panel" chip.

Pool ↔ Org links are still set up through `Pool.Assembly` / seeds; no UI for linking yet. Clicking a pool tile to open the Pool Admin page is added in #1594.

Closes https://3.basecamp.com/5734045/buckets/35926565/todos/10014635377

## Test plan

- [x] `mix test test/systems/org test/systems/admin` — 177/177 pass
- [x] credo + dialyzer + format clean
- [x] `/org/node/17` shows Members / Pools / Settings; Pools tab renders the linked pool tile
- [ ] Admin org list shows the Panl tile with a "Panel" tag
- [ ] Orgs without a linked pool still show only Members / Settings tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)