### PR TITLE
feat(identity): federated auth orchestration + link existing accounts on IdP sign-in

### DIFF
--- a/core/lib/core/identity.ex
+++ b/core/lib/core/identity.ex
@@ -1,0 +1,85 @@
+defmodule Core.Identity do
+  @moduledoc """
+  Orchestrates federated authentication against an external Identity
+  Provider (IdP).
+
+  An IdP — SURFconext, Google, … — proves the user owns an email address
+  and hands back a payload of proprietary fields ("userinfo"). Each IdP
+  is represented in code by a *provider module* that implements the
+  `Core.Identity.Provider` behaviour. A provider owns:
+
+    * the satellite Ecto schema for that IdP (a row per linked identity)
+    * the IdP-specific shape of `userinfo`
+
+  This module owns the flow that is identical across every IdP:
+
+    1. Translate `userinfo` into a normalized Account.User attrs map via
+       the provider's `user_attrs/1`.
+    2. Locate (or create) the Eyra Account.User by `:email`.
+    3. Attach a new satellite row if the user has none, or refresh the
+       existing one.
+
+  Plugs/controllers call `authenticate/2` and react to the
+  `{:ok, %{user: ..., first_time?: ...}}` result.
+  """
+
+  alias Systems.Account
+  alias Systems.Account.User
+
+  @typedoc "Normalized Account.User attrs returned by `c:Provider.user_attrs/1`."
+  @type user_attrs :: %{required(:email) => String.t(), optional(atom()) => any()}
+
+  @typedoc "Result of a successful federated authentication."
+  @type result :: %{user: User.t(), first_time?: boolean()}
+
+  @doc """
+  Authenticate a federated sign-in.
+
+  On success returns `{:ok, %{user: user, first_time?: bool}}`. The
+  `first_time?` flag is `true` iff the Account.User was just created
+  during this call; callers use it to choose between the
+  post-registration landing (e.g. onboarding) and the regular
+  post-signin destination.
+
+  `register_overrides` is merged into the provider's `user_attrs/1`
+  output before registering a brand-new Account.User. Used for
+  situational data the IdP itself doesn't carry — for example, Google
+  sign-in passes `%{creator: creator?}` because the same Google
+  identity can be a researcher or a participant depending on which
+  signup flow they came from. Has no effect when the user already
+  exists.
+  """
+  @spec authenticate(
+          provider :: module(),
+          userinfo :: map(),
+          register_overrides :: map()
+        ) :: {:ok, result()} | {:error, Ecto.Changeset.t()}
+  def authenticate(provider, userinfo, register_overrides \\ %{})
+      when is_atom(provider) and is_map(userinfo) and is_map(register_overrides) do
+    attrs = provider.user_attrs(userinfo) |> Map.merge(register_overrides)
+
+    with {:ok, user, first_time?} <- find_or_register(attrs),
+         {:ok, _satellite} <- upsert_satellite(provider, user, userinfo) do
+      {:ok, %{user: user, first_time?: first_time?}}
+    end
+  end
+
+  defp find_or_register(%{email: email} = attrs) do
+    case Account.Public.get_user_by_email(email) do
+      %User{} = existing ->
+        {:ok, existing, false}
+
+      nil ->
+        with {:ok, user} <- Account.Public.register_via_sso(attrs) do
+          {:ok, user, true}
+        end
+    end
+  end
+
+  defp upsert_satellite(provider, user, userinfo) do
+    case provider.get(user) do
+      nil -> provider.attach(user, userinfo)
+      _existing -> {:ok, provider.refresh(user, userinfo)}
+    end
+  end
+end

--- a/core/lib/core/identity/provider.ex
+++ b/core/lib/core/identity/provider.ex
@@ -1,0 +1,47 @@
+defmodule Core.Identity.Provider do
+  @moduledoc """
+  Behaviour for Identity Provider satellite modules (SURFconext, Google, …).
+
+  An implementation owns the satellite Ecto schema (one row per linked
+  identity) and the proprietary shape of the IdP's `userinfo` payload.
+  The orchestrator in `Core.Identity` is the only caller of these
+  callbacks; it relies on each implementation being thin and stateless
+  beyond the satellite row.
+
+  See `Core.SurfConext` and `GoogleSignIn` for the canonical implementations.
+  """
+
+  alias Systems.Account.User
+
+  @typedoc """
+  Normalized Account.User attrs derived from a proprietary `userinfo` map.
+
+  Keys mirror what `Systems.Account.User.sso_changeset/2` casts — adding
+  a new key here means widening the cast list there too. `:email` is the
+  only required key; the rest are optional and may be omitted by an IdP
+  that doesn't carry them.
+  """
+  @type user_attrs :: %{
+          required(:email) => String.t(),
+          optional(:displayname) => String.t(),
+          optional(:creator) => boolean(),
+          optional(:confirmed_at) => NaiveDateTime.t(),
+          optional(:verified_at) => NaiveDateTime.t(),
+          optional(:fullname) => String.t(),
+          optional(:title) => String.t(),
+          optional(:photo_url) => String.t()
+        }
+
+  @doc "Translate a proprietary IdP `userinfo` map into normalized user attrs."
+  @callback user_attrs(userinfo :: map()) :: user_attrs()
+
+  @doc "Return the satellite row for `user`, or `nil` if none exists."
+  @callback get(user :: User.t()) :: struct() | nil
+
+  @doc "Insert a new satellite row linked to `user` from `userinfo`."
+  @callback attach(user :: User.t(), userinfo :: map()) ::
+              {:ok, struct()} | {:error, Ecto.Changeset.t()}
+
+  @doc "Refresh the satellite row for `user` with the latest `userinfo`. The row MUST exist."
+  @callback refresh(user :: User.t(), userinfo :: map()) :: struct()
+end

--- a/core/lib/core/surfconext.ex
+++ b/core/lib/core/surfconext.ex
@@ -1,7 +1,13 @@
 defmodule Core.SurfConext do
+  @moduledoc """
+  SURFconext identity provider. Implements `Core.Identity.Provider` —
+  the orchestration of "find user by email, attach or refresh satellite"
+  lives in `Core.Identity`.
+  """
+  @behaviour Core.Identity.Provider
+
   alias Systems.Account.User
   alias Core.Repo
-  alias Frameworks.Signal
   import Ecto.Query, warn: false
 
   require Logger
@@ -10,65 +16,56 @@ defmodule Core.SurfConext do
     defexception [:message]
   end
 
-  def get_user_by_sub(sub) do
-    from(u in User,
-      where:
-        u.id in subquery(
-          from(sc in Core.SurfConext.User, where: sc.sub == ^sub, select: sc.user_id)
-        )
-    )
-    |> Repo.one()
-  end
-
-  def get_surfconext_user_by_user(%User{id: id}) do
-    from(surfconext_user in Core.SurfConext.User, where: surfconext_user.user_id == ^id)
-    |> Repo.one!()
-  end
-
-  def register_user(attrs) do
+  @impl Core.Identity.Provider
+  def user_attrs(userinfo) when is_map(userinfo) do
     fullname =
       ~w(given_name family_name)
-      |> Enum.map(&Map.get(attrs, &1, ""))
+      |> Enum.map(&Map.get(userinfo, &1, ""))
       |> Enum.filter(&(&1 != ""))
       |> Enum.join(" ")
 
-    display_name = Map.get(attrs, "given_name", fullname)
-    email = get_email(attrs)
-
-    sso_info = %{
-      email: email,
-      displayname: display_name,
-      profile: %{
-        fullname: fullname
-      },
+    %{
+      email: get_email(userinfo),
+      displayname: Map.get(userinfo, "given_name", fullname),
       creator: true,
-      confirmed_at: NaiveDateTime.utc_now()
+      confirmed_at: NaiveDateTime.utc_now(),
+      fullname: fullname
     }
-
-    user = User.sso_changeset(%User{}, sso_info)
-    sub = Map.get(attrs, "sub")
-
-    with {:ok, surf_user} <-
-           %Core.SurfConext.User{}
-           |> Core.SurfConext.User.register_changeset(%{email: email, sub: sub, userinfo: attrs})
-           |> Ecto.Changeset.put_assoc(:user, user)
-           |> Repo.insert() do
-      Signal.Public.dispatch!({:user, :created}, %{user: surf_user.user})
-      {:ok, surf_user}
-    end
   end
 
-  defp get_email(attrs) do
-    case Map.get(attrs, "email") do
-      nil -> raise SurfConextError, "No email found in user info #{attrs |> inspect()}"
+  @impl Core.Identity.Provider
+  def get(%User{id: id}) do
+    Repo.get_by(Core.SurfConext.User, user_id: id)
+  end
+
+  @impl Core.Identity.Provider
+  def attach(%User{} = user, userinfo) when is_map(userinfo) do
+    %Core.SurfConext.User{}
+    |> Core.SurfConext.User.register_changeset(satellite_attrs(userinfo))
+    |> Ecto.Changeset.put_assoc(:user, user)
+    |> Repo.insert()
+  end
+
+  @impl Core.Identity.Provider
+  def refresh(%User{} = user, userinfo) when is_map(userinfo) do
+    get(user)
+    |> Core.SurfConext.User.update_changeset(%{userinfo: userinfo})
+    |> Repo.update!()
+  end
+
+  defp satellite_attrs(userinfo) do
+    %{
+      email: get_email(userinfo),
+      sub: Map.get(userinfo, "sub"),
+      userinfo: userinfo
+    }
+  end
+
+  defp get_email(userinfo) do
+    case Map.get(userinfo, "email") do
+      nil -> raise SurfConextError, "No email found in user info #{inspect(userinfo)}"
       email -> email
     end
-  end
-
-  def update_user(%User{} = user, attrs) do
-    get_surfconext_user_by_user(user)
-    |> Core.SurfConext.User.update_changeset(%{userinfo: attrs})
-    |> Repo.update!()
   end
 
   defmacro routes(otp_app) do

--- a/core/lib/core/surfconext/plug.ex
+++ b/core/lib/core/surfconext/plug.ex
@@ -72,45 +72,18 @@ defmodule Core.SurfConext.CallbackController do
   defp do_authenticate(conn, params, session_params) do
     config = config(:core) |> Keyword.put(:session_params, session_params)
 
-    {:ok, %{user: surf_user, token: token}} = oidc_module(config).callback(config, params)
-    Logger.debug("SURFconext user: #{inspect(surf_user)}")
+    {:ok, %{token: token}} = oidc_module(config).callback(config, params)
 
-    Logger.debug(
-      "SURFconext oidc info: #{inspect(oidc_module(config).fetch_userinfo(config, token))}"
-    )
+    with {:ok, userinfo} <- oidc_module(config).fetch_userinfo(config, token) do
+      Logger.debug("SURFconext userinfo: #{inspect(userinfo)}")
 
-    authenticate_user(config, conn, token, surf_user)
-  end
-
-  defp authenticate_user(config, conn, token, surf_user) do
-    if user = Core.SurfConext.get_user_by_sub(surf_user["sub"]) do
-      update_user(config, conn, user, token)
-    else
-      register_user(config, conn, token)
-    end
-  end
-
-  defp update_user(config, conn, user, token) do
-    with {:ok, userinfo} <- fetch_userinfo(config, token) do
-      Core.SurfConext.update_user(user, userinfo)
-    end
-
-    log_in_user(config, conn, user, false)
-  end
-
-  defp register_user(config, conn, token) do
-    with {:ok, userinfo} <- fetch_userinfo(config, token) do
-      case(Core.SurfConext.register_user(userinfo)) do
-        {:ok, surfconext_user} ->
-          log_in_user(config, conn, surfconext_user.user, true)
+      case Core.Identity.authenticate(Core.SurfConext, userinfo) do
+        {:ok, %{user: user, first_time?: first_time?}} ->
+          log_in_user(config, conn, user, first_time?)
 
         {:error, changeset} ->
           Core.SSOHelpers.handle_registration_error(conn, changeset)
       end
     end
-  end
-
-  defp fetch_userinfo(config, token) do
-    oidc_module(config).fetch_userinfo(config, token)
   end
 end

--- a/core/lib/google_sign_in.ex
+++ b/core/lib/google_sign_in.ex
@@ -1,50 +1,56 @@
 defmodule GoogleSignIn do
+  @moduledoc """
+  Google identity provider. Implements `Core.Identity.Provider` — the
+  orchestration of "find user by email, attach or refresh satellite"
+  lives in `Core.Identity`.
+
+  Whether a Google sign-in produces a researcher or a participant
+  depends on the signup flow the user came from. The Google callback
+  plug passes `%{creator: creator?}` as `register_overrides` to
+  `Core.Identity.authenticate/3`; the orchestrator merges it on top of
+  this module's `user_attrs/1` output when a brand-new Account.User
+  is registered.
+  """
+  @behaviour Core.Identity.Provider
+
   alias Systems.Account.User
   alias Core.Repo
-  alias Frameworks.Signal
   import Ecto.Query, warn: false
 
-  def get_user_by_sub(sub) do
-    from(u in User,
-      where:
-        u.id in subquery(from(sc in GoogleSignIn.User, where: sc.sub == ^sub, select: sc.user_id))
-    )
-    |> Repo.one()
-  end
-
-  def register_user(attrs, creator?) do
+  @impl Core.Identity.Provider
+  def user_attrs(userinfo) when is_map(userinfo) do
     fullname =
       ~w(given_name family_name)
-      |> Enum.map(&Map.get(attrs, &1, ""))
+      |> Enum.map(&Map.get(userinfo, &1, ""))
       |> Enum.filter(&(&1 != ""))
       |> Enum.join(" ")
 
-    display_name = Map.get(attrs, "given_name", fullname)
-
-    # See:
-    # Apply temp: https://github.com/eyra/mono/issues/558
-    # Revert: https://github.com/eyra/mono/issues/563
-
-    sso_info = %{
-      creator: creator?,
-      email: Map.get(attrs, "email"),
-      displayname: display_name,
-      profile: %{
-        fullname: fullname
-      },
-      verified_at: NaiveDateTime.utc_now()
+    %{
+      email: Map.get(userinfo, "email"),
+      displayname: Map.get(userinfo, "given_name", fullname),
+      verified_at: NaiveDateTime.utc_now(),
+      fullname: fullname
     }
+  end
 
-    user = User.sso_changeset(%User{}, sso_info)
+  @impl Core.Identity.Provider
+  def get(%User{id: id}) do
+    Repo.get_by(GoogleSignIn.User, user_id: id)
+  end
 
-    with {:ok, google_user} <-
-           %GoogleSignIn.User{}
-           |> GoogleSignIn.User.changeset(attrs)
-           |> Ecto.Changeset.put_assoc(:user, user)
-           |> Repo.insert() do
-      Signal.Public.dispatch!({:user, :created}, %{user: google_user.user})
-      {:ok, google_user}
-    end
+  @impl Core.Identity.Provider
+  def attach(%User{} = user, userinfo) when is_map(userinfo) do
+    %GoogleSignIn.User{}
+    |> GoogleSignIn.User.changeset(userinfo)
+    |> Ecto.Changeset.put_assoc(:user, user)
+    |> Repo.insert()
+  end
+
+  @impl Core.Identity.Provider
+  def refresh(%User{} = user, userinfo) when is_map(userinfo) do
+    get(user)
+    |> GoogleSignIn.User.changeset(userinfo)
+    |> Repo.update!()
   end
 
   defmacro routes(otp_app) do

--- a/core/lib/google_sign_in/plug.ex
+++ b/core/lib/google_sign_in/plug.ex
@@ -102,19 +102,10 @@ defmodule GoogleSignIn.CallbackPlug do
       throw("Google login is disabled")
     end
 
-    if user = GoogleSignIn.get_user_by_sub(google_user["sub"]) do
-      dispatch_post_signin_action(user, post_action)
-      log_in_user(config, conn, user, false)
-    else
-      register_new_user(conn, config, google_user, creator?, post_action)
-    end
-  end
-
-  defp register_new_user(conn, config, google_user, creator?, post_action) do
-    case GoogleSignIn.register_user(google_user, creator?) do
-      {:ok, google_sign_in_user} ->
-        dispatch_post_signin_action(google_sign_in_user.user, post_action)
-        log_in_user(config, conn, google_sign_in_user.user, true)
+    case Core.Identity.authenticate(GoogleSignIn, google_user, %{creator: creator?}) do
+      {:ok, %{user: user, first_time?: first_time?}} ->
+        dispatch_post_signin_action(user, post_action)
+        log_in_user(config, conn, user, first_time?)
 
       {:error, changeset} ->
         Core.SSOHelpers.handle_registration_error(conn, changeset)

--- a/core/systems/account/_public.ex
+++ b/core/systems/account/_public.ex
@@ -246,6 +246,34 @@ defmodule Systems.Account.Public do
   end
 
   @doc """
+  Registers a new user from an SSO-provided attrs map. The IdP (SURFconext,
+  Google, …) has already proven email ownership, so the account is created
+  with `confirmed_at`/`verified_at` set by the caller's attrs and is
+  immediately usable. Dispatches `{:user, :created}`.
+
+  `attrs` is the flat normalized map produced by a `Core.Identity.Provider`'s
+  `user_attrs/1` callback — the User vs Profile schema split is an internal
+  concern handled here, not something the IdP has to know about. See
+  `Core.Identity.Provider.user_attrs/0` for the allowed keys.
+  """
+  def register_via_sso(%{email: _} = attrs) do
+    with {:ok, user} <-
+           %User{}
+           |> User.sso_changeset(nest_profile_attrs(attrs))
+           |> Repo.insert() do
+      Frameworks.Signal.Public.dispatch!({:user, :created}, %{user: user})
+      {:ok, user}
+    end
+  end
+
+  @profile_keys [:fullname, :title, :photo_url]
+
+  defp nest_profile_attrs(attrs) do
+    {profile_attrs, user_attrs} = Map.split(attrs, @profile_keys)
+    Map.put(user_attrs, :profile, profile_attrs)
+  end
+
+  @doc """
   Registers a new user from just an email (OTP-only auth flow). Creates a
   passwordless account (`hashed_password: "no-password-set"`) with email
   ownership marked as verified (the OTP code itself proves possession of

--- a/core/test/core/identity_test.exs
+++ b/core/test/core/identity_test.exs
@@ -1,0 +1,131 @@
+defmodule Core.IdentityTest do
+  use Core.DataCase, async: true
+  import Frameworks.Signal.TestHelper
+
+  alias Core.Factories
+  alias Core.Identity
+  alias Core.SurfConext
+  alias Systems.Account
+
+  describe "authenticate/2 — SURFconext" do
+    test "registers a new Account.User and attaches a satellite when neither exists" do
+      isolate_signals()
+
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "new@uva.nl",
+        "given_name" => "New",
+        "family_name" => "Researcher"
+      }
+
+      {:ok, %{user: user, first_time?: first_time?}} =
+        Identity.authenticate(SurfConext, userinfo)
+
+      assert first_time? == true
+      assert user.email == "new@uva.nl"
+      assert user.creator == true
+      assert SurfConext.get(user) != nil
+      assert_signal_dispatched({:user, :created})
+    end
+
+    test "attaches a satellite to an existing Account.User (the link case)" do
+      existing = Factories.insert!(:member, %{email: "existing@uva.nl"})
+
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "existing@uva.nl",
+        "given_name" => "Existing"
+      }
+
+      {:ok, %{user: user, first_time?: first_time?}} =
+        Identity.authenticate(SurfConext, userinfo)
+
+      assert first_time? == false
+      assert user.id == existing.id
+      assert SurfConext.get(user) != nil
+    end
+
+    test "refreshes the satellite on subsequent sign-ins" do
+      user = Factories.insert!(:member, %{email: "repeat@uva.nl"})
+
+      first = %{
+        "sub" => "stable",
+        "email" => "repeat@uva.nl",
+        "given_name" => "First"
+      }
+
+      {:ok, _} = Identity.authenticate(SurfConext, first)
+
+      second = %{
+        "sub" => "stable",
+        "email" => "repeat@uva.nl",
+        "given_name" => "Second"
+      }
+
+      {:ok, %{user: same_user, first_time?: first_time?}} =
+        Identity.authenticate(SurfConext, second)
+
+      assert first_time? == false
+      assert same_user.id == user.id
+
+      satellite = SurfConext.get(same_user)
+      assert satellite.userinfo == second
+    end
+
+    test "does not touch the existing user's email or displayname when linking" do
+      _existing =
+        Factories.insert!(:member, %{
+          email: "stable@uva.nl",
+          displayname: "Local Display"
+        })
+
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "stable@uva.nl",
+        "given_name" => "From SURFconext"
+      }
+
+      {:ok, %{user: user}} = Identity.authenticate(SurfConext, userinfo)
+
+      reloaded = Account.Public.get_user!(user.id)
+      assert reloaded.email == "stable@uva.nl"
+      assert reloaded.displayname == "Local Display"
+    end
+  end
+
+  describe "authenticate/3 — register_overrides" do
+    test "merges overrides into the registered user (Google passes creator?)" do
+      isolate_signals()
+
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "fresh@example.com",
+        "email_verified" => true,
+        "given_name" => "Fresh",
+        "family_name" => "User"
+      }
+
+      {:ok, %{user: user, first_time?: true}} =
+        Identity.authenticate(GoogleSignIn, userinfo, %{creator: false})
+
+      assert user.creator == false
+    end
+
+    test "overrides have no effect when the user already exists" do
+      existing = Factories.insert!(:member, %{email: "preset@example.com", creator: true})
+
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "preset@example.com",
+        "email_verified" => true,
+        "given_name" => "Whatever"
+      }
+
+      {:ok, %{user: user, first_time?: false}} =
+        Identity.authenticate(GoogleSignIn, userinfo, %{creator: false})
+
+      assert user.id == existing.id
+      assert user.creator == true
+    end
+  end
+end

--- a/core/test/core/surfconext/plug_test.exs
+++ b/core/test/core/surfconext/plug_test.exs
@@ -122,42 +122,48 @@ defmodule Core.SurfConext.CallbackController.Test do
       assert user.creator == true
     end
 
-    test "authenticates an existing user", %{conn: conn} do
+    test "authenticates an existing user", %{conn: conn, conf: conf} do
       email = Faker.Internet.email()
 
-      Core.SurfConext.register_user(%{
+      Core.Identity.authenticate(Core.SurfConext, %{
         "sub" => "test",
         "email" => email,
         "preferred_username" => Faker.Person.name()
       })
 
+      Application.put_env(:core, Core.SurfConext, Keyword.put(conf, :email, email))
+
       conn = conn |> get("/auth/surfconext/callback")
       assert redirected_to(conn) == "/project"
     end
 
-    test "authenticates an existing researcher", %{conn: conn} do
+    test "authenticates an existing researcher", %{conn: conn, conf: conf} do
       email = Faker.Internet.email()
 
-      Core.SurfConext.register_user(%{
+      Core.Identity.authenticate(Core.SurfConext, %{
         "sub" => "test",
         "email" => email,
         "preferred_username" => Faker.Person.name(),
         "eduperson_affiliation" => ["employee"]
       })
 
+      Application.put_env(:core, Core.SurfConext, Keyword.put(conf, :email, email))
+
       conn = conn |> get("/auth/surfconext/callback")
       assert redirected_to(conn) == "/project"
     end
 
-    test "authenticates an existing student", %{conn: conn} do
+    test "authenticates an existing student", %{conn: conn, conf: conf} do
       email = Faker.Internet.email()
 
-      Core.SurfConext.register_user(%{
+      Core.Identity.authenticate(Core.SurfConext, %{
         "sub" => "test",
         "email" => email,
         "preferred_username" => Faker.Person.name(),
         "eduperson_affiliation" => ["student"]
       })
+
+      Application.put_env(:core, Core.SurfConext, Keyword.put(conf, :email, email))
 
       conn = conn |> get("/auth/surfconext/callback")
       assert redirected_to(conn) == "/project"
@@ -190,7 +196,7 @@ defmodule Core.SurfConext.CallbackController.Test do
     test "updates an existing student", %{conn: conn, conf: conf} do
       email = Faker.Internet.email()
 
-      Core.SurfConext.register_user(%{
+      Core.Identity.authenticate(Core.SurfConext, %{
         "sub" => "student",
         "email" => email,
         "preferred_username" => Faker.Person.name(),
@@ -201,24 +207,26 @@ defmodule Core.SurfConext.CallbackController.Test do
         conf
         |> Keyword.put(:sub, "student")
         |> Keyword.put(:token, "student-token")
+        |> Keyword.put(:email, email)
 
       Application.put_env(:core, Core.SurfConext, conf)
 
       conn = conn |> get("/auth/surfconext/callback")
 
-      user = Core.SurfConext.get_user_by_sub("student")
-      surfconext_user = Core.SurfConext.get_surfconext_user_by_user(user)
+      user = Systems.Account.Public.get_user_by_email(email)
+      surfconext_user = Core.SurfConext.get(user)
 
       assert redirected_to(conn) == "/project"
       assert surfconext_user.userinfo["eduperson_affiliation"] == ["student"]
     end
 
-    test "handles duplicate email gracefully", %{conn: conn, conf: conf} do
-      # Create an existing user with a specific email
+    test "links a SURFconext satellite onto an existing email/password account", %{
+      conn: conn,
+      conf: conf
+    } do
       existing_email = "duplicate@example.com"
-      Core.Factories.insert!(:member, %{email: existing_email})
+      existing = Core.Factories.insert!(:member, %{email: existing_email, creator: true})
 
-      # Configure FakeOIDC to return a new SUB but with the same email
       conf =
         conf
         |> Keyword.put(:sub, "new-sso-user-different-sub")
@@ -226,11 +234,14 @@ defmodule Core.SurfConext.CallbackController.Test do
 
       Application.put_env(:core, Core.SurfConext, conf)
 
-      # Attempt SSO login - should redirect to signin with error, not crash
       conn = conn |> get("/auth/surfconext/callback")
 
-      assert redirected_to(conn) == "/user/signin"
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "already been taken"
+      assert redirected_to(conn) == "/project"
+
+      # Satellite is now attached to the existing user; identity is unchanged.
+      reloaded = Systems.Account.Public.get_user!(existing.id)
+      assert reloaded.email == existing_email
+      assert Core.SurfConext.get(reloaded) != nil
     end
 
     test "redirects to signin and logs error when session is missing" do

--- a/core/test/core/surfconext_test.exs
+++ b/core/test/core/surfconext_test.exs
@@ -1,114 +1,90 @@
 defmodule Core.SurfConext.Test do
   use Core.DataCase, async: true
-  import Frameworks.Signal.TestHelper
 
   alias Core.Factories
+  alias Core.SurfConext
 
-  describe "get_user_by_sub/1" do
-    test "get a user by their subject id" do
+  describe "user_attrs/1" do
+    test "maps proprietary fields to the normalized Account.User attrs" do
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "researcher@uva.nl",
+        "given_name" => "Re",
+        "family_name" => "Searcher"
+      }
+
+      attrs = SurfConext.user_attrs(userinfo)
+
+      assert attrs.email == "researcher@uva.nl"
+      assert attrs.displayname == "Re"
+      assert attrs.creator == true
+      assert attrs.fullname == "Re Searcher"
+      assert %NaiveDateTime{} = attrs.confirmed_at
+    end
+
+    test "displayname falls back to fullname when given_name is missing" do
+      userinfo = %{"sub" => "x", "email" => "x@uva.nl", "family_name" => "Only"}
+
+      attrs = SurfConext.user_attrs(userinfo)
+
+      assert attrs.displayname == "Only"
+    end
+
+    test "raises when email is missing" do
+      userinfo = %{"sub" => "x", "given_name" => "Re"}
+
+      assert_raise SurfConext.SurfConextError, fn -> SurfConext.user_attrs(userinfo) end
+    end
+  end
+
+  describe "get/1" do
+    test "returns the satellite linked to the user" do
       user = Factories.insert!(:member)
-      Repo.insert!(%Core.SurfConext.User{sub: "test", user: user})
+      satellite = Repo.insert!(%SurfConext.User{sub: "x", user: user})
 
-      loaded_user = Core.SurfConext.get_user_by_sub("test")
+      assert SurfConext.get(user).id == satellite.id
+    end
 
-      assert loaded_user.id == user.id
+    test "returns nil when the user has no satellite" do
+      user = Factories.insert!(:member)
+
+      assert SurfConext.get(user) == nil
     end
   end
 
-  describe "get_surfconext_user_by_user/1" do
-    test "get a surf conext user by a core user reference" do
-      core_user = Factories.insert!(:member)
-      surfconext_user = Repo.insert!(%Core.SurfConext.User{sub: "test", user: core_user})
+  describe "attach/2" do
+    test "inserts a satellite row linked to the user" do
+      user = Factories.insert!(:member, %{email: "researcher@uva.nl"})
 
-      loaded_surfconext_user = Core.SurfConext.get_surfconext_user_by_user(core_user)
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "researcher@uva.nl",
+        "given_name" => "Re"
+      }
 
-      assert loaded_surfconext_user.id == surfconext_user.id
+      {:ok, satellite} = SurfConext.attach(user, userinfo)
+
+      assert satellite.user_id == user.id
+      assert satellite.sub == userinfo["sub"]
+      assert satellite.email == "researcher@uva.nl"
+      assert satellite.userinfo == userinfo
     end
   end
 
-  describe "register_surfconext_user/1" do
-    test "fails to register: missing email" do
-      sso_info = %{
-        "sub" => Faker.UUID.v4(),
-        "given_name" => Faker.Person.name(),
-        "family_name" => Faker.Person.name()
-      }
+  describe "refresh/2" do
+    test "replaces userinfo on the existing satellite without touching sub or user" do
+      user = Factories.insert!(:member)
 
-      assert_raise Core.SurfConext.SurfConextError, fn ->
-        Core.SurfConext.register_user(sso_info)
-      end
-    end
+      original = %{"sub" => "stable", "email" => "first@uva.nl", "given_name" => "First"}
+      {:ok, before} = SurfConext.attach(user, original)
 
-    test "creates a user with a profile" do
-      sso_info = %{
-        "sub" => Faker.UUID.v4(),
-        "email" => Faker.Internet.email(),
-        "given_name" => Faker.Person.name(),
-        "family_name" => Faker.Person.name()
-      }
+      updated = %{"sub" => "stable", "email" => "second@uva.nl", "given_name" => "Second"}
+      refreshed = SurfConext.refresh(user, updated)
 
-      {:ok, surf_user} = Core.SurfConext.register_user(sso_info)
-
-      assert surf_user.sub == Map.get(sso_info, "sub")
-      assert surf_user.email == Map.get(sso_info, "email")
-      assert surf_user.userinfo == sso_info
-
-      assert surf_user.user.email == Map.get(sso_info, "email")
-      assert surf_user.user.displayname == "#{sso_info["given_name"]}"
-
-      assert surf_user.user.profile.fullname ==
-               "#{sso_info["given_name"]} #{sso_info["family_name"]}"
-    end
-
-    test "dispatches signal" do
-      isolate_signals()
-
-      sso_info = %{
-        "sub" => Faker.UUID.v4(),
-        "email" => Faker.Internet.email(),
-        "preferred_username" => Faker.Person.name()
-      }
-
-      {:ok, %{user: user}} = Core.SurfConext.register_user(sso_info)
-
-      message = assert_signal_dispatched({:user, :created})
-      assert %{user: ^user} = message
-    end
-  end
-
-  describe "update_surfconext_user/1" do
-    test "refreshes userinfo on re-authentication; sub/email columns are stable" do
-      sso_info1 = %{
-        "sub" => Faker.UUID.v4(),
-        "email" => Faker.Internet.email(),
-        "given_name" => Faker.Person.name(),
-        "family_name" => Faker.Person.name()
-      }
-
-      {:ok, surf_user1} = Core.SurfConext.register_user(sso_info1)
-
-      sso_info2 = %{
-        "sub" => Faker.UUID.v4(),
-        "email" => Faker.Internet.email(),
-        "given_name" => Faker.Person.name(),
-        "family_name" => Faker.Person.name()
-      }
-
-      surf_user2 = Core.SurfConext.update_user(surf_user1.user, sso_info2)
-      core_user2 = Systems.Account.Public.get_user!(surf_user2.user_id)
-      profile2 = Systems.Account.Public.get_profile(core_user2)
-
-      # userinfo is fully replaced
-      assert surf_user2.userinfo == sso_info2
-
-      # identity columns (sub/email) and the general user model are not touched
-      assert surf_user2.sub != sso_info2["sub"]
-      assert surf_user2.email != sso_info2["email"]
-      assert core_user2.email != sso_info2["email"]
-      assert core_user2.displayname != sso_info2["given_name"]
-
-      assert profile2.fullname !=
-               "#{sso_info2["given_name"]} #{sso_info2["family_name"]}"
+      assert refreshed.id == before.id
+      assert refreshed.user_id == user.id
+      assert refreshed.sub == "stable"
+      assert refreshed.userinfo == updated
     end
   end
 end

--- a/core/test/google_sign_in/plug_test.exs
+++ b/core/test/google_sign_in/plug_test.exs
@@ -115,12 +115,13 @@ defmodule GoogleSignIn.CallbackPlug.Test do
     end
 
     test "authenticates an existing user" do
-      email = Faker.Internet.email()
+      email = GoogleSignIn.FakeGoogle.email()
 
       given_name = Faker.Person.first_name()
       family_name = Faker.Person.last_name()
 
-      GoogleSignIn.register_user(
+      Core.Identity.authenticate(
+        GoogleSignIn,
         %{
           "sub" => GoogleSignIn.FakeGoogle.sub(),
           "name" => "#{given_name} #{family_name}",
@@ -131,7 +132,7 @@ defmodule GoogleSignIn.CallbackPlug.Test do
           "picture" => Faker.Internet.url(),
           "locale" => "en"
         },
-        true
+        %{creator: true}
       )
 
       user =

--- a/core/test/google_sign_in_test.exs
+++ b/core/test/google_sign_in_test.exs
@@ -3,43 +3,86 @@ defmodule GoogleSignIn.Test do
 
   alias Core.Factories
 
-  describe "get_user_by_sub/1" do
-    test "get a user by their subject id" do
-      user = Factories.insert!(:member)
-      Repo.insert!(%GoogleSignIn.User{sub: "test", user: user})
+  describe "user_attrs/1" do
+    test "maps proprietary fields to the normalized Account.User attrs" do
+      userinfo = %{
+        "sub" => Faker.UUID.v4(),
+        "email" => "user@example.com",
+        "given_name" => "Re",
+        "family_name" => "Searcher"
+      }
 
-      loaded_user = GoogleSignIn.get_user_by_sub("test")
+      attrs = GoogleSignIn.user_attrs(userinfo)
 
-      assert loaded_user.id == user.id
+      assert attrs.email == "user@example.com"
+      assert attrs.displayname == "Re"
+      assert attrs.fullname == "Re Searcher"
+      assert %NaiveDateTime{} = attrs.verified_at
+      refute Map.has_key?(attrs, :creator)
     end
   end
 
-  describe "register_google_sign_in_user/1" do
-    test "creates a user with a profile" do
-      given_name = Faker.Person.first_name()
-      family_name = Faker.Person.last_name()
+  describe "get/1" do
+    test "returns the satellite linked to the user" do
+      user = Factories.insert!(:member)
+      satellite = Repo.insert!(%GoogleSignIn.User{sub: "test", user: user})
 
-      sso_info = %{
+      assert GoogleSignIn.get(user).id == satellite.id
+    end
+
+    test "returns nil when the user has no satellite" do
+      user = Factories.insert!(:member)
+
+      assert GoogleSignIn.get(user) == nil
+    end
+  end
+
+  describe "attach/2" do
+    test "inserts a satellite row linked to the user" do
+      user = Factories.insert!(:member, %{email: "user@example.com"})
+
+      userinfo = %{
         "sub" => Faker.UUID.v4(),
-        "name" => "#{given_name} #{family_name}",
-        "email" => Faker.Internet.email(),
+        "email" => "user@example.com",
         "email_verified" => true,
-        "given_name" => given_name,
-        "family_name" => family_name,
-        "picture" => Faker.Internet.url(),
-        "locale" => "en"
+        "given_name" => "First",
+        "family_name" => "Last"
       }
 
-      {:ok, google_user} = GoogleSignIn.register_user(sso_info, false)
+      {:ok, satellite} = GoogleSignIn.attach(user, userinfo)
 
-      for key <- Map.keys(sso_info) do
-        assert Map.get(google_user, String.to_atom(key)) == Map.get(sso_info, key)
-      end
+      assert satellite.user_id == user.id
+      assert satellite.sub == userinfo["sub"]
+      assert satellite.email == "user@example.com"
+      assert satellite.email_verified == true
+    end
+  end
 
-      assert google_user.user.creator == false
-      assert google_user.user.email == Map.get(sso_info, "email")
-      assert google_user.user.displayname == "#{given_name}"
-      assert google_user.user.profile.fullname == "#{given_name} #{family_name}"
+  describe "refresh/2" do
+    test "replaces userinfo on the existing satellite without touching sub or user" do
+      user = Factories.insert!(:member)
+
+      original = %{
+        "sub" => "stable",
+        "email" => "first@example.com",
+        "given_name" => "First"
+      }
+
+      {:ok, before} = GoogleSignIn.attach(user, original)
+
+      updated = %{
+        "sub" => "stable",
+        "email" => "second@example.com",
+        "given_name" => "Second"
+      }
+
+      refreshed = GoogleSignIn.refresh(user, updated)
+
+      assert refreshed.id == before.id
+      assert refreshed.user_id == user.id
+      assert refreshed.sub == "stable"
+      assert refreshed.email == "second@example.com"
+      assert refreshed.given_name == "Second"
     end
   end
 end


### PR DESCRIPTION
## Summary

Signing in via SURFconext (or Google) with an email that already belongs to a regular email/password Eyra account used to fail with "email already taken". The IdP has already proven the user owns that address, so a link is the natural outcome — this PR does that, and along the way makes the flow federated-provider-agnostic.

**Behaviour change**
- SURFconext / Google sign-in whose email matches an existing Eyra account → the IdP satellite is silently attached to that account, the user is logged in.
- Fresh IdP identities still register a new Account.User as before.
- Repeat sign-ins refresh the satellite's userinfo (unchanged).

**Refactor**

The old `Core.SurfConext` and `GoogleSignIn` modules bundled schema ops with the "find user, register-or-link" orchestration. That orchestration is the same for every IdP, so it moves to one place:

- `Core.Identity` — the orchestrator, single owner of `authenticate/3`.
- `Core.Identity.Provider` — behaviour with four thin, user-centric callbacks: `user_attrs/1`, `get/1`, `attach/2`, `refresh/2`.
- `Core.SurfConext` and `GoogleSignIn` — minimal implementations (~50 lines each).
- `Systems.Account.Public.register_via_sso/1` — new entry point for federated registration; owns the User↔Profile schema split so IdP providers only ever see a flat attrs map.
- SurfConext and Google callback plugs shrink from ~50 to ~15 lines each.

Adding a new IdP is now: implement the four callbacks (~30 lines) + wire the OAuth plug.

Closes FX#10014797901 — https://3.basecamp.com/5734045/buckets/35926565/todos/10014797901

## Test plan

- [x] `mix test test/systems/account test/core` — 313/313 pass
- [x] Full identity/plug suites — 35/35 pass
- [x] `mix format` + `mix credo` + `mix dialyzer` clean
- [x] Unit tests cover: each provider callback, orchestrator `authenticate/3` scenarios (fresh register / link existing / refresh / register overrides), plug end-to-end callback with mocked OIDC
- [ ] Manual on staging: existing email/password researcher signs in via SURFconext — lands on `/project` with satellite attached, existing name/email preserved
- [ ] Manual on staging: fresh SURFconext user → registers + lands on `/user/onboarding`

🤖 Generated with [Claude Code](https://claude.com/claude-code)