### PR TITLE
feat(layout): desktop sidepadding + 1536px max content + paper-sheet shadow

### DIFF
--- a/core/assets/package-lock.json
+++ b/core/assets/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "@novasoftwarefoundation/prism": "0.1.5",
+        "@novasoftwarefoundation/prism": "0.1.7",
         "blurhash": "2.0.5",
         "lodash": "4.18.1",
         "pdfjs-dist": "5.4.296",
@@ -552,9 +552,9 @@
       }
     },
     "node_modules/@novasoftwarefoundation/prism": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@novasoftwarefoundation/prism/-/prism-0.1.5.tgz",
-      "integrity": "sha512-pH0mDqP9ipELFuVXKP8WpHceXdK6HPzG7trZRU7U+04gHphaGgL9TTdgn++9Q+//Kkaw8sRMnTQGlrYUvo/vaQ==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@novasoftwarefoundation/prism/-/prism-0.1.7.tgz",
+      "integrity": "sha512-p8g7TxCDHOYjOLdd3m2/eA3djEbfCkVUirwQRDB23SHvDJhuUcflonsMNLT0SMRET49vR7lc/fjefNA4Vn2Jtw==",
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0"

--- a/core/assets/package.json
+++ b/core/assets/package.json
@@ -11,7 +11,7 @@
     "lodash": "4.18.1",
     "pdfjs-dist": "5.4.296",
     "pinch-zoom-js": "2.3.5",
-    "@novasoftwarefoundation/prism": "0.1.5",
+    "@novasoftwarefoundation/prism": "0.1.7",
     "trix": "2.1.18"
   },
   "devDependencies": {

--- a/core/frameworks/pixel/components/navigation.ex
+++ b/core/frameworks/pixel/components/navigation.ex
@@ -184,7 +184,7 @@ defmodule Frameworks.Pixel.Navigation do
 
   def desktop_navbar(assigns) do
     ~H"""
-    <div class="bg-grey5 w-full pl-6 pr-6">
+    <div class="bg-grey5 w-full">
       <.navbar {assigns} />
     </div>
     """

--- a/core/lib/core_web/controllers/layouts/stripped/html.ex
+++ b/core/lib/core_web/controllers/layouts/stripped/html.ex
@@ -23,38 +23,34 @@ defmodule CoreWeb.Layouts.Stripped.Html do
     ~H"""
     <div class="flex flex-row">
       <div class="flex-1">
-        <div id="main-content" class="flex flex-col w-full min-h-viewport md:h-viewport">
-            <div class="flex-wrap lg:hidden">
-              <Navigation.mobile_navbar {@menus.mobile_navbar} />
-            </div>
-            <div class="flex-wrap hidden lg:flex">
-              <Navigation.desktop_navbar {@menus.desktop_navbar} />
-            </div>
-          <div class="flex-1 flex flex-col">
-            <div class="flex-1 flex flex-col border-t border-b border-grey4">
-              <%= render_slot(@header) %>
-              <%= if @title do %>
-                <div class="flex-none">
-                  <Hero.illustration2 title={@title} />
-                </div>
-              <% end %>
-              <div class="flex-1 min-h-0 bg-white">
-                <div class="flex flex-row w-full h-full min-h-0">
-                  <div id="layout-inner-block" class="flex-1 h-full min-h-0">
-                    <%= render_slot(@inner_block) %>
-                    <Margin.y id={:page_footer_top} />
-                  </div>
-                </div>
+        <div class="bg-grey5 lg:px-16">
+          <div id="main-content" class="flex flex-col w-full min-h-viewport md:h-viewport lg:max-w-[1536px] lg:mx-auto">
+              <div class="flex-wrap lg:hidden">
+                <Navigation.mobile_navbar {@menus.mobile_navbar} />
               </div>
-              <%= if @footer? do %>
-                <div class="bg-white">
-                  <.content_footer />
+              <div class="flex-wrap hidden lg:flex">
+                <Navigation.desktop_navbar {@menus.desktop_navbar} />
+              </div>
+            <div class="flex-1 flex flex-col lg:relative lg:z-10">
+              <div class="flex-1 flex flex-col min-h-0 bg-white lg:shadow-prism-container">
+                <%= render_slot(@header) %>
+                <%= if @title do %>
+                  <div class="flex-none">
+                    <Hero.illustration2 title={@title} />
+                  </div>
+                <% end %>
+                <div id="layout-inner-block" class="flex-1 h-full min-h-0">
+                  <%= render_slot(@inner_block) %>
+                  <Margin.y id={:page_footer_top} />
                 </div>
-              <% end %>
+                <%= if @footer? do %>
+                  <.content_footer />
+                <% end %>
+              </div>
             </div>
-          </div>
-          <div class="bg-grey5">
-            <.platform_footer privacy_text={@privacy_text} terms_text={@terms_text} />
+            <div class="bg-grey5">
+              <.platform_footer privacy_text={@privacy_text} terms_text={@terms_text} />
+            </div>
           </div>
         </div>
       </div>

--- a/core/lib/core_web/controllers/layouts/website/html.ex
+++ b/core/lib/core_web/controllers/layouts/website/html.ex
@@ -36,36 +36,38 @@ defmodule CoreWeb.Layouts.Website.Html do
           >
             <Navigation.mobile_menu {@menus.mobile_menu} />
           </div>
-          <div id="main-content" class="flex flex-col w-full h-viewport">
-            <div class="flex-wrap lg:hidden">
-              <Navigation.mobile_navbar {@menus.mobile_navbar} />
-            </div>
-            <div class="flex-wrap hidden lg:flex">
-              <Navigation.desktop_navbar {@menus.desktop_navbar} />
-            </div>
-            <div class="flex-1">
-              <div class="flex flex-col h-full border-t border-b border-grey4">
-                <div class="bg-white">
-                  <%= render_slot(@hero) %>
-                </div>
-                <div class="flex-1 bg-white">
-                  <div class="flex flex-row">
-                    <div id="layout-inner-block" class="flex-1">
-                      <%= render_slot(@inner_block) %>
-                      <Margin.y id={:page_footer_top} />
+          <div class="bg-grey5 lg:px-16">
+            <div id="main-content" class="flex flex-col w-full h-viewport lg:max-w-[1536px] lg:mx-auto">
+              <div class="flex-wrap lg:hidden">
+                <Navigation.mobile_navbar {@menus.mobile_navbar} />
+              </div>
+              <div class="flex-wrap hidden lg:flex">
+                <Navigation.desktop_navbar {@menus.desktop_navbar} />
+              </div>
+              <div class="flex-1 lg:relative lg:z-10">
+                <div class="flex flex-col h-full lg:shadow-prism-container">
+                  <div class="bg-white">
+                    <%= render_slot(@hero) %>
+                  </div>
+                  <div class="flex-1 bg-white">
+                    <div class="flex flex-row">
+                      <div id="layout-inner-block" class="flex-1">
+                        <%= render_slot(@inner_block) %>
+                        <Margin.y id={:page_footer_top} />
+                      </div>
+                      <%= if @include_right_sidepadding? do %>
+                        <div class="w-0 md:w-sidepadding"></div>
+                      <% end %>
                     </div>
-                    <%= if @include_right_sidepadding? do %>
-                      <div class="w-0 md:w-sidepadding"></div>
-                    <% end %>
+                  </div>
+                  <div class="bg-white">
+                    <.content_footer />
                   </div>
                 </div>
-                <div class="bg-white">
-                  <.content_footer />
-                </div>
               </div>
-            </div>
-            <div class="bg-grey5">
-              <.platform_footer />
+              <div class="bg-grey5">
+                <.platform_footer />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

On wide desktop screens, the Website and Stripped layouts now centre their content in a **1536px column** with **64px** grey sidepadding. Beyond ~1664px viewport the sidepadding grows. Below desktop, the layouts are unchanged.

The content reads as a sheet of paper on the grey background: white sheet with a soft drop-shadow (the Nova "Container" effect), platform footer in the grey band underneath.

Also: drops the now-redundant horizontal padding inside the desktop navbar so the logo and menu items align with the content edges.

## Dependency

Bumps `@novasoftwarefoundation/prism` to `0.1.7` — adds `shadow-prism-container` (and three sibling shadow tokens mirroring the Nova effect styles).

Closes FX#10030003873 — https://3.basecamp.com/5734045/buckets/35926565/todos/10030003873

## Test plan

- [x] `mix test test/systems/account test/systems/home test/core_web` — passes
- [x] Wide desktop: 1536 sheet centred, sidepadding visible, soft shadow around all four edges
- [x] `/user/account` (participant, Stripped) — same treatment
- [ ] 1024–1664 viewport: sheet shrinks but sidepadding stays ≥64
- [ ] <1024: edge-to-edge as before
- [ ] `/user/account` as a creator (Workspace): untouched, sanity check

🤖 Generated with [Claude Code](https://claude.com/claude-code)