### PR TITLE
feat(pool, account): pool-scoped join flow + reworked onboarding

### DIFF
--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -17,12 +17,17 @@ defmodule Next.Account.AuthCodeVerifyPage do
   @token_max_age 120
 
   @impl true
-  def mount(%{"email" => email}, _session, socket) do
+  def mount(%{"email" => email} = params, _session, socket) do
     if feature_enabled?(:otp) do
       {
         :ok,
         socket
-        |> assign(email: email, form: to_form(%{"code" => ""}), error: nil)
+        |> assign(
+          email: email,
+          form: to_form(%{"code" => ""}),
+          error: nil,
+          after_action: Map.get(params, "after")
+        )
         |> update_menus()
       }
     else
@@ -38,10 +43,11 @@ defmodule Next.Account.AuthCodeVerifyPage do
   @impl true
   def handle_event("verify", %{"code" => code}, %{assigns: %{email: email}} = socket) do
     code = String.trim(code)
+    after_action = socket.assigns[:after_action]
 
     case Account.Public.verify_otp(email, code) do
       {:ok, user} ->
-        payload = %{user_id: user && user.id, email: email}
+        payload = %{user_id: user && user.id, email: email, after: after_action}
         token = Phoenix.Token.sign(Endpoint, @token_salt, payload)
         {:noreply, redirect(socket, to: ~p"/user/auth/redeem?token=#{token}")}
 

--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -26,7 +26,7 @@ defmodule Next.Account.AuthCodeVerifyPage do
           email: email,
           form: to_form(%{"code" => ""}),
           error: nil,
-          after_action: Map.get(params, "after")
+          return_to: sanitize_return_to(Map.get(params, "return_to"))
         )
         |> update_menus()
       }
@@ -34,6 +34,9 @@ defmodule Next.Account.AuthCodeVerifyPage do
       {:ok, redirect(socket, to: ~p"/user/signin")}
     end
   end
+
+  defp sanitize_return_to("/" <> _rest = path), do: path
+  defp sanitize_return_to(_), do: nil
 
   def update_menus(%{assigns: %{current_user: user, uri: uri}} = socket) do
     menus = build_menus(stripped_menus_config(), user, uri)
@@ -43,11 +46,11 @@ defmodule Next.Account.AuthCodeVerifyPage do
   @impl true
   def handle_event("verify", %{"code" => code}, %{assigns: %{email: email}} = socket) do
     code = String.trim(code)
-    after_action = socket.assigns[:after_action]
+    return_to = socket.assigns[:return_to]
 
     case Account.Public.verify_otp(email, code) do
       {:ok, user} ->
-        payload = %{user_id: user && user.id, email: email, after: after_action}
+        payload = %{user_id: user && user.id, email: email, return_to: return_to}
         token = Phoenix.Token.sign(Endpoint, @token_salt, payload)
         {:noreply, redirect(socket, to: ~p"/user/auth/redeem?token=#{token}")}
 

--- a/core/bundles/next/lib/account/auth_page.ex
+++ b/core/bundles/next/lib/account/auth_page.ex
@@ -14,12 +14,17 @@ defmodule Next.Account.AuthPage do
   alias Systems.Account
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     if feature_enabled?(:otp) do
       {
         :ok,
         socket
-        |> assign(form: to_form(%{"email" => ""}), error: nil, loading: false)
+        |> assign(
+          form: to_form(%{"email" => ""}),
+          error: nil,
+          loading: false,
+          after_action: Map.get(params, "after")
+        )
         |> update_menus()
       }
     else
@@ -59,17 +64,19 @@ defmodule Next.Account.AuthPage do
 
   @impl true
   def handle_info({:route_email, email}, socket) do
+    after_action = socket.assigns[:after_action]
+
     case Account.EmailRouter.route(email) do
       :google ->
-        {:noreply, redirect(socket, to: "/auth/google?login_hint=#{URI.encode_www_form(email)}")}
+        {:noreply, redirect(socket, to: append_after(google_url(email), after_action))}
 
       :surfconext ->
-        {:noreply, redirect(socket, to: "/auth/surfconext")}
+        {:noreply, redirect(socket, to: append_after("/auth/surfconext", after_action))}
 
       :otp ->
         case Account.Public.generate_otp(email) do
           :ok ->
-            {:noreply, push_navigate(socket, to: ~p"/user/auth/verify?email=#{email}")}
+            {:noreply, push_navigate(socket, to: verify_url(email, after_action))}
 
           {:error, :rate_limited} ->
             {:noreply,
@@ -79,6 +86,20 @@ defmodule Next.Account.AuthPage do
              )}
         end
     end
+  end
+
+  defp google_url(email), do: "/auth/google?login_hint=#{URI.encode_www_form(email)}"
+
+  defp verify_url(email, nil), do: ~p"/user/auth/verify?email=#{email}"
+
+  defp verify_url(email, after_action),
+    do: ~p"/user/auth/verify?email=#{email}&after=#{after_action}"
+
+  defp append_after(url, nil), do: url
+
+  defp append_after(url, after_action) do
+    sep = if String.contains?(url, "?"), do: "&", else: "?"
+    "#{url}#{sep}after=#{URI.encode_www_form(after_action)}"
   end
 
   defp valid_email?(email), do: String.match?(email, ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/)

--- a/core/bundles/next/lib/account/auth_page.ex
+++ b/core/bundles/next/lib/account/auth_page.ex
@@ -23,7 +23,7 @@ defmodule Next.Account.AuthPage do
           form: to_form(%{"email" => ""}),
           error: nil,
           loading: false,
-          after_action: Map.get(params, "after")
+          return_to: sanitize_return_to(Map.get(params, "return_to"))
         )
         |> update_menus()
       }
@@ -31,6 +31,11 @@ defmodule Next.Account.AuthPage do
       {:ok, redirect(socket, to: ~p"/user/signin")}
     end
   end
+
+  # Only same-origin paths are accepted, so an attacker cannot craft a link
+  # that ends up bouncing the user to an external site after login.
+  defp sanitize_return_to("/" <> _rest = path), do: path
+  defp sanitize_return_to(_), do: nil
 
   def update_menus(%{assigns: %{current_user: user, uri: uri}} = socket) do
     menus = build_menus(stripped_menus_config(), user, uri)
@@ -64,19 +69,19 @@ defmodule Next.Account.AuthPage do
 
   @impl true
   def handle_info({:route_email, email}, socket) do
-    after_action = socket.assigns[:after_action]
+    return_to = socket.assigns[:return_to]
 
     case Account.EmailRouter.route(email) do
       :google ->
-        {:noreply, redirect(socket, to: append_after(google_url(email), after_action))}
+        {:noreply, redirect(socket, to: append_return_to(google_url(email), return_to))}
 
       :surfconext ->
-        {:noreply, redirect(socket, to: append_after("/auth/surfconext", after_action))}
+        {:noreply, redirect(socket, to: append_return_to("/auth/surfconext", return_to))}
 
       :otp ->
         case Account.Public.generate_otp(email) do
           :ok ->
-            {:noreply, push_navigate(socket, to: verify_url(email, after_action))}
+            {:noreply, push_navigate(socket, to: verify_url(email, return_to))}
 
           {:error, :rate_limited} ->
             {:noreply,
@@ -92,14 +97,14 @@ defmodule Next.Account.AuthPage do
 
   defp verify_url(email, nil), do: ~p"/user/auth/verify?email=#{email}"
 
-  defp verify_url(email, after_action),
-    do: ~p"/user/auth/verify?email=#{email}&after=#{after_action}"
+  defp verify_url(email, return_to),
+    do: ~p"/user/auth/verify?email=#{email}&return_to=#{return_to}"
 
-  defp append_after(url, nil), do: url
+  defp append_return_to(url, nil), do: url
 
-  defp append_after(url, after_action) do
+  defp append_return_to(url, return_to) do
     sep = if String.contains?(url, "?"), do: "&", else: "?"
-    "#{url}#{sep}after=#{URI.encode_www_form(after_action)}"
+    "#{url}#{sep}return_to=#{URI.encode_www_form(return_to)}"
   end
 
   defp valid_email?(email), do: String.match?(email, ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/)

--- a/core/bundles/next/lib/account/session_controller.ex
+++ b/core/bundles/next/lib/account/session_controller.ex
@@ -66,7 +66,9 @@ defmodule Next.Account.SessionController do
       {:ok, %{user_id: nil, email: email} = payload} ->
         case Account.Public.register_user_with_email(email) do
           {:ok, user} ->
-            Account.UserAuth.log_in_user(conn, user, true, log_in_params(payload))
+            conn
+            |> stash_return_to(payload)
+            |> Account.UserAuth.log_in_user(user, true)
 
           {:error, _changeset} ->
             conn
@@ -76,7 +78,10 @@ defmodule Next.Account.SessionController do
 
       {:ok, %{user_id: user_id} = payload} ->
         user = Account.Public.get_user!(user_id)
-        Account.UserAuth.log_in_user(conn, user, false, log_in_params(payload))
+
+        conn
+        |> stash_return_to(payload)
+        |> Account.UserAuth.log_in_user(user, false)
 
       _ ->
         conn
@@ -85,14 +90,14 @@ defmodule Next.Account.SessionController do
     end
   end
 
-  # Forwards the (signed) `after` action from the redeem token to
-  # `Account.UserAuth.log_in_user/4` so the landing page (onboarding for
-  # new users, home for existing users) gets it as `?after=…` and can
-  # surface the informed-consent UI.
-  defp log_in_params(%{after: after_action}) when is_binary(after_action) and after_action != "",
-    do: %{"after" => after_action}
+  # `log_in_user/4` reads `:user_return_to` from the session (via
+  # `redirect_path_after_signin/2`) before renewing the session, so
+  # placing it here honours the caller's intent for both new users
+  # (falls back to onboarding) and existing users (honoured).
+  defp stash_return_to(conn, %{return_to: "/" <> _rest = path}),
+    do: put_session(conn, :user_return_to, path)
 
-  defp log_in_params(_), do: %{}
+  defp stash_return_to(conn, _payload), do: conn
 
   defp render_new(conn) do
     redirect(conn, to: ~p"/user/signin")

--- a/core/bundles/next/lib/account/session_controller.ex
+++ b/core/bundles/next/lib/account/session_controller.ex
@@ -63,10 +63,10 @@ defmodule Next.Account.SessionController do
 
   defp do_redeem_otp(conn, token) do
     case Next.Account.AuthCodeVerifyPage.decode_redeem_token(token) do
-      {:ok, %{user_id: nil, email: email}} ->
+      {:ok, %{user_id: nil, email: email} = payload} ->
         case Account.Public.register_user_with_email(email) do
           {:ok, user} ->
-            Account.UserAuth.log_in_user(conn, user, true, %{})
+            Account.UserAuth.log_in_user(conn, user, true, log_in_params(payload))
 
           {:error, _changeset} ->
             conn
@@ -74,9 +74,9 @@ defmodule Next.Account.SessionController do
             |> redirect(to: ~p"/user/auth/identify")
         end
 
-      {:ok, %{user_id: user_id}} ->
+      {:ok, %{user_id: user_id} = payload} ->
         user = Account.Public.get_user!(user_id)
-        Account.UserAuth.log_in_user(conn, user, false, %{})
+        Account.UserAuth.log_in_user(conn, user, false, log_in_params(payload))
 
       _ ->
         conn
@@ -84,6 +84,15 @@ defmodule Next.Account.SessionController do
         |> redirect(to: ~p"/user/auth/identify")
     end
   end
+
+  # Forwards the (signed) `after` action from the redeem token to
+  # `Account.UserAuth.log_in_user/4` so the landing page (onboarding for
+  # new users, home for existing users) gets it as `?after=…` and can
+  # surface the informed-consent UI.
+  defp log_in_params(%{after: after_action}) when is_binary(after_action) and after_action != "",
+    do: %{"after" => after_action}
+
+  defp log_in_params(_), do: %{}
 
   defp render_new(conn) do
     redirect(conn, to: ~p"/user/signin")

--- a/core/lib/core/authorization.ex
+++ b/core/lib/core/authorization.ex
@@ -65,6 +65,7 @@ defmodule Core.Authorization do
   grant_access(Systems.Pool.DetailPage, [:creator])
   grant_access(Systems.Pool.LandingPage, [:visitor, :member, :owner])
   grant_access(Systems.Pool.MarketplacePage, [:visitor, :member, :owner])
+  grant_access(Systems.Pool.OnboardingPage, [:member])
   grant_access(Systems.Pool.ParticipantPage, [:creator])
   grant_access(Systems.Pool.SubmissionPage, [:creator])
   grant_access(Systems.Project.NodePage, [:owner])

--- a/core/lib/core_web/ui/area.ex
+++ b/core/lib/core_web/ui/area.ex
@@ -51,7 +51,7 @@ defmodule CoreWeb.UI.Area do
 
   def form(assigns) do
     ~H"""
-    <div class={"flex justify-center #{@class}"}>
+    <div class={"flex justify-center items-start #{@class}"}>
       <div class="flex-grow sm:max-w-form">
         <%= render_slot(@inner_block) %>
       </div>
@@ -64,7 +64,7 @@ defmodule CoreWeb.UI.Area do
 
   def sheet(assigns) do
     ~H"""
-    <div class={"flex justify-center #{@class}"}>
+    <div class={"flex justify-center items-start #{@class}"}>
       <div class="flex-grow sm:max-w-sheet">
         <%= render_slot(@inner_block) %>
       </div>

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -161,7 +161,7 @@ msgstr "Panl"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "profile.tab.profile.title"
-msgstr "Mein Konto"
+msgstr "Konto"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.continue.button"
@@ -169,7 +169,7 @@ msgstr "Weiter"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.hero.title"
-msgstr "Onboarding"
+msgstr "Willkommen"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.token.invalid"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
@@ -110,3 +110,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr ""

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
@@ -160,7 +160,7 @@ msgstr "Panl"
 
 #, elixir-autogen, elixir-format
 msgid "profile.tab.profile.title"
-msgstr "My profile"
+msgstr "Profile"
 
 #, elixir-autogen, elixir-format
 msgid "onboarding.continue.button"
@@ -168,7 +168,7 @@ msgstr "Continue"
 
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
-msgstr "Onboarding"
+msgstr "Welcome"
 
 #, elixir-autogen, elixir-format
 msgid "onboarding.token.invalid"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-pool.po
@@ -109,3 +109,19 @@ msgstr "Icon"
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr "Name"
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr "Join %{pool_name}"
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr "Would you like to join the %{pool_name} pool? Participants get invited to research studies and can earn rewards. You can leave the pool any time from your account settings."
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr "Not now"
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr "Join %{pool_name}"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-pool.po
@@ -116,7 +116,7 @@ msgstr "Join %{pool_name}"
 
 #, elixir-autogen, elixir-format
 msgid "join_consent.body"
-msgstr "Would you like to join the %{pool_name} pool? Participants get invited to research studies and can earn rewards. You can leave the pool any time from your account settings."
+msgstr "Would you like to join the %{pool_name} pool? Participants get invited to research studies and can earn rewards."
 
 #, elixir-autogen, elixir-format
 msgid "join_consent.decline.button"
@@ -125,3 +125,15 @@ msgstr "Not now"
 #, elixir-autogen, elixir-format
 msgid "join_consent.title"
 msgstr "Join %{pool_name}"
+
+#, elixir-autogen, elixir-format
+msgid "onboarding.hero.title"
+msgstr "Join %{pool_name}"
+
+#, elixir-autogen, elixir-format
+msgid "already_member.title"
+msgstr "You already joined %{pool_name}"
+
+#, elixir-autogen, elixir-format
+msgid "already_member.home.button"
+msgstr "Back to home"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -161,7 +161,7 @@ msgstr "Panl"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "profile.tab.profile.title"
-msgstr "Mi perfil"
+msgstr "Perfil"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.continue.button"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
@@ -110,3 +110,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr ""

--- a/core/priv/gettext/eyra-pool.pot
+++ b/core/priv/gettext/eyra-pool.pot
@@ -109,3 +109,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -161,7 +161,7 @@ msgstr "Panl"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "profile.tab.profile.title"
-msgstr "Il mio profilo"
+msgstr "Profilo"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.continue.button"
@@ -169,7 +169,7 @@ msgstr "Continua"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.hero.title"
-msgstr "Onboarding"
+msgstr "Benvenuto"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.token.invalid"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
@@ -110,3 +110,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr ""

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -170,7 +170,7 @@ msgstr "Panl"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "profile.tab.profile.title"
-msgstr "Mano paskyra"
+msgstr "Paskyra"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.continue.button"
@@ -178,7 +178,7 @@ msgstr "Tęsti"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.hero.title"
-msgstr "Pradžia"
+msgstr "Sveiki"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.token.invalid"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
@@ -110,3 +110,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr ""

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
@@ -160,7 +160,7 @@ msgstr "Panl"
 
 #, elixir-autogen, elixir-format
 msgid "profile.tab.profile.title"
-msgstr "Mijn profiel"
+msgstr "Profiel"
 
 #, elixir-autogen, elixir-format
 msgid "onboarding.continue.button"
@@ -168,7 +168,7 @@ msgstr "Doorgaan"
 
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
-msgstr "Onboarding"
+msgstr "Welkom"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.token.invalid"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-pool.po
@@ -109,3 +109,19 @@ msgstr "Icoon"
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr "Naam"
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr ""

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -170,7 +170,7 @@ msgstr "Panl"
 
 #, elixir-autogen, elixir-format
 msgid "profile.tab.profile.title"
-msgstr "Profilul meu"
+msgstr "Profil"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.continue.button"
@@ -178,7 +178,7 @@ msgstr "Continuă"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.hero.title"
-msgstr "Onboarding"
+msgstr "Bun venit"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "onboarding.token.invalid"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
@@ -110,3 +110,19 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "settings.name.label"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.accept.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.decline.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "join_consent.title"
+msgstr ""

--- a/core/systems/account/features_tab.ex
+++ b/core/systems/account/features_tab.ex
@@ -19,11 +19,13 @@ defmodule Systems.Account.FeaturesTab do
 
   @impl true
   def build(_user, live_context) do
+    features_context = LiveContext.extend(live_context, %{show_title: true})
+
     element =
       CoreWeb.Live.Element.prepare_live_view(
         :features_view,
         Account.FeaturesView,
-        live_context: live_context
+        live_context: features_context
       )
 
     %{

--- a/core/systems/account/features_view.ex
+++ b/core/systems/account/features_view.ex
@@ -11,7 +11,7 @@ defmodule Systems.Account.FeaturesView do
   alias Frameworks.Pixel.Text
   alias Systems.Account
 
-  def dependencies(), do: [:user_id]
+  def dependencies(), do: [:user_id, :show_title]
 
   def get_model(:not_mounted_at_router, _session, %{assigns: %{user_id: user_id}}) do
     user = Account.Public.get_user!(user_id)
@@ -72,27 +72,27 @@ defmodule Systems.Account.FeaturesView do
   def render(assigns) do
     ~H"""
     <div data-testid="features-view">
-      <Area.form>
+      <%= if @show_title do %>
         <Text.title2><%= @vm.title %></Text.title2>
-        <Text.body_medium><%= @vm.description %></Text.body_medium>
+      <% end %>
+      <Text.body_medium><%= @vm.description %></Text.body_medium>
 
-        <.spacing value="XL" />
+      <.spacing value="XL" />
 
-        <Text.title3><%= @vm.gender_title %></Text.title3>
-        <.element {Map.from_struct(@vm.gender_selector)} socket={@socket} />
+      <Text.title3><%= @vm.gender_title %></Text.title3>
+      <.element {Map.from_struct(@vm.gender_selector)} socket={@socket} />
 
-        <.spacing value="XL" />
+      <.spacing value="XL" />
 
-        <Text.title3><%= @vm.birth_year_title %></Text.title3>
-        <.spacing value="S" />
-        <.form :let={form} for={@vm.changeset} phx-change="change" phx-submit="submit">
-          <.number_input
-            form={form}
-            field={:birth_year}
-            label_text=""
-          />
-        </.form>
-      </Area.form>
+      <Text.title3><%= @vm.birth_year_title %></Text.title3>
+      <.spacing value="S" />
+      <.form :let={form} for={@vm.changeset} phx-change="change" phx-submit="submit">
+        <.number_input
+          form={form}
+          field={:birth_year}
+          label_text=""
+        />
+      </.form>
     </div>
     """
   end

--- a/core/systems/account/onboarding_page.ex
+++ b/core/systems/account/onboarding_page.ex
@@ -2,6 +2,10 @@ defmodule Systems.Account.OnboardingPage do
   @moduledoc """
   Onboarding page for new users (especially PANL participants).
   Shows required profile steps sequentially before allowing access to the app.
+
+  Honours `?return_to=/<path>` — after the last step (or a skip) the user is
+  sent to that URL instead of the default signed-in landing. Used by CTAs
+  that chain the user into a subsequent flow (e.g. `/pool/panl/join`).
   """
   use CoreWeb, :routed_live_view
   use CoreWeb.Layouts.Stripped.Composer
@@ -20,23 +24,40 @@ defmodule Systems.Account.OnboardingPage do
   end
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     {:ok,
      socket
      |> assign(
        current_step_index: 0,
-       modal_toolbar_buttons: []
+       modal_toolbar_buttons: [],
+       return_to: sanitize_return_to(Map.get(params, "return_to"))
      )}
   end
+
+  # Same-origin paths only, so a hostile CTA can't bounce the user to an
+  # external site after login.
+  defp sanitize_return_to("/" <> _rest = path), do: path
+  defp sanitize_return_to(_), do: nil
 
   @impl true
   def handle_view_model_updated(socket) do
     socket
   end
 
+  # Terms activated the user in the DB. Advance in-place instead of
+  # remounting via push_navigate — a remount would reset
+  # `current_step_index` to 0, and the builder (seeing an activated user)
+  # would collapse the step list from [:terms_and_privacy, :profile] to
+  # just [:profile], dropping the progress dots mid-flow.
   @impl true
-  def consume_event(%{name: :terms_completed}, socket) do
-    {:stop, socket |> push_navigate(to: ~p"/user/onboarding")}
+  def consume_event(
+        %{name: :terms_completed},
+        %{assigns: %{vm: %{current_step_index: idx}}} = socket
+      ) do
+    {:stop,
+     socket
+     |> assign(current_step_index: idx + 1)
+     |> update_view_model()}
   end
 
   @impl true
@@ -49,12 +70,12 @@ defmodule Systems.Account.OnboardingPage do
     } = socket
 
     if is_last_step do
-      {:noreply, socket |> push_navigate(to: Account.UserAuth.signed_in_path(user))}
+      {:noreply, socket |> push_navigate(to: post_onboarding_path(socket, user))}
     else
       next_step = Enum.at(steps, current_step_index + 1)
 
       if next_step == :activate_account and activated?(socket) do
-        {:noreply, socket |> push_navigate(to: Account.UserAuth.signed_in_path(user))}
+        {:noreply, socket |> push_navigate(to: post_onboarding_path(socket, user))}
       else
         {:noreply,
          socket
@@ -66,8 +87,14 @@ defmodule Systems.Account.OnboardingPage do
 
   @impl true
   def handle_event("skip", _params, %{assigns: %{current_user: user}} = socket) do
-    {:noreply, socket |> push_navigate(to: Account.UserAuth.signed_in_path(user))}
+    {:noreply, socket |> push_navigate(to: post_onboarding_path(socket, user))}
   end
+
+  defp post_onboarding_path(%{assigns: %{return_to: return_to}}, _user)
+       when is_binary(return_to),
+       do: return_to
+
+  defp post_onboarding_path(_socket, user), do: Account.UserAuth.signed_in_path(user)
 
   defp activated?(%{assigns: %{current_user: %{id: user_id}}}) do
     user_id
@@ -81,24 +108,36 @@ defmodule Systems.Account.OnboardingPage do
       <Area.content>
         <Margin.y id={:page_top} />
 
-        <%= if @vm.step_view do %>
-          <.element {Map.from_struct(@vm.step_view)} socket={@socket} />
-        <% end %>
-        <%= if @vm.step_title do %>
-          <div class="flex flex-col items-center" data-testid="activate-account-view">
-            <Text.title2>{@vm.step_title}</Text.title2>
-            <.spacing value="S" />
-            <Text.body align="text-center">{@vm.step_body}</Text.body>
-          </div>
-        <% end %>
+        <Area.sheet>
+          <%= if @vm.progress_dots do %>
+            <div class="flex flex-row gap-2 justify-center mt-8 mb-10" data-testid="account-onboarding-progress">
+              <%= for i <- 0..(@vm.progress_dots.total - 1) do %>
+                <div class={"w-2 h-2 rounded-full #{if i == @vm.progress_dots.current, do: "bg-primary", else: "bg-grey4"}"}></div>
+              <% end %>
+            </div>
+          <% end %>
+          <%= if @vm.hero_title do %>
+            <Text.title1>{@vm.hero_title}</Text.title1>
+            <.spacing value="L" />
+          <% end %>
+          <%= if @vm.step_view do %>
+            <.element {Map.from_struct(@vm.step_view)} socket={@socket} />
+          <% end %>
+          <%= if @vm.step_title do %>
+            <div data-testid="activate-account-view">
+              <Text.title2>{@vm.step_title}</Text.title2>
+              <.spacing value="S" />
+              <Text.body>{@vm.step_body}</Text.body>
+            </div>
+          <% end %>
 
-        <.spacing value="L" />
-
-        <%= if @vm.continue_button do %>
-          <div class="flex flex-row gap-4 justify-center">
-            <Button.dynamic {@vm.continue_button} testid="onboarding-continue" />
-          </div>
-        <% end %>
+          <%= if @vm.continue_button do %>
+            <.spacing value="L" />
+            <div class="flex flex-row gap-4 justify-start">
+              <Button.dynamic {@vm.continue_button} testid="onboarding-continue" />
+            </div>
+          <% end %>
+        </Area.sheet>
       </Area.content>
     </.stripped>
     """

--- a/core/systems/account/onboarding_page_builder.ex
+++ b/core/systems/account/onboarding_page_builder.ex
@@ -7,16 +7,21 @@ defmodule Systems.Account.OnboardingPageBuilder do
 
   alias Frameworks.Concept.LiveContext
   alias Systems.Account
-  alias Systems.Pool
 
   def view_model(%Account.User{email: email} = user, assigns) do
-    steps = build_steps(user)
     current_step_index = Map.get(assigns, :current_step_index, 0)
+    steps = build_steps(user, current_step_index)
     current_step = Enum.at(steps, current_step_index)
 
+    # `show_title: false` in the shared context means each step view drops
+    # its own title so the page-level `hero_title` is the sole visual
+    # anchor across the flow. Each callsite that mounts the same view
+    # outside the flow (e.g. Account settings tabs) passes
+    # `show_title: true`.
     live_context =
       LiveContext.new(%{
-        user_id: user.id
+        user_id: user.id,
+        show_title: false
       })
 
     step_view =
@@ -35,19 +40,32 @@ defmodule Systems.Account.OnboardingPageBuilder do
       step_title: build_step_title(current_step),
       step_body: build_step_body(current_step, email),
       is_last_step: current_step_index >= length(steps) - 1,
-      continue_button: build_continue_button(current_step)
+      continue_button: build_continue_button(current_step),
+      progress_dots: build_progress_dots(steps, current_step_index)
     }
   end
 
-  defp build_steps(user) do
-    steps = [:profile]
+  # Progress dots only appear for multi-step flows. A single-step flow
+  # (activated non-PANL user with just :profile) doesn't need them.
+  defp build_progress_dots(steps, index) when length(steps) > 1,
+    do: %{current: index, total: length(steps)}
 
-    steps =
-      if Pool.Public.participant?(:panl, user) do
-        steps ++ [:features]
-      else
-        steps
-      end
+  defp build_progress_dots(_steps, _index), do: nil
+
+  # Once we're past step 0 the flow is committed — a passwordless user who
+  # just accepted terms is now activated in the DB, but we still want to
+  # show them as being at step 2 of 2 in the same [:terms_and_privacy, :profile]
+  # flow. Same trick as `Pool.OnboardingPageBuilder.build_steps/3`.
+  defp build_steps(user, index) when index > 0 do
+    cond do
+      Account.Public.passwordless?(user) -> [:terms_and_privacy, :profile]
+      not Account.Public.activated?(user) -> [:profile, :activate_account]
+      true -> [:profile]
+    end
+  end
+
+  defp build_steps(user, 0) do
+    steps = [:profile]
 
     cond do
       Account.Public.activated?(user) ->
@@ -59,14 +77,6 @@ defmodule Systems.Account.OnboardingPageBuilder do
       true ->
         steps ++ [:activate_account]
     end
-  end
-
-  defp build_step_view(:features, _user, live_context) do
-    CoreWeb.Live.Element.prepare_live_view(
-      :features_view,
-      Account.FeaturesView,
-      live_context: live_context
-    )
   end
 
   defp build_step_view(:profile, _user, live_context) do

--- a/core/systems/account/page.ex
+++ b/core/systems/account/page.ex
@@ -84,6 +84,7 @@ defmodule Systems.Account.Page do
         items={@vm.items}
         tabbar_id={@tabbar_id}
         initial_item={@initial_item}
+        area_type={:sheet}
       />
     </.live_stripped>
     """
@@ -97,6 +98,7 @@ defmodule Systems.Account.Page do
         items={@vm.items}
         tabbar_id={@tabbar_id}
         initial_item={@initial_item}
+        area_type={:sheet}
       />
     </.live_workspace>
     """

--- a/core/systems/account/payouts_view.ex
+++ b/core/systems/account/payouts_view.ex
@@ -111,67 +111,64 @@ defmodule Systems.Account.PayoutsView do
   def render(assigns) do
     ~H"""
     <div data-testid="payouts-view">
-      <Area.content>
-        <.spacing value="L" />
-        <Text.title2><%= @vm.title %></Text.title2>
+      <Text.title2><%= @vm.title %></Text.title2>
 
-        <.spacing value="M" />
-        <Text.title3><%= @vm.bank.title %></Text.title3>
-        <.spacing value="XS" />
-        <.bank_status variant={@vm.bank.status_variant} label={@vm.bank.status_label} />
+      <.spacing value="M" />
+      <Text.title3><%= @vm.bank.title %></Text.title3>
+      <.spacing value="XS" />
+      <.bank_status variant={@vm.bank.status_variant} label={@vm.bank.status_label} />
+      <.spacing value="S" />
+      <Text.body><%= @vm.bank.intro %></Text.body>
+      <%= if @vm.bank.button do %>
         <.spacing value="S" />
-        <Text.body><%= @vm.bank.intro %></Text.body>
-        <%= if @vm.bank.button do %>
-          <.spacing value="S" />
-          <Button.dynamic {@vm.bank.button} />
-        <% end %>
+        <Button.dynamic {@vm.bank.button} />
+      <% end %>
 
-        <.spacing value="L" />
-        <div class="border-t border-grey4"></div>
-        <.spacing value="L" />
+      <.spacing value="L" />
+      <div class="border-t border-grey4"></div>
+      <.spacing value="L" />
 
-        <Text.title3><%= @vm.overview.title %></Text.title3>
-        <.spacing value="XS" />
-        <Text.body><%= @vm.overview.intro %></Text.body>
+      <Text.title3><%= @vm.overview.title %></Text.title3>
+      <.spacing value="XS" />
+      <Text.body><%= @vm.overview.intro %></Text.body>
+      <.spacing value="M" />
+
+      <%= if @vm.overview.empty? do %>
+        <Text.body><%= @vm.overview.empty_message %></Text.body>
+      <% else %>
+        <% selected = @selected_year || List.first(@vm.overview.years) %>
+        <div class="flex flex-row flex-wrap gap-3 items-center" data-testid="year-filter">
+          <%= for year <- @vm.overview.years do %>
+            <button
+              type="button"
+              phx-click="select_year"
+              phx-value-year={year}
+              class={[
+                "rounded-full px-6 py-3 text-label font-label select-none",
+                year == selected && "bg-primary text-white",
+                year != selected && "bg-grey5 text-grey2"
+              ]}
+            >
+              <%= year %>
+            </button>
+          <% end %>
+        </div>
         <.spacing value="M" />
+        <Text.title4>
+          <%= @vm.overview.total_label %>: <%= Map.get(@vm.overview.totals_by_year, selected) %>
+        </Text.title4>
+        <.spacing value="S" />
+        <Table.table
+          id="payouts-table"
+          layout={payout_table_layout()}
+          head_cells={@vm.overview.table_headers}
+          rows={Map.get(@vm.overview.rows_by_year, selected, [])}
+          border={false}
+          top_line?={true}
+        />
+      <% end %>
 
-        <%= if @vm.overview.empty? do %>
-          <Text.body><%= @vm.overview.empty_message %></Text.body>
-        <% else %>
-          <% selected = @selected_year || List.first(@vm.overview.years) %>
-          <div class="flex flex-row flex-wrap gap-3 items-center" data-testid="year-filter">
-            <%= for year <- @vm.overview.years do %>
-              <button
-                type="button"
-                phx-click="select_year"
-                phx-value-year={year}
-                class={[
-                  "rounded-full px-6 py-3 text-label font-label select-none",
-                  year == selected && "bg-primary text-white",
-                  year != selected && "bg-grey5 text-grey2"
-                ]}
-              >
-                <%= year %>
-              </button>
-            <% end %>
-          </div>
-          <.spacing value="M" />
-          <Text.title4>
-            <%= @vm.overview.total_label %>: <%= Map.get(@vm.overview.totals_by_year, selected) %>
-          </Text.title4>
-          <.spacing value="S" />
-          <Table.table
-            id="payouts-table"
-            layout={payout_table_layout()}
-            head_cells={@vm.overview.table_headers}
-            rows={Map.get(@vm.overview.rows_by_year, selected, [])}
-            border={false}
-            top_line?={true}
-          />
-        <% end %>
-
-        <.spacing value="XL" />
-      </Area.content>
+      <.spacing value="XL" />
     </div>
     """
   end

--- a/core/systems/account/profile_tab.ex
+++ b/core/systems/account/profile_tab.ex
@@ -22,7 +22,8 @@ defmodule Systems.Account.ProfileTab do
       LiveContext.extend(live_context, %{
         show_signout_button: true,
         show_email: true,
-        show_top_margin: true
+        show_top_margin: true,
+        show_title: true
       })
 
     element =

--- a/core/systems/account/profile_view.ex
+++ b/core/systems/account/profile_view.ex
@@ -12,7 +12,7 @@ defmodule Systems.Account.ProfileView do
   alias Frameworks.Pixel.Text
   alias Systems.Account
 
-  def dependencies(), do: [:user_id, :show_signout_button, :show_email]
+  def dependencies(), do: [:user_id, :show_signout_button, :show_email, :show_title]
 
   def get_model(:not_mounted_at_router, _session, %{assigns: %{user_id: user_id}}) do
     user = Account.Public.get_user!(user_id)
@@ -75,43 +75,43 @@ defmodule Systems.Account.ProfileView do
   def render(assigns) do
     ~H"""
     <div data-testid="profile-view">
-      <Area.form>
+      <%= if @show_title do %>
         <Text.title2><%= @vm.title %></Text.title2>
-        <div id="user_profile_content" phx-hook="LiveContent" data-show-errors={@show_errors}>
-          <.form id="main_form" :let={form} for={@vm.changeset} phx-submit="save" phx-change="save">
-            <.photo_input
-              static_path={&CoreWeb.Endpoint.static_path/1}
-              photo_url={@vm.photo_url}
-              uploads={@uploads}
-              primary_button_text={@vm.choose_photo_text}
-              secondary_button_text={@vm.choose_other_photo_text}
-            />
-            <.spacing value="M" />
-
-            <.text_input form={form} field={:fullname} label_text={@vm.fullname_label} />
-            <.text_input form={form} field={:displayname} label_text={@vm.displayname_label} />
-
-            <%= if @vm.user.creator do %>
-              <.text_input form={form} field={:title} label_text={@vm.title_label} />
-            <% end %>
-
-            <%= if @vm.show_email do %>
-              <Text.form_field_label id={:user_email_label}>
-                <%= @vm.email_label %>
-              </Text.form_field_label>
-              <div class="text-grey1 text-bodymedium font-body">
-                <%= @vm.user.email %>
-              </div>
-            <% end %>
-          </.form>
-        </div>
-        <%= if @vm.signout_button do %>
+      <% end %>
+      <div id="user_profile_content" phx-hook="LiveContent" data-show-errors={@show_errors}>
+        <.form id="main_form" :let={form} for={@vm.changeset} phx-submit="save" phx-change="save">
+          <.photo_input
+            static_path={&CoreWeb.Endpoint.static_path/1}
+            photo_url={@vm.photo_url}
+            uploads={@uploads}
+            primary_button_text={@vm.choose_photo_text}
+            secondary_button_text={@vm.choose_other_photo_text}
+          />
           <.spacing value="M" />
-          <div class="flex flex-row justify-start">
-            <Button.dynamic {@vm.signout_button} />
-          </div>
-        <% end %>
-      </Area.form>
+
+          <.text_input form={form} field={:fullname} label_text={@vm.fullname_label} />
+          <.text_input form={form} field={:displayname} label_text={@vm.displayname_label} />
+
+          <%= if @vm.user.creator do %>
+            <.text_input form={form} field={:title} label_text={@vm.title_label} />
+          <% end %>
+
+          <%= if @vm.show_email do %>
+            <Text.form_field_label id={:user_email_label}>
+              <%= @vm.email_label %>
+            </Text.form_field_label>
+            <div class="text-grey1 text-bodymedium font-body">
+              <%= @vm.user.email %>
+            </div>
+          <% end %>
+        </.form>
+      </div>
+      <%= if @vm.signout_button do %>
+        <.spacing value="M" />
+        <div class="flex flex-row justify-start">
+          <Button.dynamic {@vm.signout_button} />
+        </div>
+      <% end %>
     </div>
     """
   end

--- a/core/systems/account/terms_and_privacy_view.ex
+++ b/core/systems/account/terms_and_privacy_view.ex
@@ -19,7 +19,7 @@ defmodule Systems.Account.TermsAndPrivacyView do
 
   defp policy_url(key), do: @policy_urls[key]
 
-  def dependencies(), do: [:user_id]
+  def dependencies(), do: [:user_id, :show_title]
 
   def get_model(:not_mounted_at_router, _session, %{assigns: %{user_id: user_id}}) do
     Account.Public.get_user!(user_id)
@@ -66,9 +66,11 @@ defmodule Systems.Account.TermsAndPrivacyView do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col gap-8 items-center" data-testid="terms-and-privacy-view">
-      <Text.title2 align="text-center"><%= dgettext("eyra-account", "terms_and_privacy.onboarding.title") %></Text.title2>
-      <Text.body align="text-center"><%= dgettext("eyra-account", "terms_and_privacy.onboarding.body") %></Text.body>
+    <div class="flex flex-col gap-8" data-testid="terms-and-privacy-view">
+      <%= if @show_title do %>
+        <Text.title2><%= dgettext("eyra-account", "terms_and_privacy.onboarding.title") %></Text.title2>
+      <% end %>
+      <Text.body><%= dgettext("eyra-account", "terms_and_privacy.onboarding.body") %></Text.body>
       <div class="cursor-pointer" phx-click="toggle_terms" data-testid="terms-and-privacy-onboarding-terms">
         <SelectorItem.checkbox raw?={true} item={%{
           value: dgettext("eyra-account", "terms_and_privacy.onboarding.terms",

--- a/core/systems/account/user_auth.ex
+++ b/core/systems/account/user_auth.ex
@@ -34,6 +34,8 @@ defmodule Systems.Account.UserAuth do
         do: ~p"/user/onboarding",
         else: redirect_path_after_signin(conn, user)
 
+    redirect_to = append_after_action(redirect_to, params)
+
     conn
     |> renew_session()
     |> put_session(:user_token, token)
@@ -41,6 +43,14 @@ defmodule Systems.Account.UserAuth do
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: redirect_to)
   end
+
+  defp append_after_action(path, %{"after" => after_action})
+       when is_binary(after_action) and after_action != "" do
+    sep = if String.contains?(path, "?"), do: "&", else: "?"
+    "#{path}#{sep}after=#{URI.encode_www_form(after_action)}"
+  end
+
+  defp append_after_action(path, _params), do: path
 
   def log_in_user_without_redirect(conn, user) do
     token = Account.Public.generate_user_session_token(user)

--- a/core/systems/account/user_auth.ex
+++ b/core/systems/account/user_auth.ex
@@ -29,12 +29,17 @@ defmodule Systems.Account.UserAuth do
   def log_in_user(conn, user, first_time?, params \\ %{}) do
     token = Account.Public.generate_user_session_token(user)
 
+    # For first-time users, we always land on onboarding — but if the caller
+    # stashed a `:user_return_to` (e.g. an affiliate CTA that carried
+    # `?return_to=/pool/panl/join` into the OTP flow), we forward it as a URL
+    # param so onboarding can honour it on its final step. Existing users go
+    # straight to their return_to via `redirect_path_after_signin/2`.
     redirect_to =
-      if first_time?,
-        do: ~p"/user/onboarding",
-        else: redirect_path_after_signin(conn, user)
-
-    redirect_to = append_after_action(redirect_to, params)
+      if first_time? do
+        with_return_to(~p"/user/onboarding", get_session(conn, :user_return_to))
+      else
+        redirect_path_after_signin(conn, user)
+      end
 
     conn
     |> renew_session()
@@ -44,13 +49,12 @@ defmodule Systems.Account.UserAuth do
     |> redirect(to: redirect_to)
   end
 
-  defp append_after_action(path, %{"after" => after_action})
-       when is_binary(after_action) and after_action != "" do
-    sep = if String.contains?(path, "?"), do: "&", else: "?"
-    "#{path}#{sep}after=#{URI.encode_www_form(after_action)}"
-  end
+  defp with_return_to(path, nil), do: path
 
-  defp append_after_action(path, _params), do: path
+  defp with_return_to(path, return_to) when is_binary(return_to) do
+    sep = if String.contains?(path, "?"), do: "&", else: "?"
+    "#{path}#{sep}return_to=#{URI.encode_www_form(return_to)}"
+  end
 
   def log_in_user_without_redirect(conn, user) do
     token = Account.Public.generate_user_session_token(user)

--- a/core/systems/advert/_public.ex
+++ b/core/systems/advert/_public.ex
@@ -174,6 +174,18 @@ defmodule Systems.Advert.Public do
     |> Repo.preload(preload)
   end
 
+  def list_by_pool_and_status(%Pool.Model{id: pool_id}, status, opts \\ []) do
+    preload = Keyword.get(opts, :preload, [])
+
+    from(a in Advert.Model,
+      inner_join: ps in Pool.SubmissionModel,
+      on: ps.id == a.submission_id,
+      where: a.status == ^status and ps.pool_id == ^pool_id,
+      preload: ^preload
+    )
+    |> Repo.all()
+  end
+
   def list_excluded_user_ids(advert_ids) when is_list(advert_ids) do
     from(u in User,
       join: m in Crew.MemberModel,

--- a/core/systems/content/adaptable.ex
+++ b/core/systems/content/adaptable.ex
@@ -96,6 +96,10 @@ defmodule Systems.Content.Adaptable do
   attr(:initial_item, :any, default: nil)
   attr(:empty_state, :map, default: nil)
   attr(:toolbar_buttons, :list, default: [])
+  # Column width for the content area. Defaults to `:content` (uncapped, minus
+  # horizontal page margins). Callers with narrower content — e.g. the Account
+  # settings page — pass `:sheet` or `:form` so all tabs share one column.
+  attr(:area_type, :atom, default: :content)
 
   def layout(assigns) do
     assigns = assign(assigns, :layout_mode, determine_layout(assigns.items))
@@ -105,7 +109,7 @@ defmodule Systems.Content.Adaptable do
       <% :empty -> %>
         <.empty_layout empty_state={@empty_state} creatables={@creatables} />
       <% :single -> %>
-        <.single_layout socket={@socket} item={hd(@items)} creatables={@creatables} toolbar_buttons={@toolbar_buttons} />
+        <.single_layout socket={@socket} item={hd(@items)} creatables={@creatables} toolbar_buttons={@toolbar_buttons} area_type={@area_type} />
       <% :individual_tabs -> %>
         <.individual_tabs_layout
           socket={@socket}
@@ -114,6 +118,7 @@ defmodule Systems.Content.Adaptable do
           tabbar_id={@tabbar_id}
           initial_item={@initial_item}
           toolbar_buttons={@toolbar_buttons}
+          area_type={@area_type}
         />
       <% :grouped_tabs -> %>
         <.grouped_tabs_layout
@@ -122,6 +127,7 @@ defmodule Systems.Content.Adaptable do
           creatables={@creatables}
           tabbar_id={@tabbar_id}
           initial_item={@initial_item}
+          area_type={@area_type}
         />
     <% end %>
     """
@@ -165,11 +171,12 @@ defmodule Systems.Content.Adaptable do
   attr(:item, :map, required: true)
   attr(:creatables, :list, default: [])
   attr(:toolbar_buttons, :list, default: [])
+  attr(:area_type, :atom, default: :content)
 
   defp single_layout(assigns) do
     ~H"""
     <div>
-      <Area.content>
+      <Area.dynamic type={@area_type}>
         <Margin.y id={:page_top} />
         <.item_content socket={@socket} item={@item} />
         <%= if Enum.any?(@toolbar_buttons) do %>
@@ -178,7 +185,7 @@ defmodule Systems.Content.Adaptable do
             <Button.dynamic_bar buttons={@toolbar_buttons} />
           </div>
         <% end %>
-      </Area.content>
+      </Area.dynamic>
     </div>
     """
   end
@@ -190,6 +197,7 @@ defmodule Systems.Content.Adaptable do
   attr(:tabbar_id, :any, required: true)
   attr(:initial_item, :any, default: nil)
   attr(:toolbar_buttons, :list, default: [])
+  attr(:area_type, :atom, default: :content)
 
   defp individual_tabs_layout(assigns) do
     tabs = items_to_tabs(assigns.items)
@@ -201,7 +209,7 @@ defmodule Systems.Content.Adaptable do
       |> assign(:initial_tab, initial_tab)
 
     ~H"""
-    <Navigation.action_bar breadcrumbs={[]} right_bar_buttons={@toolbar_buttons}>
+    <Navigation.action_bar breadcrumbs={[]} right_bar_buttons={@toolbar_buttons} align={:center}>
       <Tabbed.bar
         id={@tabbar_id}
         tabs={@tabs}
@@ -211,10 +219,10 @@ defmodule Systems.Content.Adaptable do
         preserve_tab_in_url={true}
       />
     </Navigation.action_bar>
-    <Area.content>
+    <Area.dynamic type={@area_type}>
       <Margin.y id={:page_top} />
       <Tabbed.content socket={@socket} bar_id={@tabbar_id} tabs={@tabs} />
-    </Area.content>
+    </Area.dynamic>
     """
   end
 
@@ -224,6 +232,7 @@ defmodule Systems.Content.Adaptable do
   attr(:creatables, :list, default: [])
   attr(:tabbar_id, :any, required: true)
   attr(:initial_item, :any, default: nil)
+  attr(:area_type, :atom, default: :content)
 
   defp grouped_tabs_layout(assigns) do
     groups = group_items_by_type(assigns.items)
@@ -254,12 +263,13 @@ defmodule Systems.Content.Adaptable do
           data-tab-id={group_type}
           class="tab-panel hidden"
         >
-          <.group_content
+          <.group_body
             socket={@socket}
             group_type={group_type}
             items={group_items}
             creatables={filter_creatables(@creatables, group_type)}
             tabbar_id={"#{@tabbar_id}_#{group_type}"}
+            area_type={@area_type}
           />
         </div>
       <% end %>
@@ -273,8 +283,9 @@ defmodule Systems.Content.Adaptable do
   attr(:items, :list, required: true)
   attr(:creatables, :list, default: [])
   attr(:tabbar_id, :any, required: true)
+  attr(:area_type, :atom, default: :content)
 
-  defp group_content(assigns) do
+  defp group_body(assigns) do
     tabs = items_to_tabs(assigns.items)
     initial_tab = hd(assigns.items).id
 
@@ -297,10 +308,10 @@ defmodule Systems.Content.Adaptable do
           <.add_button creatables={@creatables} />
         <% end %>
       </div>
-      <Area.content>
+      <Area.dynamic type={@area_type}>
         <Margin.y id={:page_top} />
         <Tabbed.content socket={@socket} bar_id={@tabbar_id} tabs={@tabs} />
-      </Area.content>
+      </Area.dynamic>
     </div>
     """
   end

--- a/core/systems/content/html.ex
+++ b/core/systems/content/html.ex
@@ -289,6 +289,7 @@ defmodule Systems.Content.Html do
   attr(:initial_item, :any, default: nil)
   attr(:empty_state, :map, default: nil)
   attr(:toolbar_buttons, :list, default: [])
+  attr(:area_type, :atom, default: :content)
 
   def adaptable_layout(assigns) do
     Adaptable.layout(assigns)

--- a/core/systems/home/logged_in_view.ex
+++ b/core/systems/home/logged_in_view.ex
@@ -18,7 +18,7 @@ defmodule Systems.Home.LoggedInView do
   def render(assigns) do
     ~H"""
     <div>
-      <div class="bg-grey6 px-6 lg:px-8 py-6 lg:py-8">
+      <div class="px-6 lg:px-8 py-6 lg:py-8">
         <div class="space-y-6">
           <%= for {name, _} <- @blocks do %>
             <.child name={name} fabric={@fabric} />

--- a/core/systems/home/page.ex
+++ b/core/systems/home/page.ex
@@ -1,12 +1,7 @@
 defmodule Systems.Home.Page do
   use Systems.Content.Composer, :live_website
 
-  require Logger
-
   alias Systems.Home
-  alias Systems.Pool
-  alias Systems.Account
-  alias Frameworks.Signal
   alias Frameworks.Pixel.Hero
 
   @impl true
@@ -15,42 +10,12 @@ defmodule Systems.Home.Page do
   end
 
   @impl true
-  def mount(params, _session, socket) do
+  def mount(_params, _session, socket) do
     {
       :ok,
       socket
-      |> assign(join_pool: nil, after_action: nil)
       |> compose_child(:home_view)
-      |> maybe_show_join_pool_consent(params)
     }
-  end
-
-  # `?after=join_pool:<slug>` lands here after the OTP redeem (or any other
-  # flow that carries the param via `Account.UserAuth.log_in_user/4`). If
-  # the slug resolves to a real pool the user isn't already a member of,
-  # show the informed-consent modal.
-  defp maybe_show_join_pool_consent(
-         %{assigns: %{current_user: %Account.User{} = user}} = socket,
-         %{"after" => "join_pool:" <> slug = action}
-       ) do
-    with {:ok, slug_atom} <- safe_to_existing_atom(slug),
-         %Pool.Model{} = pool <- Pool.Public.get_by_slug(slug_atom),
-         false <- Pool.Public.participant?(pool, user) do
-      socket
-      |> assign(join_pool: pool, after_action: action)
-      |> compose_child(:join_pool_consent_modal)
-      |> Fabric.ModalController.show_modal(:join_pool_consent_modal, :compact)
-    else
-      _ -> socket
-    end
-  end
-
-  defp maybe_show_join_pool_consent(socket, _params), do: socket
-
-  defp safe_to_existing_atom(str) when is_binary(str) do
-    {:ok, String.to_existing_atom(str)}
-  rescue
-    ArgumentError -> :error
   end
 
   @impl true
@@ -70,15 +35,6 @@ defmodule Systems.Home.Page do
     }
   end
 
-  def compose(:join_pool_consent_modal, %{join_pool: %Pool.Model{} = pool}) do
-    %{
-      module: Pool.JoinConsentView,
-      params: %{pool: pool}
-    }
-  end
-
-  def compose(:join_pool_consent_modal, _assigns), do: nil
-
   @impl true
   def handle_view_model_updated(socket) do
     # FIXME: consider to move updates of childs to Fabric.LiveHook
@@ -89,28 +45,6 @@ defmodule Systems.Home.Page do
   # has to happen here (a routed LiveView), not inside the component's update/2.
   def handle_info(:payout_completed, socket) do
     {:noreply, push_navigate(socket, to: ~p"/user/account?tab=payouts")}
-  end
-
-  @impl true
-  def consume_event(
-        %{name: :accept, source: %{name: :join_pool_consent_modal}},
-        %{assigns: %{current_user: user, after_action: action}} = socket
-      )
-      when is_binary(action) do
-    Signal.Public.dispatch({:account, :post_signup}, %{user: user, action: action})
-
-    {:stop, socket |> close_join_consent_modal()}
-  end
-
-  def consume_event(%{name: :decline, source: %{name: :join_pool_consent_modal}}, socket) do
-    {:stop, socket |> close_join_consent_modal()}
-  end
-
-  defp close_join_consent_modal(socket) do
-    socket
-    |> Fabric.ModalController.hide_modal(:join_pool_consent_modal)
-    |> assign(join_pool: nil, after_action: nil)
-    |> push_patch(to: ~p"/")
   end
 
   @impl true

--- a/core/systems/home/page.ex
+++ b/core/systems/home/page.ex
@@ -1,7 +1,12 @@
 defmodule Systems.Home.Page do
   use Systems.Content.Composer, :live_website
 
+  require Logger
+
   alias Systems.Home
+  alias Systems.Pool
+  alias Systems.Account
+  alias Frameworks.Signal
   alias Frameworks.Pixel.Hero
 
   @impl true
@@ -10,12 +15,42 @@ defmodule Systems.Home.Page do
   end
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     {
       :ok,
       socket
+      |> assign(join_pool: nil, after_action: nil)
       |> compose_child(:home_view)
+      |> maybe_show_join_pool_consent(params)
     }
+  end
+
+  # `?after=join_pool:<slug>` lands here after the OTP redeem (or any other
+  # flow that carries the param via `Account.UserAuth.log_in_user/4`). If
+  # the slug resolves to a real pool the user isn't already a member of,
+  # show the informed-consent modal.
+  defp maybe_show_join_pool_consent(
+         %{assigns: %{current_user: %Account.User{} = user}} = socket,
+         %{"after" => "join_pool:" <> slug = action}
+       ) do
+    with {:ok, slug_atom} <- safe_to_existing_atom(slug),
+         %Pool.Model{} = pool <- Pool.Public.get_by_slug(slug_atom),
+         false <- Pool.Public.participant?(pool, user) do
+      socket
+      |> assign(join_pool: pool, after_action: action)
+      |> compose_child(:join_pool_consent_modal)
+      |> Fabric.ModalController.show_modal(:join_pool_consent_modal, :compact)
+    else
+      _ -> socket
+    end
+  end
+
+  defp maybe_show_join_pool_consent(socket, _params), do: socket
+
+  defp safe_to_existing_atom(str) when is_binary(str) do
+    {:ok, String.to_existing_atom(str)}
+  rescue
+    ArgumentError -> :error
   end
 
   @impl true
@@ -35,6 +70,15 @@ defmodule Systems.Home.Page do
     }
   end
 
+  def compose(:join_pool_consent_modal, %{join_pool: %Pool.Model{} = pool}) do
+    %{
+      module: Pool.JoinConsentView,
+      params: %{pool: pool}
+    }
+  end
+
+  def compose(:join_pool_consent_modal, _assigns), do: nil
+
   @impl true
   def handle_view_model_updated(socket) do
     # FIXME: consider to move updates of childs to Fabric.LiveHook
@@ -45,6 +89,28 @@ defmodule Systems.Home.Page do
   # has to happen here (a routed LiveView), not inside the component's update/2.
   def handle_info(:payout_completed, socket) do
     {:noreply, push_navigate(socket, to: ~p"/user/account?tab=payouts")}
+  end
+
+  @impl true
+  def consume_event(
+        %{name: :accept, source: %{name: :join_pool_consent_modal}},
+        %{assigns: %{current_user: user, after_action: action}} = socket
+      )
+      when is_binary(action) do
+    Signal.Public.dispatch({:account, :post_signup}, %{user: user, action: action})
+
+    {:stop, socket |> close_join_consent_modal()}
+  end
+
+  def consume_event(%{name: :decline, source: %{name: :join_pool_consent_modal}}, socket) do
+    {:stop, socket |> close_join_consent_modal()}
+  end
+
+  defp close_join_consent_modal(socket) do
+    socket
+    |> Fabric.ModalController.hide_modal(:join_pool_consent_modal)
+    |> assign(join_pool: nil, after_action: nil)
+    |> push_patch(to: ~p"/")
   end
 
   @impl true

--- a/core/systems/home/page_builder.ex
+++ b/core/systems/home/page_builder.ex
@@ -123,10 +123,12 @@ defmodule Systems.Home.PageBuilder do
   end
 
   defp block(:available_adverts, %Account.User{} = user, assigns, _opts) do
-    %Pool.Model{id: panl_id} = Pool.Public.get_panl()
+    %Pool.Model{id: panl_id} = panl = Pool.Public.get_panl()
 
     adverts =
-      Advert.Public.list_by_status(:online, preload: Advert.Model.preload_graph(:down))
+      Advert.Public.list_by_pool_and_status(panl, :online,
+        preload: Advert.Model.preload_graph(:down)
+      )
       |> Enum.filter(&(Advert.Public.validate_open(&1, user) == :ok))
 
     cards =

--- a/core/systems/pool/_routes.ex
+++ b/core/systems/pool/_routes.ex
@@ -3,6 +3,8 @@ defmodule Systems.Pool.Routes do
     quote do
       scope "/", Systems.Pool do
         pipe_through([:browser, :require_authenticated_user])
+        get("/pool/:slug/join", Controller, :join)
+        live("/pool/:slug/onboarding", OnboardingPage)
         live("/pool/:id", LandingPage)
         live("/pool/:id/content", ContentPage)
         live("/pool/:id/marketplace", MarketplacePage)

--- a/core/systems/pool/account_post_action_handler.ex
+++ b/core/systems/pool/account_post_action_handler.ex
@@ -12,11 +12,22 @@ defmodule Systems.Pool.AccountPostActionHandler do
 
   def handle(%Account.User{creator: true}, _action), do: :ok
 
+  # Legacy value from the pre-OTP signup flow; treat as a Panl-scoped join.
   def handle(%Account.User{} = user, "add_to_panl") do
-    if feature_enabled?(:panl) do
-      Pool.Public.add_user_to_panl_pool(user)
+    handle(user, "join_pool:panl")
+  end
+
+  def handle(%Account.User{} = user, "join_pool:" <> slug) do
+    with {:ok, slug_atom} <- safe_to_existing_atom(slug),
+         %Pool.Model{} = pool <- Pool.Public.get_by_slug(slug_atom) do
+      if pool.name == "Panl" and not feature_enabled?(:panl) do
+        Logger.info("Ignoring join_pool:#{slug} action: panl feature is disabled")
+      else
+        Pool.Public.add_participant!(pool, user)
+      end
     else
-      Logger.info("Ignoring add_to_panl action: panl feature is disabled")
+      _ ->
+        Logger.warning("Ignoring join_pool:#{slug} action: unknown pool slug")
     end
 
     :ok
@@ -28,5 +39,11 @@ defmodule Systems.Pool.AccountPostActionHandler do
     )
 
     :ok
+  end
+
+  defp safe_to_existing_atom(str) when is_binary(str) do
+    {:ok, String.to_existing_atom(str)}
+  rescue
+    ArgumentError -> :error
   end
 end

--- a/core/systems/pool/controller.ex
+++ b/core/systems/pool/controller.ex
@@ -1,0 +1,28 @@
+defmodule Systems.Pool.Controller do
+  @moduledoc """
+  Phoenix controller for Pool-scoped HTTP entry points that are not
+  themselves LiveViews.
+
+  Currently exposes:
+
+    * `join/2` — gate at `/pool/:slug/join`. Resolves the slug, checks
+      whether the current user is already a participant, and either
+      forwards to the pool-scoped onboarding LiveView or redirects
+      home.
+  """
+  use CoreWeb, {:controller, [formats: [:html]]}
+
+  alias Systems.Pool
+  alias Systems.Account
+
+  def join(conn, %{"slug" => slug}) do
+    user = conn.assigns.current_user
+    %Pool.Model{} = pool = Pool.Public.get_by_slug(String.to_existing_atom(slug))
+
+    if Pool.Public.participant?(pool, user) do
+      redirect(conn, to: Account.UserAuth.signed_in_path(user))
+    else
+      redirect(conn, to: ~p"/pool/#{slug}/onboarding")
+    end
+  end
+end

--- a/core/systems/pool/join_consent_view.ex
+++ b/core/systems/pool/join_consent_view.ex
@@ -1,0 +1,79 @@
+defmodule Systems.Pool.JoinConsentView do
+  @moduledoc """
+  Informed-consent view for joining a pool.
+
+  Renders a short "would you like to join this pool?" prompt with accept and
+  decline actions. Publishes `:accept` on accept and `:decline` on decline;
+  the parent handles the actual join (typically by dispatching
+  `{:account, :post_signup}` with `"join_pool:<slug>"`) and manages its own
+  container UI (close the modal, advance the onboarding step, …).
+
+  Soft consent only — no signed record is created. If the pool ever needs a
+  proper signed agreement, wrap `Systems.Consent.ClickWrapView` instead.
+  """
+  use CoreWeb.LiveForm
+  import LiveNest.Event.Publisher, only: [publish_event: 2]
+
+  @impl true
+  def update(%{id: id, pool: pool}, socket) do
+    {
+      :ok,
+      socket
+      |> assign(id: id, pool: pool)
+      |> update_buttons()
+    }
+  end
+
+  defp update_buttons(%{assigns: %{myself: myself, pool: pool}} = socket) do
+    accept_button = %{
+      action: %{type: :send, event: "accept", target: myself},
+      face: %{
+        type: :primary,
+        label: dgettext("eyra-pool", "join_consent.accept.button", pool_name: pool.name)
+      },
+      testid: "pool-join-consent-accept-button"
+    }
+
+    decline_button = %{
+      action: %{type: :send, event: "decline", target: myself},
+      face: %{
+        type: :label,
+        label: dgettext("eyra-pool", "join_consent.decline.button")
+      },
+      testid: "pool-join-consent-decline-button"
+    }
+
+    assign(socket, buttons: [accept_button, decline_button])
+  end
+
+  @impl true
+  def handle_event("accept", _payload, socket) do
+    {:noreply, socket |> publish_event(:accept)}
+  end
+
+  @impl true
+  def handle_event("decline", _payload, socket) do
+    {:noreply, socket |> publish_event(:decline)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div data-testid="pool-join-consent-view">
+      <Text.title2>
+        <%= dgettext("eyra-pool", "join_consent.title", pool_name: @pool.name) %>
+      </Text.title2>
+      <.spacing value="M" />
+      <Text.body>
+        <%= dgettext("eyra-pool", "join_consent.body", pool_name: @pool.name) %>
+      </Text.body>
+      <.spacing value="L" />
+      <div class="flex flex-row gap-4">
+        <%= for button <- @buttons do %>
+          <Button.dynamic {button} />
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/core/systems/pool/join_consent_view.ex
+++ b/core/systems/pool/join_consent_view.ex
@@ -15,11 +15,15 @@ defmodule Systems.Pool.JoinConsentView do
   import LiveNest.Event.Publisher, only: [publish_event: 2]
 
   @impl true
-  def update(%{id: id, pool: pool}, socket) do
+  def update(%{id: id, pool: pool} = assigns, socket) do
     {
       :ok,
       socket
-      |> assign(id: id, pool: pool)
+      |> assign(
+        id: id,
+        pool: pool,
+        show_title: Map.get(assigns, :show_title, true)
+      )
       |> update_buttons()
     }
   end
@@ -60,10 +64,12 @@ defmodule Systems.Pool.JoinConsentView do
   def render(assigns) do
     ~H"""
     <div data-testid="pool-join-consent-view">
-      <Text.title2>
-        <%= dgettext("eyra-pool", "join_consent.title", pool_name: @pool.name) %>
-      </Text.title2>
-      <.spacing value="M" />
+      <%= if @show_title do %>
+        <Text.title2>
+          <%= dgettext("eyra-pool", "join_consent.title", pool_name: @pool.name) %>
+        </Text.title2>
+        <.spacing value="M" />
+      <% end %>
       <Text.body>
         <%= dgettext("eyra-pool", "join_consent.body", pool_name: @pool.name) %>
       </Text.body>

--- a/core/systems/pool/onboarding_page.ex
+++ b/core/systems/pool/onboarding_page.ex
@@ -1,0 +1,126 @@
+defmodule Systems.Pool.OnboardingPage do
+  @moduledoc """
+  Pool-scoped onboarding at `/pool/:slug/onboarding`.
+
+  Reached through `Systems.Pool.Controller.join/2`, which acts as the
+  gate: it resolves the slug and checks participation before forwarding
+  here. This page trusts that gate — it does not re-check participation
+  and does not redirect from `mount/3`. An invalid slug crashes with
+  `Ecto.NoResultsError`, which Phoenix renders as 404.
+
+  Mirrors `Systems.Account.OnboardingPage`: a builder produces the
+  ordered `:steps` and the current step's `step_view` element (plus an
+  optional page-level continue button); the page renders them via
+  `<.element>` and progresses either via `consume_event` (for steps
+  whose view publishes events, like `:join_consent`) or `handle_event`
+  (for steps advanced by the continue button, like `:features`).
+
+  Steps:
+
+    * `:join_consent` — `Pool.JoinConsentView` publishes `:accept` or
+      `:decline`. Accept adds the user as a participant and advances
+      to `:features`; decline skips remaining steps and goes home.
+    * `:features` — `Account.FeaturesView` (embedded LiveView) captures
+      gender / birth year. A page-level continue button advances.
+    * `:already_member` — static info block; no interaction.
+  """
+  use CoreWeb, :routed_live_view
+  use CoreWeb.Layouts.Stripped.Composer
+
+  import LiveNest.HTML
+
+  alias Frameworks.Pixel.Button
+  alias Frameworks.Pixel.Text
+  alias Systems.Pool
+
+  on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
+
+  @impl true
+  def get_model(%{"slug" => slug}, _session, _socket) do
+    Pool.Public.get_by_slug(String.to_existing_atom(slug))
+  end
+
+  @impl true
+  def mount(_params, _session, socket), do: {:ok, socket}
+
+  @impl true
+  def consume_event(
+        %{name: :accept},
+        %{assigns: %{current_user: user, model: %Pool.Model{} = pool}} = socket
+      ) do
+    Pool.Public.add_participant!(pool, user)
+
+    {:stop, socket |> advance_or_finish()}
+  end
+
+  # Decline short-circuits the remaining steps: features is only
+  # meaningful for someone who has just joined, so a declined user
+  # goes straight home.
+  def consume_event(
+        %{name: :decline},
+        %{assigns: %{vm: %{finish_path: finish_path}}} = socket
+      ) do
+    {:stop, socket |> push_navigate(to: finish_path)}
+  end
+
+  @impl true
+  def handle_event("continue", _params, socket) do
+    {:noreply, socket |> advance_or_finish()}
+  end
+
+  defp advance_or_finish(
+         %{assigns: %{vm: %{is_last_step: true, finish_path: finish_path}}} = socket
+       ) do
+    push_navigate(socket, to: finish_path)
+  end
+
+  defp advance_or_finish(%{assigns: %{vm: %{current_step_index: idx}}} = socket) do
+    socket
+    |> assign(current_step_index: idx + 1)
+    |> update_view_model()
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.stripped menus={@menus}>
+      <Area.content>
+        <Margin.y id={:page_top} />
+
+        <Area.sheet>
+          <%= if @vm.progress_dots do %>
+            <div class="flex flex-row gap-2 justify-center mt-8 mb-10" data-testid="pool-onboarding-progress">
+              <%= for i <- 0..(@vm.progress_dots.total - 1) do %>
+                <div class={"w-2 h-2 rounded-full #{if i == @vm.progress_dots.current, do: "bg-primary", else: "bg-grey4"}"}></div>
+              <% end %>
+            </div>
+          <% end %>
+          <%= if @vm.hero_title do %>
+            <Text.title1>{@vm.hero_title}</Text.title1>
+            <.spacing value="L" />
+          <% end %>
+          <%= if @vm.step_view do %>
+            <.element {Map.from_struct(@vm.step_view)} socket={@socket} />
+          <% end %>
+          <%= if @vm.step_title do %>
+            <div data-testid="pool-already-member-view">
+              <Text.title2>{@vm.step_title}</Text.title2>
+              <%= if @vm.step_body do %>
+                <.spacing value="S" />
+                <Text.body>{@vm.step_body}</Text.body>
+              <% end %>
+            </div>
+          <% end %>
+
+          <%= if @vm.continue_button do %>
+            <.spacing value="L" />
+            <div class="flex flex-row gap-4 justify-start">
+              <Button.dynamic {@vm.continue_button} testid="pool-onboarding-continue" />
+            </div>
+          <% end %>
+        </Area.sheet>
+      </Area.content>
+    </.stripped>
+    """
+  end
+end

--- a/core/systems/pool/onboarding_page_builder.ex
+++ b/core/systems/pool/onboarding_page_builder.ex
@@ -1,0 +1,148 @@
+defmodule Systems.Pool.OnboardingPageBuilder do
+  @moduledoc """
+  View model builder for `Systems.Pool.OnboardingPage`. Mirrors the shape
+  of `Systems.Account.OnboardingPageBuilder` for the page-owned parts
+  (steps + current step_view + optional info block + continue button),
+  so both pages can share render conventions.
+
+  The step list is participation-aware:
+
+    * Non-participant → `[:join_consent, :features]` — first the
+      consent screen (renders `Pool.JoinConsentView`), then the features
+      form (renders `Account.FeaturesView`) to capture pool-relevant
+      participant attributes like gender and birth year. Features used
+      to live in the Account onboarding but is now pool-scoped, since
+      it's only meaningful for someone who has just joined a pool.
+    * Participant → `[:already_member]` — renders a static info
+      block via `step_title` / `step_body`. No step_view is attached
+      because there is nothing to interact with (yet — a leave-pool
+      action is likely to be added here later).
+  """
+  use Gettext, backend: CoreWeb.Gettext
+
+  alias Frameworks.Concept.LiveContext
+  alias Systems.Pool
+  alias Systems.Account
+
+  def view_model(%Pool.Model{} = pool, assigns) do
+    current_step_index = Map.get(assigns, :current_step_index, 0)
+    user = Map.get(assigns, :current_user)
+    steps = build_steps(pool, user, current_step_index)
+    current_step = Enum.at(steps, current_step_index)
+    live_context = build_live_context(user)
+
+    %{
+      pool: pool,
+      steps: steps,
+      current_step_index: current_step_index,
+      current_step: current_step,
+      step_view: build_step_view(current_step, pool, live_context),
+      step_title: build_step_title(current_step, pool),
+      step_body: build_step_body(current_step, pool),
+      continue_button: build_continue_button(current_step),
+      is_last_step: current_step_index >= length(steps) - 1,
+      finish_path: build_finish_path(user),
+      hero_title: build_hero_title(current_step, pool),
+      progress_dots: build_progress_dots(steps, current_step_index)
+    }
+  end
+
+  # Progress dots are only meaningful for multi-step flows. A one-step
+  # terminal screen like `:already_member` doesn't get one.
+  defp build_progress_dots(steps, index) when length(steps) > 1,
+    do: %{current: index, total: length(steps)}
+
+  defp build_progress_dots(_steps, _index), do: nil
+
+  # One flow-level title anchors :join_consent + :features so the steps
+  # feel like one journey. The terminal :already_member screen has its
+  # own step_title and doesn't get a hero.
+  defp build_hero_title(:already_member, _pool), do: nil
+
+  defp build_hero_title(_step, %Pool.Model{name: name}),
+    do: dgettext("eyra-pool", "onboarding.hero.title", pool_name: name)
+
+  # Where the flow exits — the user's signed-in landing. Owned by the
+  # builder so the page never has to know the URL scheme; a decline or
+  # a "continue" on the last step just reads `vm.finish_path`.
+  defp build_finish_path(%Account.User{} = user), do: Account.UserAuth.signed_in_path(user)
+  defp build_finish_path(_), do: "/"
+
+  # `show_title: false` hides each step view's own title so the page-level
+  # `hero_title` is the sole visual anchor across the flow.
+  defp build_live_context(%Account.User{id: user_id}),
+    do: LiveContext.new(%{user_id: user_id, show_title: false})
+
+  defp build_live_context(_), do: nil
+
+  # Once the user is past step 0, they've opted into the join flow —
+  # the step list is committed, even if accepting the consent already
+  # flipped them into a real DB participant. Only at index 0 do we
+  # consult the DB to choose between the join flow and the
+  # "you're already a member" screen.
+  defp build_steps(_pool, _user, index) when index > 0, do: [:join_consent, :features]
+
+  defp build_steps(%Pool.Model{} = pool, %Account.User{} = user, 0) do
+    if Pool.Public.participant?(pool, user) do
+      [:already_member]
+    else
+      [:join_consent, :features]
+    end
+  end
+
+  defp build_steps(_pool, _user, 0), do: [:join_consent, :features]
+
+  defp build_step_view(:join_consent, %Pool.Model{} = pool, _live_context) do
+    LiveNest.Element.prepare_live_component(
+      :join_consent,
+      Pool.JoinConsentView,
+      id: :join_consent,
+      pool: pool,
+      show_title: false
+    )
+  end
+
+  defp build_step_view(:features, _pool, %LiveContext{} = live_context) do
+    CoreWeb.Live.Element.prepare_live_view(
+      :features_view,
+      Account.FeaturesView,
+      live_context: live_context
+    )
+  end
+
+  defp build_step_view(_, _, _), do: nil
+
+  defp build_step_title(:already_member, %Pool.Model{name: name}) do
+    dgettext("eyra-pool", "already_member.title", pool_name: name)
+  end
+
+  defp build_step_title(_, _), do: nil
+
+  defp build_step_body(_, _), do: nil
+
+  # Join consent has its own accept/decline buttons. Features and
+  # already_member both need a page-level exit button — features to
+  # advance to the finish, already_member to give the user a way back
+  # to home instead of being stranded on an informational screen.
+  defp build_continue_button(:features) do
+    %{
+      action: %{type: :send, event: "continue"},
+      face: %{
+        type: :primary,
+        label: dgettext("eyra-account", "onboarding.continue.button")
+      }
+    }
+  end
+
+  defp build_continue_button(:already_member) do
+    %{
+      action: %{type: :send, event: "continue"},
+      face: %{
+        type: :primary,
+        label: dgettext("eyra-pool", "already_member.home.button")
+      }
+    }
+  end
+
+  defp build_continue_button(_), do: nil
+end

--- a/core/test/bundles/next/account/session_controller_test.exs
+++ b/core/test/bundles/next/account/session_controller_test.exs
@@ -1,0 +1,83 @@
+defmodule Next.Account.SessionControllerTest do
+  @moduledoc """
+  Integration coverage for the redeem step of the email-first OTP flow.
+  """
+  use CoreWeb.ConnCase, async: false
+  use Core.FeatureFlags.Test
+
+  alias CoreWeb.Endpoint
+  alias Next.Account.AuthCodeVerifyPage
+
+  @token_salt "otp-redeem"
+
+  setup %{conn: conn} do
+    set_feature_flag(:otp, true)
+    %{conn: conn}
+  end
+
+  describe "GET /user/auth/redeem — new user, no after action" do
+    test "registers, logs in, and lands on /user/onboarding", %{conn: conn} do
+      email = "fresh-#{Faker.UUID.v4()}@example.com"
+
+      token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: nil,
+          email: email,
+          after: nil
+        })
+
+      conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
+
+      assert redirected_to(conn) == "/user/onboarding"
+    end
+  end
+
+  describe "GET /user/auth/redeem — new user, with after action" do
+    test "lands on /user/onboarding?after=<action>", %{conn: conn} do
+      email = "fresh-#{Faker.UUID.v4()}@example.com"
+
+      token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: nil,
+          email: email,
+          after: "join_pool:panl"
+        })
+
+      conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
+
+      assert redirected_to(conn) == "/user/onboarding?after=join_pool%3Apanl"
+    end
+  end
+
+  describe "GET /user/auth/redeem — existing user, with after action" do
+    test "lands on the post-signin destination with ?after=<action> appended", %{conn: conn} do
+      user =
+        Factories.insert!(:member, %{
+          email: "existing-#{Faker.UUID.v4()}@example.com",
+          creator: false,
+          confirmed_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        })
+
+      token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: user.id,
+          email: user.email,
+          after: "join_pool:panl"
+        })
+
+      conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
+
+      redirected = redirected_to(conn)
+      assert redirected =~ "after=join_pool%3Apanl"
+    end
+  end
+
+  describe "AuthCodeVerifyPage.decode_redeem_token/1" do
+    test "roundtrips :after alongside :user_id and :email" do
+      payload = %{user_id: 42, email: "x@example.com", after: "join_pool:panl"}
+      token = Phoenix.Token.sign(Endpoint, @token_salt, payload)
+
+      assert {:ok, ^payload} = AuthCodeVerifyPage.decode_redeem_token(token)
+    end
+  end
+end

--- a/core/test/bundles/next/account/session_controller_test.exs
+++ b/core/test/bundles/next/account/session_controller_test.exs
@@ -15,7 +15,7 @@ defmodule Next.Account.SessionControllerTest do
     %{conn: conn}
   end
 
-  describe "GET /user/auth/redeem — new user, no after action" do
+  describe "GET /user/auth/redeem — new user, no return_to" do
     test "registers, logs in, and lands on /user/onboarding", %{conn: conn} do
       email = "fresh-#{Faker.UUID.v4()}@example.com"
 
@@ -23,7 +23,7 @@ defmodule Next.Account.SessionControllerTest do
         Phoenix.Token.sign(Endpoint, @token_salt, %{
           user_id: nil,
           email: email,
-          after: nil
+          return_to: nil
         })
 
       conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
@@ -32,25 +32,30 @@ defmodule Next.Account.SessionControllerTest do
     end
   end
 
-  describe "GET /user/auth/redeem — new user, with after action" do
-    test "lands on /user/onboarding?after=<action>", %{conn: conn} do
+  describe "GET /user/auth/redeem — new user, with return_to" do
+    # New users always land on /user/onboarding first; the return_to is
+    # preserved as a URL param so onboarding can chain the user into the
+    # requested destination when the flow finishes.
+    test "lands on /user/onboarding?return_to=<path>", %{conn: conn} do
       email = "fresh-#{Faker.UUID.v4()}@example.com"
 
       token =
         Phoenix.Token.sign(Endpoint, @token_salt, %{
           user_id: nil,
           email: email,
-          after: "join_pool:panl"
+          return_to: "/pool/panl/join"
         })
 
       conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
 
-      assert redirected_to(conn) == "/user/onboarding?after=join_pool%3Apanl"
+      assert redirected_to(conn) == "/user/onboarding?return_to=%2Fpool%2Fpanl%2Fjoin"
     end
   end
 
-  describe "GET /user/auth/redeem — existing user, with after action" do
-    test "lands on the post-signin destination with ?after=<action> appended", %{conn: conn} do
+  describe "GET /user/auth/redeem — existing user, with return_to" do
+    # Existing users go straight to the return_to destination — no
+    # onboarding stop needed.
+    test "lands on the return_to path directly", %{conn: conn} do
       user =
         Factories.insert!(:member, %{
           email: "existing-#{Faker.UUID.v4()}@example.com",
@@ -62,19 +67,18 @@ defmodule Next.Account.SessionControllerTest do
         Phoenix.Token.sign(Endpoint, @token_salt, %{
           user_id: user.id,
           email: user.email,
-          after: "join_pool:panl"
+          return_to: "/pool/panl/join"
         })
 
       conn = get(conn, ~p"/user/auth/redeem?token=#{token}")
 
-      redirected = redirected_to(conn)
-      assert redirected =~ "after=join_pool%3Apanl"
+      assert redirected_to(conn) == "/pool/panl/join"
     end
   end
 
   describe "AuthCodeVerifyPage.decode_redeem_token/1" do
-    test "roundtrips :after alongside :user_id and :email" do
-      payload = %{user_id: 42, email: "x@example.com", after: "join_pool:panl"}
+    test "roundtrips :return_to alongside :user_id and :email" do
+      payload = %{user_id: 42, email: "x@example.com", return_to: "/pool/panl/join"}
       token = Phoenix.Token.sign(Endpoint, @token_salt, payload)
 
       assert {:ok, ^payload} = AuthCodeVerifyPage.decode_redeem_token(token)

--- a/core/test/systems/account/features_view_test.exs
+++ b/core/test/systems/account/features_view_test.exs
@@ -21,7 +21,8 @@ defmodule Systems.Account.FeaturesViewTest do
 
       live_context =
         LiveContext.new(%{
-          user_id: user.id
+          user_id: user.id,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -43,7 +44,8 @@ defmodule Systems.Account.FeaturesViewTest do
 
       live_context =
         LiveContext.new(%{
-          user_id: user.id
+          user_id: user.id,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -62,7 +64,8 @@ defmodule Systems.Account.FeaturesViewTest do
 
       live_context =
         LiveContext.new(%{
-          user_id: user.id
+          user_id: user.id,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -82,7 +85,8 @@ defmodule Systems.Account.FeaturesViewTest do
 
       live_context =
         LiveContext.new(%{
-          user_id: user.id
+          user_id: user.id,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -107,7 +111,8 @@ defmodule Systems.Account.FeaturesViewTest do
 
       live_context =
         LiveContext.new(%{
-          user_id: user.id
+          user_id: user.id,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}

--- a/core/test/systems/account/onboarding_page_builder_test.exs
+++ b/core/test/systems/account/onboarding_page_builder_test.exs
@@ -3,19 +3,15 @@ defmodule Systems.Account.OnboardingPageBuilderTest do
   use Gettext, backend: CoreWeb.Gettext
 
   alias Systems.Account
-  alias Systems.Pool
 
-  describe "view_model/2 with confirmed PANL participant" do
+  # Note: `:features` has moved to `Systems.Pool.OnboardingPageBuilder`.
+  # These tests only cover the account-level steps (profile, terms,
+  # activate_account) — pool participation no longer affects this list.
+
+  describe "view_model/2 with confirmed user" do
     setup do
       user = Factories.insert!(:member)
-
-      panl_pool =
-        Pool.Public.get_panl() || Factories.insert!(:pool, %{name: "Panl", director: :citizen})
-
-      Pool.Public.add_participant!(panl_pool, user)
-
       user = Core.Repo.preload(user, [:features, :profile])
-
       %{user: user}
     end
 
@@ -25,37 +21,21 @@ defmodule Systems.Account.OnboardingPageBuilderTest do
       assert vm.hero_title == dgettext("eyra-account", "onboarding.hero.title")
     end
 
-    test "includes profile and features steps (no activate_account)", %{user: user} do
+    test "has only the profile step", %{user: user} do
       vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
 
-      assert vm.steps == [:profile, :features]
-      refute :activate_account in vm.steps
+      assert vm.steps == [:profile]
     end
 
-    test "first step is profile", %{user: user} do
+    test "first step is profile with ProfileView", %{user: user} do
       vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
 
       assert vm.current_step == :profile
-      assert vm.step_view != nil
       assert vm.step_view.implementation == Account.ProfileView
     end
 
-    test "features step has features view", %{user: user} do
-      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 1})
-
-      assert vm.current_step == :features
-      assert vm.step_view != nil
-      assert vm.step_view.implementation == Account.FeaturesView
-    end
-
-    test "is_last_step is false on first step", %{user: user} do
+    test "is_last_step is true (single step)", %{user: user} do
       vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
-
-      assert vm.is_last_step == false
-    end
-
-    test "is_last_step is true on last step", %{user: user} do
-      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 1})
 
       assert vm.is_last_step == true
     end
@@ -72,28 +52,21 @@ defmodule Systems.Account.OnboardingPageBuilderTest do
     end
   end
 
-  describe "view_model/2 with unconfirmed PANL participant" do
+  describe "view_model/2 with unconfirmed user" do
     setup do
       user = Factories.insert!(:member, %{confirmed_at: nil})
-
-      panl_pool =
-        Pool.Public.get_panl() || Factories.insert!(:pool, %{name: "Panl", director: :citizen})
-
-      Pool.Public.add_participant!(panl_pool, user)
-
       user = Core.Repo.preload(user, [:features, :profile])
-
       %{user: user}
     end
 
-    test "includes activate_account as last step", %{user: user} do
+    test "has profile and activate_account steps", %{user: user} do
       vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
 
-      assert vm.steps == [:profile, :features, :activate_account]
+      assert vm.steps == [:profile, :activate_account]
     end
 
     test "activate_account step has no step_view but has title and body", %{user: user} do
-      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 2})
+      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 1})
 
       assert vm.current_step == :activate_account
       assert vm.step_view == nil
@@ -102,47 +75,10 @@ defmodule Systems.Account.OnboardingPageBuilderTest do
     end
 
     test "activate_account step has special continue button label", %{user: user} do
-      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 2})
+      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 1})
 
       assert vm.continue_button.face.label ==
                dgettext("eyra-account", "onboarding.activate_account.continue.button")
-    end
-  end
-
-  describe "view_model/2 with confirmed non-PANL user" do
-    setup do
-      user = Factories.insert!(:member)
-      user = Core.Repo.preload(user, [:features, :profile])
-
-      %{user: user}
-    end
-
-    test "has only profile step", %{user: user} do
-      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
-
-      assert vm.steps == [:profile]
-    end
-
-    test "first step is profile with step_view", %{user: user} do
-      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
-
-      assert vm.step_view != nil
-      assert vm.step_view.implementation == Account.ProfileView
-    end
-  end
-
-  describe "view_model/2 with unconfirmed non-PANL user" do
-    setup do
-      user = Factories.insert!(:member, %{confirmed_at: nil})
-      user = Core.Repo.preload(user, [:features, :profile])
-
-      %{user: user}
-    end
-
-    test "has profile and activate_account steps", %{user: user} do
-      vm = Account.OnboardingPageBuilder.view_model(user, %{current_step_index: 0})
-
-      assert vm.steps == [:profile, :activate_account]
     end
   end
 
@@ -228,14 +164,7 @@ defmodule Systems.Account.OnboardingPageBuilderTest do
   describe "view_model/2 defaults" do
     setup do
       user = Factories.insert!(:member)
-
-      panl_pool =
-        Pool.Public.get_panl() || Factories.insert!(:pool, %{name: "Panl", director: :citizen})
-
-      Pool.Public.add_participant!(panl_pool, user)
-
       user = Core.Repo.preload(user, [:features, :profile])
-
       %{user: user}
     end
 

--- a/core/test/systems/account/onboarding_page_test.exs
+++ b/core/test/systems/account/onboarding_page_test.exs
@@ -3,25 +3,22 @@ defmodule Systems.Account.OnboardingPageTest do
   import Phoenix.LiveViewTest
   import Frameworks.Signal.TestHelper
 
-  alias Systems.Pool
+  # `:features` has moved to the Pool-scoped onboarding, so a confirmed
+  # user's account onboarding is now just `:profile` (with an optional
+  # `:activate_account` step for unconfirmed users, and a leading
+  # `:terms_and_privacy` for passwordless users).
 
   setup %{conn: conn} do
     isolate_signals()
 
     user = Factories.insert!(:member)
-
-    panl_pool =
-      Pool.Public.get_panl() || Factories.insert!(:pool, %{name: "Panl", director: :citizen})
-
-    Pool.Public.add_participant!(panl_pool, user)
-
     {:ok, conn: conn, user: _user} = login(user, %{conn: conn})
 
     %{conn: conn, user: user}
   end
 
   describe "rendering" do
-    test "renders profile step first for PANL participant", %{conn: conn} do
+    test "renders profile step first for a confirmed user", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/user/onboarding")
 
       assert view |> has_element?("[data-testid='profile-view']")
@@ -43,92 +40,15 @@ defmodule Systems.Account.OnboardingPageTest do
   end
 
   describe "continue event" do
-    test "advances to features step on first continue", %{conn: conn} do
+    test "redirects to home on last step (profile is the only step)", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/user/onboarding")
 
-      # First step is profile, continue should advance to features
-      html = view |> render_click("continue")
-      assert html =~ "features" or has_element?(view, "[data-testid='features-view']")
-    end
-
-    test "redirects to home on last step", %{conn: conn} do
-      {:ok, view, _html} = live(conn, "/user/onboarding")
-
-      # First continue: profile -> features
-      view |> render_click("continue")
-      # Second continue: features -> home (last step)
       assert {:error, {:live_redirect, %{to: "/"}}} = view |> render_click("continue")
     end
   end
 
-  describe "non-PANL user" do
-    test "renders profile step for non-PANL user", %{conn: conn} do
-      non_panl_user = Factories.insert!(:member)
-      {:ok, conn: logged_in_conn, user: _user} = login(non_panl_user, %{conn: conn})
-
-      {:ok, view, _html} = live(logged_in_conn, "/user/onboarding")
-
-      assert view |> has_element?("[data-testid='profile-view']")
-    end
-
-    test "redirects non-PANL user to home on continue", %{conn: conn} do
-      non_panl_user = Factories.insert!(:member)
-      {:ok, conn: logged_in_conn, user: _user} = login(non_panl_user, %{conn: conn})
-
-      {:ok, view, _html} = live(logged_in_conn, "/user/onboarding")
-
-      # Non-PANL confirmed user has only :profile step, so continue should redirect
-      assert {:error, {:live_redirect, %{to: "/"}}} = view |> render_click("continue")
-    end
-  end
-
-  describe "unconfirmed PANL participant" do
-    test "includes confirm_email as third step", %{conn: conn} do
-      unconfirmed_user = Factories.insert!(:member, %{confirmed_at: nil})
-
-      panl_pool =
-        Pool.Public.get_panl() || Factories.insert!(:pool, %{name: "Panl", director: :citizen})
-
-      Pool.Public.add_participant!(panl_pool, unconfirmed_user)
-
-      {:ok, conn: logged_in_conn, user: _user} = login(unconfirmed_user, %{conn: conn})
-
-      {:ok, view, _html} = live(logged_in_conn, "/user/onboarding")
-
-      # Step 1: profile
-      assert view |> has_element?("[data-testid='profile-view']")
-
-      # Step 2: features
-      view |> render_click("continue")
-      assert view |> has_element?("[data-testid='features-view']")
-
-      # Step 3: confirm_email (no specific view, just title/body)
-      html = view |> render_click("continue")
-      # Should show confirm email content
-      assert html =~ "confirm" or html =~ "Confirm" or html =~ "bevestig" or html =~ "Bevestig"
-    end
-
-    test "redirects to home after confirm_email step", %{conn: conn} do
-      unconfirmed_user = Factories.insert!(:member, %{confirmed_at: nil})
-
-      panl_pool =
-        Pool.Public.get_panl() || Factories.insert!(:pool, %{name: "Panl", director: :citizen})
-
-      Pool.Public.add_participant!(panl_pool, unconfirmed_user)
-
-      {:ok, conn: logged_in_conn, user: _user} = login(unconfirmed_user, %{conn: conn})
-
-      {:ok, view, _html} = live(logged_in_conn, "/user/onboarding")
-
-      # Navigate through all steps: profile -> features -> confirm_email -> home
-      view |> render_click("continue")
-      view |> render_click("continue")
-      assert {:error, {:live_redirect, %{to: "/"}}} = view |> render_click("continue")
-    end
-  end
-
-  describe "unconfirmed non-PANL user" do
-    test "has profile and confirm_email steps", %{conn: conn} do
+  describe "unconfirmed user" do
+    test "has profile and activate_account steps", %{conn: conn} do
       unconfirmed_user = Factories.insert!(:member, %{confirmed_at: nil})
 
       {:ok, conn: logged_in_conn, user: _user} = login(unconfirmed_user, %{conn: conn})
@@ -138,19 +58,19 @@ defmodule Systems.Account.OnboardingPageTest do
       # Step 1: profile
       assert view |> has_element?("[data-testid='profile-view']")
 
-      # Step 2: confirm_email
+      # Step 2: activate_account
       html = view |> render_click("continue")
-      assert html =~ "confirm" or html =~ "Confirm" or html =~ "bevestig" or html =~ "Bevestig"
+      assert html =~ "activate" or html =~ "Activate" or html =~ "activeer" or html =~ "Activeer"
     end
 
-    test "redirects to home after confirm_email step", %{conn: conn} do
+    test "redirects to home after activate_account step", %{conn: conn} do
       unconfirmed_user = Factories.insert!(:member, %{confirmed_at: nil})
 
       {:ok, conn: logged_in_conn, user: _user} = login(unconfirmed_user, %{conn: conn})
 
       {:ok, view, _html} = live(logged_in_conn, "/user/onboarding")
 
-      # Navigate through: profile -> confirm_email -> home
+      # Navigate through: profile -> activate_account -> home
       view |> render_click("continue")
       assert {:error, {:live_redirect, %{to: "/"}}} = view |> render_click("continue")
     end

--- a/core/test/systems/account/page_test.exs
+++ b/core/test/systems/account/page_test.exs
@@ -37,8 +37,8 @@ defmodule Systems.Account.PageTest do
 
       {:ok, _view, html} = live(conn, "/user/account")
 
-      assert html =~ "Mijn profiel"
-      refute html =~ "My profile"
+      assert html =~ "Profiel"
+      refute html =~ "Profile"
     end
 
     test "renders profile tab by default", %{conn: conn} do

--- a/core/test/systems/account/profile_view_test.exs
+++ b/core/test/systems/account/profile_view_test.exs
@@ -24,7 +24,8 @@ defmodule Systems.Account.ProfileViewTest do
           user_id: user.id,
           show_signout_button: true,
           show_email: true,
-          show_top_margin: false
+          show_top_margin: false,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -32,7 +33,7 @@ defmodule Systems.Account.ProfileViewTest do
       {:ok, view, html} = live_isolated(conn, Account.ProfileView, session: session)
 
       # Should render title
-      assert html =~ "My profile"
+      assert html =~ "Profile"
 
       # Should render form elements
       assert view |> has_element?("[data-testid='profile-view']")
@@ -53,7 +54,8 @@ defmodule Systems.Account.ProfileViewTest do
           user_id: user.id,
           show_signout_button: true,
           show_email: true,
-          show_top_margin: false
+          show_top_margin: false,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -74,7 +76,8 @@ defmodule Systems.Account.ProfileViewTest do
           user_id: user.id,
           show_signout_button: true,
           show_email: true,
-          show_top_margin: false
+          show_top_margin: false,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -97,7 +100,8 @@ defmodule Systems.Account.ProfileViewTest do
           user_id: user.id,
           show_signout_button: true,
           show_email: true,
-          show_top_margin: false
+          show_top_margin: false,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -125,7 +129,8 @@ defmodule Systems.Account.ProfileViewTest do
           user_id: creator.id,
           show_signout_button: true,
           show_email: true,
-          show_top_margin: false
+          show_top_margin: false,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}
@@ -144,7 +149,8 @@ defmodule Systems.Account.ProfileViewTest do
           user_id: user.id,
           show_signout_button: true,
           show_email: true,
-          show_top_margin: false
+          show_top_margin: false,
+          show_title: true
         })
 
       session = %{"live_context" => live_context}

--- a/core/test/systems/account/terms_and_privacy_view_test.exs
+++ b/core/test/systems/account/terms_and_privacy_view_test.exs
@@ -21,7 +21,7 @@ defmodule Systems.Account.TermsAndPrivacyViewTest do
       |> Repo.insert()
 
     conn = conn |> Map.put(:request_path, "/user/onboarding")
-    session = %{"live_context" => LiveContext.new(%{user_id: user.id})}
+    session = %{"live_context" => LiveContext.new(%{user_id: user.id, show_title: true})}
 
     %{conn: conn, user: user, session: session}
   end

--- a/core/test/systems/home/page_builder_test.exs
+++ b/core/test/systems/home/page_builder_test.exs
@@ -15,13 +15,23 @@ defmodule Systems.Home.PageBuilderTest do
     params
   end
 
-  # Build an online + funded + open advert that passes validate_open/2 for any
-  # panl participant. reward_value 0 short-circuits the funding check so we
-  # don't need to wire up a Fund + currency.
+  # Build an online + funded + open advert placed inside the Panl pool so it
+  # surfaces on the home page's Panl marketplace block. reward_value 0
+  # short-circuits the funding check so we don't need to wire up a Fund +
+  # currency. The factory's own `test_pool` is discarded — we swap the
+  # submission's pool to Panl so the pool-scoped query sees it.
   defp create_open_online_advert(creator) do
+    panl_pool =
+      Pool.Public.get_panl() || Factories.insert!(:pool, %{name: "Panl", director: :citizen})
+
     advert = Advert.Factories.create_advert(creator, :accepted, 1)
     {:ok, advert} = advert |> Ecto.Changeset.change(status: :online) |> Repo.update()
-    {:ok, _} = advert.submission |> Ecto.Changeset.change(reward_value: 0) |> Repo.update()
+
+    {:ok, _} =
+      advert.submission
+      |> Ecto.Changeset.change(reward_value: 0, pool_id: panl_pool.id)
+      |> Repo.update()
+
     advert
   end
 

--- a/core/test/systems/pool/account_post_action_handler_test.exs
+++ b/core/test/systems/pool/account_post_action_handler_test.exs
@@ -56,6 +56,37 @@ defmodule Systems.Pool.AccountPostActionHandlerTest do
     end
   end
 
+  describe "handle/2 with join_pool:<slug> action" do
+    test "adds non-creator user to the resolved pool" do
+      user = Factories.insert!(:member, %{creator: false})
+      _panl_pool = Pool.Assembly.get_or_create_panl()
+
+      refute Pool.Public.participant?(:panl, user)
+
+      assert :ok = AccountPostActionHandler.handle(user, "join_pool:panl")
+
+      assert Pool.Public.participant?(:panl, user)
+    end
+
+    test "returns :ok and does not add when the slug does not resolve to a pool" do
+      user = Factories.insert!(:member, %{creator: false})
+      _panl_pool = Pool.Assembly.get_or_create_panl()
+
+      assert :ok = AccountPostActionHandler.handle(user, "join_pool:panl_unknown")
+
+      refute Pool.Public.participant?(:panl, user)
+    end
+
+    test "skips creators" do
+      creator = Factories.insert!(:member, %{creator: true})
+      _panl_pool = Pool.Assembly.get_or_create_panl()
+
+      assert :ok = AccountPostActionHandler.handle(creator, "join_pool:panl")
+
+      refute Pool.Public.participant?(:panl, creator)
+    end
+  end
+
   describe "handle/2 with unknown action" do
     test "returns :ok for unknown action" do
       user = Factories.insert!(:member, %{creator: false})

--- a/core/test/systems/pool/controller_test.exs
+++ b/core/test/systems/pool/controller_test.exs
@@ -1,0 +1,43 @@
+defmodule Systems.Pool.ControllerTest do
+  use CoreWeb.ConnCase, async: true
+
+  alias Systems.Pool
+  alias Core.Factories
+
+  # The controller looks up pools via `Pool.Public.get_by_slug/1`, which
+  # takes an atom slug. `String.to_existing_atom/1` requires the atom to
+  # already be registered — `:panl` is safe here because
+  # `Systems.Pool.AccountPostActionHandler` references it at compile time.
+  defp panl_pool, do: Factories.insert!(:pool, %{name: "Panl", director: :citizen})
+
+  describe "GET /pool/:slug/join" do
+    setup [:login_as_member]
+
+    test "redirects non-participants to the pool onboarding page", %{conn: conn, user: user} do
+      pool = panl_pool()
+      refute Pool.Public.participant?(pool, user)
+
+      conn = get(conn, ~p"/pool/panl/join")
+
+      assert redirected_to(conn) == "/pool/panl/onboarding"
+    end
+
+    test "redirects existing participants to the home page", %{conn: conn, user: user} do
+      pool = panl_pool()
+      Pool.Public.add_participant!(pool, user)
+
+      conn = get(conn, ~p"/pool/panl/join")
+
+      # Home lives at "/" for members via Account.UserAuth.signed_in_path/1.
+      assert redirected_to(conn) == "/"
+    end
+  end
+
+  describe "GET /pool/:slug/join without authentication" do
+    test "redirects to the signin page", %{conn: conn} do
+      conn = get(conn, ~p"/pool/panl/join")
+
+      assert redirected_to(conn) =~ "/user"
+    end
+  end
+end

--- a/core/test/systems/pool/onboarding_page_builder_test.exs
+++ b/core/test/systems/pool/onboarding_page_builder_test.exs
@@ -1,0 +1,175 @@
+defmodule Systems.Pool.OnboardingPageBuilderTest do
+  use Core.DataCase, async: true
+  use Gettext, backend: CoreWeb.Gettext
+
+  alias Frameworks.Concept.LiveContext
+  alias Systems.Account
+  alias Systems.Pool
+
+  # Where the flow exits — reused across finish_path assertions.
+  defp expected_finish_path(user), do: Account.UserAuth.signed_in_path(user)
+
+  setup do
+    user = Factories.insert!(:member)
+    pool = Factories.insert!(:pool, %{name: "Panl", director: :citizen})
+    {:ok, user: user, pool: pool}
+  end
+
+  describe "view_model/2 for a non-member (index 0)" do
+    test "steps are [:join_consent, :features]", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.steps == [:join_consent, :features]
+    end
+
+    test "first step is join_consent with JoinConsentView", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.current_step == :join_consent
+      assert vm.step_view.implementation == Pool.JoinConsentView
+      assert vm.step_view.options[:pool] == pool
+    end
+
+    test "join_consent has no continue button (view renders its own)",
+         %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.continue_button == nil
+    end
+
+    test "is_last_step is false", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.is_last_step == false
+    end
+  end
+
+  describe "view_model/2 for a non-member on the features step (index 1)" do
+    test "second step is features with FeaturesView + user_id in context", %{
+      user: user,
+      pool: pool
+    } do
+      vm =
+        Pool.OnboardingPageBuilder.view_model(pool, %{
+          current_user: user,
+          current_step_index: 1
+        })
+
+      assert vm.current_step == :features
+      assert vm.step_view.implementation == Account.FeaturesView
+
+      assert %LiveContext{data: %{user_id: user_id}} = vm.step_view.options[:live_context]
+      assert user_id == user.id
+    end
+
+    test "features has a continue button", %{user: user, pool: pool} do
+      vm =
+        Pool.OnboardingPageBuilder.view_model(pool, %{
+          current_user: user,
+          current_step_index: 1
+        })
+
+      assert vm.continue_button.action.type == :send
+      assert vm.continue_button.action.event == "continue"
+      assert vm.continue_button.face.type == :primary
+    end
+
+    test "is_last_step is true", %{user: user, pool: pool} do
+      vm =
+        Pool.OnboardingPageBuilder.view_model(pool, %{
+          current_user: user,
+          current_step_index: 1
+        })
+
+      assert vm.is_last_step == true
+    end
+
+    test "step list stays [:join_consent, :features] even after DB flip mid-flow", %{
+      user: user,
+      pool: pool
+    } do
+      # After accepting at step 0 the user is now a DB member. But the
+      # builder must NOT swap to `[:already_member]` — `current_step_index`
+      # is already 1 and would run off the end of a rebuilt one-step list.
+      # Index > 0 is the "we're mid-flow" signal.
+      Pool.Public.add_participant!(pool, user)
+
+      vm =
+        Pool.OnboardingPageBuilder.view_model(pool, %{
+          current_user: user,
+          current_step_index: 1
+        })
+
+      assert vm.steps == [:join_consent, :features]
+      assert vm.current_step == :features
+    end
+  end
+
+  describe "view_model/2 for an existing member (index 0)" do
+    setup %{user: user, pool: pool} do
+      Pool.Public.add_participant!(pool, user)
+      :ok
+    end
+
+    test "steps is [:already_member]", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.steps == [:already_member]
+      assert vm.current_step == :already_member
+    end
+
+    test "no step_view is attached (nothing to interact with)", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.step_view == nil
+    end
+
+    test "step_title carries the info message; step_body is nil (title-only screen)",
+         %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.step_title ==
+               dgettext("eyra-pool", "already_member.title", pool_name: pool.name)
+
+      assert vm.step_body == nil
+    end
+
+    test "has a home button (labelled for exit)", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.continue_button.action.type == :send
+      assert vm.continue_button.action.event == "continue"
+
+      assert vm.continue_button.face.label ==
+               dgettext("eyra-pool", "already_member.home.button")
+    end
+  end
+
+  describe "view_model/2 defaults" do
+    test "defaults current_step_index to 0", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.current_step_index == 0
+    end
+
+    test "exposes the pool in the view model", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.pool == pool
+    end
+  end
+
+  describe "view_model/2 finish_path" do
+    test "returns the user's signed-in landing", %{user: user, pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{current_user: user})
+
+      assert vm.finish_path == expected_finish_path(user)
+    end
+
+    test "falls back to '/' when no user is present", %{pool: pool} do
+      vm = Pool.OnboardingPageBuilder.view_model(pool, %{})
+
+      assert vm.finish_path == "/"
+    end
+  end
+end

--- a/core/test/systems/pool/onboarding_page_test.exs
+++ b/core/test/systems/pool/onboarding_page_test.exs
@@ -1,0 +1,127 @@
+defmodule Systems.Pool.OnboardingPageTest do
+  # async: false — same reason as PanlSignupTest: this exercises the global
+  # `Pool.Public.get_by_slug/1` lookup on a fixed-name "Panl" pool.
+  use CoreWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Systems.Pool
+
+  setup [:login_as_member]
+
+  setup do
+    pool = Factories.insert!(:pool, %{name: "Panl", director: :citizen})
+    {:ok, pool: pool}
+  end
+
+  describe "mount as non-participant" do
+    test "renders the join consent view first", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      assert view |> has_element?("[data-testid='pool-join-consent-view']")
+    end
+
+    test "does not render the features view yet", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      refute view |> has_element?("[data-testid='features-view']")
+    end
+  end
+
+  describe "mount as existing participant" do
+    setup %{user: user, pool: pool} do
+      Pool.Public.add_participant!(pool, user)
+      :ok
+    end
+
+    test "renders the already-member info view (not the join prompt)", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      assert view |> has_element?("[data-testid='pool-already-member-view']")
+      refute view |> has_element?("[data-testid='pool-join-consent-view']")
+    end
+
+    test "home button on the info view redirects to home", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      assert {:error, {:live_redirect, %{to: "/"}}} = render_click(view, "continue")
+    end
+  end
+
+  # Accept/decline goes through JoinConsentView -> LiveNest publish_event
+  # -> parent `handle_info` -> `consume_event`, so an eventual
+  # push_navigate lands *after* `render_click` returns. `assert_redirect/2`
+  # waits on the navigation message — the same helper Phoenix uses for
+  # any async navigation.
+  describe "join consent accepted" do
+    test "adds the user as a participant", %{conn: conn, user: user, pool: pool} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      refute Pool.Public.participant?(pool, user)
+
+      view
+      |> element("[data-testid='pool-join-consent-accept-button']")
+      |> render_click()
+
+      # Sync the parent LV: `render_click` returns before the async
+      # `handle_info` -> `consume_event` chain runs `add_participant!`.
+      render(view)
+
+      assert Pool.Public.participant?(pool, user)
+    end
+
+    test "advances to the features step (does not redirect)", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      view
+      |> element("[data-testid='pool-join-consent-accept-button']")
+      |> render_click()
+
+      # After async consume_event, the features view should be rendered
+      # and the join consent view should be gone.
+      html = render(view)
+      assert html =~ ~s(data-testid="features-view")
+      refute html =~ ~s(data-testid="pool-join-consent-view")
+    end
+  end
+
+  describe "join consent declined" do
+    test "does not add the user as a participant", %{conn: conn, user: user, pool: pool} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      view
+      |> element("[data-testid='pool-join-consent-decline-button']")
+      |> render_click()
+
+      assert_redirect(view, "/")
+      refute Pool.Public.participant?(pool, user)
+    end
+
+    test "redirects to home (skips remaining steps)", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      view
+      |> element("[data-testid='pool-join-consent-decline-button']")
+      |> render_click()
+
+      assert_redirect(view, "/")
+    end
+  end
+
+  describe "features step" do
+    test "continue on features redirects to home (last step)", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/pool/panl/onboarding")
+
+      # Advance to features by accepting the consent.
+      view
+      |> element("[data-testid='pool-join-consent-accept-button']")
+      |> render_click()
+
+      # Send "continue" straight to the parent LiveView. `element/2 +
+      # render_click` would traverse the FeaturesView's rendered form
+      # elements, one of which trips LazyHTML's CSS parser via an
+      # empty `phx-target`. The handle_event is a plain page event so
+      # dispatching by name is equivalent.
+      assert {:error, {:live_redirect, %{to: "/"}}} = render_click(view, "continue")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Auth is pool-agnostic.** OTP flow carries only opaque `?return_to=<path>`; the auth pages no longer reference pools. `Systems.Pool.Controller` gates `/pool/:slug/join` — redirects existing members home, forwards non-members to a new `Pool.OnboardingPage` at `/pool/:slug/onboarding`.
- **Pool onboarding** runs `JoinConsentView` → `FeaturesView`. Features moved out of `Account.OnboardingPage` where it never belonged; a pool-scoped attribute (gender / birth year) is only meaningful once someone joins a pool.
- **Onboarding UX overhaul** across both `Pool.OnboardingPage` and `Account.OnboardingPage`:
  - Single flow-level hero title ("Join Panl", "Welcome") with each step view's own title hidden via a `show_title` assign. Views used outside the flow (Account tabs) still show their title.
  - Centered progress dots at the top of the sheet — honour mid-flow state, so the passwordless terms → profile flow keeps a 2-step dot count even after activation flips the underlying user state.
  - Left-aligned throughout. One `Area.sheet` (760px) column at the page level; views are content-only, no self-wrapping Area.
  - `Account.OnboardingPage` advances in-place after `terms_completed` instead of `push_navigate` → mount reset (which was collapsing the step list).
- **Adaptable + Area layout hygiene**:
  - `Systems.Content.Adaptable` takes an `area_type` opt so callers can choose the column width. `Account.Page` requests `:sheet`. Private helper `group_content` → `group_body` to break the name clash with `Area.content`.
  - `items-start` on `Area.form` + `Area.sheet` so children don't inherit cross-axis stretch — that stretch was cascading `Button.dynamic`'s built-in `h-full` into hundreds of pixels of vertical growth, pushing the Overview section of Payouts past the footer illustration.
- **Copy**: "My profile" → "Profile" (7 locales, keeps each translator's noun choice); "Onboarding" → "Welcome" (7 locales).

## Test plan

- [ ] `/pool/panl/join` while not a member → redirects to `/pool/panl/onboarding`; consent + features shown; accept adds you to the pool; both dots visible with the second filled on features.
- [ ] `/pool/panl/join` while already a member → home; visiting `/pool/panl/onboarding` directly shows the "You already joined Panl" screen with a "Back to home" button.
- [ ] `/pool/panl/join` while not signed in → auth flow → after OTP redeem lands you back on `/pool/panl/join` → onboarding.
- [ ] Fresh SSO (passwordless) sign-in → `/user/onboarding` → 2 dots, terms first, profile second; accepting terms advances to profile in-place, dot count doesn't reset.
- [ ] Password signup (unconfirmed) → `/user/onboarding` → 2 dots (profile, activate_account).
- [ ] Confirmed non-PANL sign-in → `/user/onboarding` → 1 step (profile), no dots.
- [ ] Account tabs (`/user/account`) — all three tabs (Profile, Payouts, Panl) share the 760px sheet column; tabs are centered in the tabbar; Payouts renders both Bank account and Overview sections above the footer.

Fixes: FX#10052767402

🤖 Generated with [Claude Code](https://claude.com/claude-code)