### PR TITLE
i18n: fill missing OTP auth translations for de/es/it/lt/nl/ro

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -245,27 +245,27 @@ msgstr "Willkommen"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.expired"
-msgstr ""
+msgstr "Dieser Code ist abgelaufen. Bitte fordere einen neuen an."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.invalid"
-msgstr ""
+msgstr "Falscher Code. Bitte versuche es erneut."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.max_attempts"
-msgstr ""
+msgstr "Zu viele falsche Versuche. Bitte fordere einen neuen Code an."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr ""
+msgstr "Überprüfe deine E-Mails"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
-msgstr ""
+msgstr "Weiter"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.invalid"
-msgstr ""
+msgstr "Bitte gib eine gültige E-Mail-Adresse ein."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -245,27 +245,27 @@ msgstr "Bienvenido"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.expired"
-msgstr ""
+msgstr "Este código ha caducado. Solicita uno nuevo."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.invalid"
-msgstr ""
+msgstr "Código incorrecto. Inténtalo de nuevo."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.max_attempts"
-msgstr ""
+msgstr "Demasiados intentos incorrectos. Solicita un nuevo código."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr ""
+msgstr "Revisa tu correo electrónico"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
-msgstr ""
+msgstr "Continuar"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.invalid"
-msgstr ""
+msgstr "Introduce una dirección de correo electrónico válida."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -245,27 +245,27 @@ msgstr "Benvenuto"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.expired"
-msgstr ""
+msgstr "Questo codice è scaduto. Richiedine uno nuovo."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.invalid"
-msgstr ""
+msgstr "Codice errato. Riprova."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.max_attempts"
-msgstr ""
+msgstr "Troppi tentativi errati. Richiedi un nuovo codice."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr ""
+msgstr "Controlla la tua email"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
-msgstr ""
+msgstr "Continua"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.invalid"
-msgstr ""
+msgstr "Inserisci un indirizzo email valido."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -254,27 +254,27 @@ msgstr "Sveiki"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.expired"
-msgstr ""
+msgstr "Šio kodo galiojimas baigėsi. Prašykite naujo."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.invalid"
-msgstr ""
+msgstr "Neteisingas kodas. Bandykite dar kartą."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.max_attempts"
-msgstr ""
+msgstr "Per daug neteisingų bandymų. Prašykite naujo kodo."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr ""
+msgstr "Patikrinkite el. paštą"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
-msgstr ""
+msgstr "Tęsti"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.invalid"
-msgstr ""
+msgstr "Įveskite galiojantį el. pašto adresą."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
@@ -244,27 +244,27 @@ msgstr "Welkom"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.expired"
-msgstr ""
+msgstr "Deze code is verlopen. Vraag een nieuwe aan."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.invalid"
-msgstr ""
+msgstr "Onjuiste code. Probeer het opnieuw."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.max_attempts"
-msgstr ""
+msgstr "Te veel onjuiste pogingen. Vraag een nieuwe code aan."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr ""
+msgstr "Controleer je e-mail"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
-msgstr ""
+msgstr "Doorgaan"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.invalid"
-msgstr ""
+msgstr "Voer een geldig e-mailadres in."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -254,27 +254,27 @@ msgstr "Bun venit"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.expired"
-msgstr ""
+msgstr "Acest cod a expirat. Te rugăm să soliciți unul nou."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.invalid"
-msgstr ""
+msgstr "Cod incorect. Te rugăm să încerci din nou."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.max_attempts"
-msgstr ""
+msgstr "Prea multe încercări incorecte. Te rugăm să soliciți un cod nou."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr ""
+msgstr "Verifică-ți emailul"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
-msgstr ""
+msgstr "Continuă"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.invalid"
-msgstr ""
+msgstr "Te rugăm să introduci o adresă de email validă."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"


### PR DESCRIPTION
## Summary
- Fills six empty `auth.*` gettext keys (`auth.code.expired/invalid/max_attempts/title`, `auth.continue.button`, `auth.email.invalid`) across `de`, `es`, `it`, `lt`, `nl`, `ro` — they were introduced as English-only in the email-first OTP feature (#1556).
- On affected locales the Continue button on `/user/auth/identify` and all strings on the verify page rendered as raw msgids — reported in FX#10020259081.
- `lt` and `ro` were translated as a best effort and may want a native-speaker pass.

Fixes: FX#10020259081

## Test plan
- [ ] Switch UI language to Dutch (or any of the other 5 locales) and visit `/user/auth/identify` — the Continue button shows translated text.
- [ ] Submit an invalid email — error message is translated.
- [ ] Continue to `/user/auth/verify` — page title and error/expired/max-attempts messages are translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)