### PR TITLE
feat(org): allow any user (not only creators) as Org members and admins

### DIFF
--- a/core/systems/org/admins_modal_view_builder.ex
+++ b/core/systems/org/admins_modal_view_builder.ex
@@ -16,9 +16,10 @@ defmodule Systems.Org.AdminsModalViewBuilder do
     people = Org.Public.list_owners(org)
     people_ids = Enum.map(people, & &1.id)
 
-    # Get all creators who aren't already admins
+    # Org admins can be any user — the org owner decides who has access,
+    # not the platform.
     users =
-      Account.Public.list_creators([:profile])
+      Account.Public.list_users([:profile])
       |> Enum.reject(&(&1.id in people_ids))
 
     %{

--- a/core/systems/org/member_view_builder.ex
+++ b/core/systems/org/member_view_builder.ex
@@ -53,7 +53,7 @@ defmodule Systems.Org.MemberViewBuilder do
     excluded_ids = member_ids ++ owner_ids
 
     users =
-      Account.Public.list_creators([:profile])
+      Account.Public.list_users([:profile])
       |> Enum.reject(&(&1.id in excluded_ids))
 
     domain_matched = Org.Public.find_domain_matched_users(domains, all_members ++ owners)

--- a/core/test/systems/org/admins_modal_view_builder_test.exs
+++ b/core/test/systems/org/admins_modal_view_builder_test.exs
@@ -21,19 +21,20 @@ defmodule Systems.Org.AdminsModalViewBuilderTest do
       assert owner2.id in people_ids
     end
 
-    test "returns available creators as users" do
-      creator1 = Factories.insert!(:creator)
-      creator2 = Factories.insert!(:creator)
+    test "returns available users (any role) as candidates, excluding current owners" do
+      creator = Factories.insert!(:creator)
+      participant = Factories.insert!(:member, %{creator: false})
+      existing_owner = Factories.insert!(:creator)
       org = Factories.insert!(:org_node, %{identifier: ["avail_users_org"]})
 
-      # creator1 is already an owner, so should not be in users
-      Core.Authorization.assign_role(creator1, org, :owner)
+      Core.Authorization.assign_role(existing_owner, org, :owner)
 
       vm = AdminsModalViewBuilder.view_model(org, %{})
 
       user_ids = Enum.map(vm.users, & &1.id)
-      refute creator1.id in user_ids
-      assert creator2.id in user_ids
+      refute existing_owner.id in user_ids
+      assert creator.id in user_ids
+      assert participant.id in user_ids
     end
 
     test "returns title in view model" do

--- a/core/test/systems/org/member_view_builder_test.exs
+++ b/core/test/systems/org/member_view_builder_test.exs
@@ -39,6 +39,17 @@ defmodule Systems.Org.MemberViewBuilderTest do
       assert vm.people == []
       assert vm.user_count == 0
     end
+
+    test "users includes participants, not only creators", %{org: org, assigns: assigns} do
+      participant = Factories.insert!(:member, %{creator: false})
+      creator = Factories.insert!(:creator)
+
+      vm = Org.MemberViewBuilder.view_model(org, assigns)
+
+      user_ids = Enum.map(vm.users, & &1.id)
+      assert participant.id in user_ids
+      assert creator.id in user_ids
+    end
   end
 
   describe "view_model/2 cap" do


### PR DESCRIPTION
## Summary

Both the **Members tab** and the **Admins modal** on the Org page restricted the add-by-email lookup to creators only (`Account.Public.list_creators`). Typing a participant's email like `demo@example.com` returned _"No one found with this email address."_ even though the account exists.

The org owner decides who has access to their org — not the platform. Swaps both lookups to `Account.Public.list_users`.

Two small files changed:
- `Systems.Org.MemberViewBuilder` — `list_creators` → `list_users`
- `Systems.Org.AdminsModalViewBuilder` — `list_creators` → `list_users`

Tests updated: the Admins modal test name now reflects the broader behaviour, and a participant-inclusion test was added on each side.

## Test plan

- [x] `mix test test/systems/org --warnings-as-errors` — 90/90 pass
- [x] `mix format` + `mix credo` + `mix dialyzer` clean
- [x] Manual: add `demo@example.com` (participant) to the Panl org via the Members tab — works
- [ ] Manual: same for the Admins modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)