### PR TITLE
Fix/promotion full graceful message

### DIFF
--- a/core/lib/core_web/controllers/error_html.ex
+++ b/core/lib/core_web/controllers/error_html.ex
@@ -24,29 +24,6 @@ defmodule CoreWeb.ErrorHTML do
   defp error_code("503.html"), do: "503"
   defp error_code(_), do: "unknown"
 
-  def render("study_full.html", assigns) do
-    menus = build_menus(stripped_menus_config(), nil, nil)
-
-    assigns =
-      Map.merge(assigns, %{
-        title: dgettext("eyra-assignment", "study_full.title"),
-        menus: menus,
-        body: dgettext("eyra-assignment", "study_full.body"),
-        image: image("503.html"),
-        error_code: "study_full"
-      })
-
-    ~H"""
-    <.error
-      title={@title}
-      menus={@menus}
-      body={@body}
-      image={@image}
-      error_code={@error_code}
-    />
-    """
-  end
-
   def render(template, assigns) do
     status = status(template)
     menus = build_menus(stripped_menus_config(), nil, nil)

--- a/core/lib/core_web/controllers/error_html.ex
+++ b/core/lib/core_web/controllers/error_html.ex
@@ -24,9 +24,6 @@ defmodule CoreWeb.ErrorHTML do
   defp error_code("503.html"), do: "503"
   defp error_code(_), do: "unknown"
 
-  # A full study is informational, not an HTTP error, so it renders with a
-  # plain title/body rather than a status-derived one. Reuses the stripped
-  # `.error` chrome for a consistent standalone page.
   def render("study_full.html", assigns) do
     menus = build_menus(stripped_menus_config(), nil, nil)
 

--- a/core/lib/core_web/controllers/error_html.ex
+++ b/core/lib/core_web/controllers/error_html.ex
@@ -24,6 +24,32 @@ defmodule CoreWeb.ErrorHTML do
   defp error_code("503.html"), do: "503"
   defp error_code(_), do: "unknown"
 
+  # A full study is informational, not an HTTP error, so it renders with a
+  # plain title/body rather than a status-derived one. Reuses the stripped
+  # `.error` chrome for a consistent standalone page.
+  def render("study_full.html", assigns) do
+    menus = build_menus(stripped_menus_config(), nil, nil)
+
+    assigns =
+      Map.merge(assigns, %{
+        title: dgettext("eyra-assignment", "study_full.title"),
+        menus: menus,
+        body: dgettext("eyra-assignment", "study_full.body"),
+        image: image("503.html"),
+        error_code: "study_full"
+      })
+
+    ~H"""
+    <.error
+      title={@title}
+      menus={@menus}
+      body={@body}
+      image={@image}
+      error_code={@error_code}
+    />
+    """
+  end
+
   def render(template, assigns) do
     status = status(template)
     menus = build_menus(stripped_menus_config(), nil, nil)

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -718,9 +718,9 @@ msgid "pending_approvals.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
-msgstr ""
+msgid "assignment_full.body"
+msgstr "Diese Studie ist leider voll und nimmt keine neuen Teilnehmer mehr auf."
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
-msgstr ""
+msgid "assignment_full.title"
+msgstr "Diese Studie ist voll"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -716,3 +716,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr ""

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -717,9 +717,9 @@ msgid "pending_approvals.title"
 msgstr "Participants waiting for pay out"
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
+msgid "assignment_full.body"
 msgstr "Unfortunately, this study is full and is no longer accepting new participants."
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
+msgid "assignment_full.title"
 msgstr "This study is full"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -715,3 +715,11 @@ msgstr "Check pay outs"
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr "Participants waiting for pay out"
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr "Unfortunately, this study is full and is no longer accepting new participants."
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr "This study is full"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -716,3 +716,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr ""

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -718,9 +718,9 @@ msgid "pending_approvals.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
-msgstr ""
+msgid "assignment_full.body"
+msgstr "Lamentablemente, este estudio está completo y ya no acepta nuevos participantes."
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
-msgstr ""
+msgid "assignment_full.title"
+msgstr "Este estudio está completo"

--- a/core/priv/gettext/eyra-assignment.pot
+++ b/core/priv/gettext/eyra-assignment.pot
@@ -717,9 +717,9 @@ msgid "pending_approvals.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
+msgid "assignment_full.body"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
+msgid "assignment_full.title"
 msgstr ""

--- a/core/priv/gettext/eyra-assignment.pot
+++ b/core/priv/gettext/eyra-assignment.pot
@@ -715,3 +715,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -718,9 +718,9 @@ msgid "pending_approvals.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
-msgstr ""
+msgid "assignment_full.body"
+msgstr "Purtroppo questo studio è al completo e non accetta più nuovi partecipanti."
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
-msgstr ""
+msgid "assignment_full.title"
+msgstr "Questo studio è al completo"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -716,3 +716,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr ""

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -726,3 +726,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr ""

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -728,9 +728,9 @@ msgid "pending_approvals.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
-msgstr ""
+msgid "assignment_full.body"
+msgstr "Deja, šis tyrimas yra pilnas ir nebepriima naujų dalyvių."
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
-msgstr ""
+msgid "assignment_full.title"
+msgstr "Šis tyrimas yra pilnas"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -715,3 +715,11 @@ msgstr "Bekijk uitbetalingen"
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr "Deelnemers wachten op uitbetaling"
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr ""

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -717,9 +717,9 @@ msgid "pending_approvals.title"
 msgstr "Deelnemers wachten op uitbetaling"
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
-msgstr ""
+msgid "assignment_full.body"
+msgstr "Helaas zit deze studie vol en worden er geen nieuwe deelnemers meer aangenomen."
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
-msgstr ""
+msgid "assignment_full.title"
+msgstr "Deze studie zit vol"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -726,3 +726,11 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "pending_approvals.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "study_full.title"
+msgstr ""

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -728,9 +728,9 @@ msgid "pending_approvals.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "study_full.body"
-msgstr ""
+msgid "assignment_full.body"
+msgstr "Din păcate, acest studiu este complet și nu mai acceptă participanți noi."
 
 #, elixir-autogen, elixir-format
-msgid "study_full.title"
-msgstr ""
+msgid "assignment_full.title"
+msgstr "Acest studiu este complet"

--- a/core/systems/assignment/controller.ex
+++ b/core/systems/assignment/controller.ex
@@ -56,7 +56,7 @@ defmodule Systems.Assignment.Controller do
         service_unavailable(conn)
 
       full?(assignment) and not returning_participant?(conn, assignment) ->
-        study_full(conn)
+        assignment_full(conn)
 
       true ->
         start_participant(conn, assignment)
@@ -239,10 +239,10 @@ defmodule Systems.Assignment.Controller do
     |> render(:"503")
   end
 
-  defp study_full(conn) do
+  defp assignment_full(conn) do
     conn
-    |> put_view(html: CoreWeb.ErrorHTML)
-    |> render(:study_full)
+    |> put_view(html: Assignment.ErrorHTML)
+    |> render(:assignment_full)
   end
 
   defp start_participant(conn, %{id: id} = assignment) do

--- a/core/systems/assignment/controller.ex
+++ b/core/systems/assignment/controller.ex
@@ -239,9 +239,6 @@ defmodule Systems.Assignment.Controller do
     |> render(:"503")
   end
 
-  # A full study is not an error: show a friendly "study is full" page (200)
-  # instead of the generic 503, so a participant arriving via a direct invite
-  # link sees a clear message rather than a server error.
   defp study_full(conn) do
     conn
     |> put_view(html: CoreWeb.ErrorHTML)

--- a/core/systems/assignment/controller.ex
+++ b/core/systems/assignment/controller.ex
@@ -37,39 +37,29 @@ defmodule Systems.Assignment.Controller do
     |> redirect(to: ~p"/assignment/#{id}")
   end
 
-  def invite(conn, %{"id" => id}) do
-    if assignment = Assignment.Public.get(String.to_integer(id), [:crew]) do
-      if blocked?(conn, assignment) do
-        service_unavailable(conn)
-      else
-        start_participant(conn, assignment)
-      end
-    else
-      service_unavailable(conn)
+  def invite(conn, %{"id" => id}), do: participate(conn, id)
+
+  def apply(conn, %{"id" => id}), do: participate(conn, id)
+
+  def join(conn, %{"id" => id}), do: participate(conn, id)
+
+  defp participate(conn, id) when is_binary(id) do
+    case Assignment.Public.get(String.to_integer(id), [:crew]) do
+      %Assignment.Model{} = assignment -> participate(conn, assignment)
+      nil -> service_unavailable(conn)
     end
   end
 
-  def apply(conn, %{"id" => id}) do
-    if assignment = Assignment.Public.get(String.to_integer(id), [:crew]) do
-      if blocked?(conn, assignment) do
+  defp participate(conn, %Assignment.Model{} = assignment) do
+    cond do
+      offline?(assignment) ->
         service_unavailable(conn)
-      else
-        start_participant(conn, assignment)
-      end
-    else
-      service_unavailable(conn)
-    end
-  end
 
-  def join(conn, %{"id" => id}) do
-    if assignment = Assignment.Public.get(String.to_integer(id), [:crew]) do
-      if blocked?(conn, assignment) do
-        service_unavailable(conn)
-      else
+      full?(assignment) and not returning_participant?(conn, assignment) ->
+        study_full(conn)
+
+      true ->
         start_participant(conn, assignment)
-      end
-    else
-      service_unavailable(conn)
     end
   end
 
@@ -234,10 +224,6 @@ defmodule Systems.Assignment.Controller do
     status != :online
   end
 
-  defp blocked?(conn, %Assignment.Model{} = assignment) do
-    offline?(assignment) or (full?(assignment) and not returning_participant?(conn, assignment))
-  end
-
   defp full?(%Assignment.Model{} = assignment) do
     not Assignment.Public.has_budget_capacity?(assignment)
   end
@@ -251,6 +237,15 @@ defmodule Systems.Assignment.Controller do
     |> put_status(:service_unavailable)
     |> put_view(html: CoreWeb.ErrorHTML)
     |> render(:"503")
+  end
+
+  # A full study is not an error: show a friendly "study is full" page (200)
+  # instead of the generic 503, so a participant arriving via a direct invite
+  # link sees a clear message rather than a server error.
+  defp study_full(conn) do
+    conn
+    |> put_view(html: CoreWeb.ErrorHTML)
+    |> render(:study_full)
   end
 
   defp start_participant(conn, %{id: id} = assignment) do

--- a/core/systems/assignment/error_html.ex
+++ b/core/systems/assignment/error_html.ex
@@ -1,0 +1,37 @@
+defmodule Systems.Assignment.ErrorHTML do
+  @moduledoc """
+  Renders the "assignment is full" page shown when a participant tries to join an
+  assignment that no longer has budget capacity.
+
+  It lives in the Assignment system rather than the generic `CoreWeb.ErrorHTML`
+  because both the copy and the meaning are assignment-specific; it reuses the
+  shared `CoreWeb.ErrorHTML.error/1` chrome for the layout.
+  """
+  use CoreWeb, :html
+
+  import CoreWeb.Layouts.Stripped.Composer
+  import CoreWeb.Menus
+
+  def render("assignment_full.html", assigns) do
+    menus = build_menus(stripped_menus_config(), nil, nil)
+
+    assigns =
+      Map.merge(assigns, %{
+        title: dgettext("eyra-assignment", "assignment_full.title"),
+        body: dgettext("eyra-assignment", "assignment_full.body"),
+        menus: menus,
+        image: "/images/illustrations/503.svg",
+        error_code: "assignment_full"
+      })
+
+    ~H"""
+    <CoreWeb.ErrorHTML.error
+      title={@title}
+      menus={@menus}
+      body={@body}
+      image={@image}
+      error_code={@error_code}
+    />
+    """
+  end
+end

--- a/core/test/systems/assignment/controller_test.exs
+++ b/core/test/systems/assignment/controller_test.exs
@@ -63,7 +63,7 @@ defmodule Systems.Assignment.ControllerTest do
 
       conn = get(conn, "/assignment/#{id}/apply")
       response = html_response(conn, 200)
-      assert response =~ "error-study_full"
+      assert response =~ "error-assignment_full"
       assert response =~ "This study is full"
     end
 

--- a/core/test/systems/assignment/controller_test.exs
+++ b/core/test/systems/assignment/controller_test.exs
@@ -57,11 +57,14 @@ defmodule Systems.Assignment.ControllerTest do
   describe "apply with budget capacity" do
     setup :login_as_member
 
-    test "blocks apply when the budget cannot cover one more reward", %{conn: conn} do
+    test "shows a friendly 'study is full' page when the budget cannot cover one more reward",
+         %{conn: conn} do
       id = online_paid_assignment_id(6000)
 
       conn = get(conn, "/assignment/#{id}/apply")
-      html_response(conn, 503)
+      response = html_response(conn, 200)
+      assert response =~ "error-study_full"
+      assert response =~ "This study is full"
     end
 
     test "allows apply when the budget can cover one more reward", %{conn: conn} do


### PR DESCRIPTION
Joining a full paid study via a direct invite link raised in reserve_reward!, surfacing a 500. invite/apply/join (consolidated into one participate/2) now render a friendly 'study is full' page for the budget-full case; an offline study still returns 503 and the returning-participant exemption is preserved.

Refs Flux/Basecamp issue 9938512879