### PR TITLE
style(auth): vertically center the identify and code-verify pages

### DIFF
--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -82,9 +82,9 @@ defmodule Next.Account.AuthCodeVerifyPage do
   def render(assigns) do
     ~H"""
     <.stripped menus={@menus}>
+      <div class="h-full flex flex-col justify-center">
       <Area.content>
         <Area.form>
-          <Margin.y id={:page_top} />
           <Text.title2 align="text-center"><%= dgettext("eyra-account", "auth.code.title") %></Text.title2>
           <.spacing value="L" />
           <.form id="auth_code_form" for={@form} phx-submit="verify">
@@ -122,6 +122,7 @@ defmodule Next.Account.AuthCodeVerifyPage do
           </.form>
         </Area.form>
       </Area.content>
+      </div>
     </.stripped>
     """
   end

--- a/core/bundles/next/lib/account/auth_page.ex
+++ b/core/bundles/next/lib/account/auth_page.ex
@@ -113,9 +113,9 @@ defmodule Next.Account.AuthPage do
   def render(assigns) do
     ~H"""
     <.stripped menus={@menus}>
+      <div class="h-full flex flex-col justify-center">
       <Area.content>
         <Area.form>
-          <Margin.y id={:page_top} />
           <Text.title2 align="text-center"><%= dgettext("eyra-account", "auth.title") %></Text.title2>
           <.spacing value="L" />
           <.form id="auth_form" for={@form} phx-submit="submit" phx-change="change">
@@ -140,6 +140,7 @@ defmodule Next.Account.AuthPage do
           </.form>
         </Area.form>
       </Area.content>
+      </div>
     </.stripped>
     """
   end


### PR DESCRIPTION
## Summary

- Wraps the identify and code-verify pages' `<Area.content>` in an `h-full flex flex-col justify-center` container so the short form + title sits mid-page instead of pinned to the top.
- Drops the now-unneeded `<Margin.y :page_top />` spacer on both.

Neo's finetune from FX#10074856705.

## Test plan

- [ ] `/user/auth/identify` — the email input + title is vertically centered on the page (both on tall and short viewports).
- [ ] `/user/auth/verify` — the 6-cell code input + title is vertically centered.
- [ ] The rest of the stripped layout (topbar, footer illustration) still renders correctly around the centered content.

Fixes: FX#10074856705

🤖 Generated with [Claude Code](https://claude.com/claude-code)