### PR TITLE
feat(assignment): post-launch Panl block on the finished page

### DIFF
--- a/core/bundles/next/lib/account/session_controller.ex
+++ b/core/bundles/next/lib/account/session_controller.ex
@@ -64,17 +64,7 @@ defmodule Next.Account.SessionController do
   defp do_redeem_otp(conn, token) do
     case Next.Account.AuthCodeVerifyPage.decode_redeem_token(token) do
       {:ok, %{user_id: nil, email: email} = payload} ->
-        case Account.Public.register_user_with_email(email) do
-          {:ok, user} ->
-            conn
-            |> stash_return_to(payload)
-            |> Account.UserAuth.log_in_user(user, true)
-
-          {:error, _changeset} ->
-            conn
-            |> put_flash(:error, dgettext("eyra-user", "auth.session.expired"))
-            |> redirect(to: ~p"/user/auth/identify")
-        end
+        handle_new_email_redeem(conn, email, payload)
 
       {:ok, %{user_id: user_id} = payload} ->
         user = Account.Public.get_user!(user_id)
@@ -84,6 +74,49 @@ defmodule Next.Account.SessionController do
         |> Account.UserAuth.log_in_user(user, false)
 
       _ ->
+        conn
+        |> put_flash(:error, dgettext("eyra-user", "auth.session.expired"))
+        |> redirect(to: ~p"/user/auth/identify")
+    end
+  end
+
+  # When the redeem token was minted for an email that had no user yet, we
+  # normally register a fresh Account.User. But if a provisional user is
+  # already logged in — an affiliate synth account that never had a real
+  # email — link the real email to *that* user instead. Without this,
+  # completing auth from the finished-page "Join Panl" CTA would leave the
+  # synth affiliate record behind and mint a new duplicate user.
+  defp handle_new_email_redeem(
+         %{assigns: %{current_user: %Account.User{} = user}} = conn,
+         email,
+         payload
+       ) do
+    if EmailSignUp.provisional?(user) do
+      case EmailSignUp.link(user, email) do
+        {:ok, linked_user} ->
+          conn
+          |> stash_return_to(payload)
+          |> Account.UserAuth.log_in_user(linked_user, false)
+
+        {:error, _} ->
+          register_new_email_user(conn, email, payload)
+      end
+    else
+      register_new_email_user(conn, email, payload)
+    end
+  end
+
+  defp handle_new_email_redeem(conn, email, payload),
+    do: register_new_email_user(conn, email, payload)
+
+  defp register_new_email_user(conn, email, payload) do
+    case Account.Public.register_user_with_email(email) do
+      {:ok, user} ->
+        conn
+        |> stash_return_to(payload)
+        |> Account.UserAuth.log_in_user(user, true)
+
+      {:error, _changeset} ->
         conn
         |> put_flash(:error, dgettext("eyra-user", "auth.session.expired"))
         |> redirect(to: ~p"/user/auth/identify")

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -542,6 +542,30 @@ msgid "email_capture.error.role_account"
 msgstr "Bitte verwenden Sie eine persönliche E-Mail-Adresse, keine geteilte (z.B. info@, admin@)."
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr "Möchtest du öfter an Forschung teilnehmen?"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr "Werde Mitglied von Panl — dem Teilnehmerpool, der Bürger und Wissenschaft verbindet. Du entscheidest, wann du teilnimmst, und erhältst eine Vergütung für jede Studie."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr "Panl beitreten"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr "Sieh, was du verdient hast"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr "Dein Guthaben, vergangene Studien und verfügbare Studien findest du auf deiner Startseite."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr "Zur Startseite"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr ""
 

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -541,6 +541,30 @@ msgid "email_capture.error.role_account"
 msgstr "Please use a personal email address, not a shared one (e.g. info@, admin@)."
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr "Want to take part in more research?"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr "Join Panl — the participant pool that connects citizens with science. You decide when to participate, and you get paid for each study."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr "Join Panl"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr "See what you've earned"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr "Your wallet, past studies, and available studies are all on your home page."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr "Go to home"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr "Aim of the study"
 

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -542,6 +542,30 @@ msgid "email_capture.error.role_account"
 msgstr "Por favor, usa una dirección de correo personal, no una compartida (p.ej. info@, admin@)."
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr "¿Quieres participar en más investigaciones?"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr "Únete a Panl — la comunidad de participantes que conecta a los ciudadanos con la ciencia. Tú decides cuándo participar y recibes una recompensa por cada estudio."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr "Unirse a Panl"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr "Mira lo que has ganado"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr "Tu cartera, estudios pasados y estudios disponibles están todos en tu página de inicio."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr "Ir al inicio"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr ""
 

--- a/core/priv/gettext/eyra-assignment.pot
+++ b/core/priv/gettext/eyra-assignment.pot
@@ -541,6 +541,30 @@ msgid "email_capture.error.role_account"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr ""
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr ""
 

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -542,6 +542,30 @@ msgid "email_capture.error.role_account"
 msgstr "Usa un indirizzo email personale, non uno condiviso (es. info@, admin@)."
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr "Vuoi partecipare più spesso alla ricerca?"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr "Unisciti a Panl — il pool di partecipanti che collega cittadini e scienza. Decidi tu quando partecipare e ricevi un compenso per ogni studio."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr "Unisciti a Panl"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr "Guarda quanto hai guadagnato"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr "Il tuo portafoglio, gli studi passati e quelli disponibili sono tutti sulla tua homepage."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr "Vai alla homepage"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr ""
 

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -552,6 +552,30 @@ msgid "email_capture.error.role_account"
 msgstr "Naudokite asmeninį el. pašto adresą, ne bendrinamą (pvz. info@, admin@)."
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr "Norite dažniau dalyvauti tyrimuose?"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr "Prisijunkite prie Panl — dalyvių pulo, jungiančio piliečius su mokslu. Jūs sprendžiate, kada dalyvauti, ir gaunate atlygį už kiekvieną tyrimą."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr "Prisijungti prie Panl"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr "Peržiūrėkite, kiek uždirbote"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr "Jūsų piniginė, ankstesni tyrimai ir prieinami tyrimai — viskas yra jūsų pradžios puslapyje."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr "Į pradžios puslapį"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr ""
 

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -541,6 +541,30 @@ msgid "email_capture.error.role_account"
 msgstr "Gebruik een persoonlijk e-mailadres, geen gedeeld adres (bijv. info@, admin@)."
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr "Wil je vaker meedoen aan onderzoek?"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr "Word lid van Panl — de deelnemerspool die burgers en wetenschap verbindt. Jij bepaalt wanneer je meedoet en je ontvangt een vergoeding voor elk onderzoek."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr "Word lid van Panl"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr "Bekijk wat je hebt verdiend"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr "Je uitbetalingen, eerdere onderzoeken en beschikbare onderzoeken vind je allemaal op je startpagina."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr "Naar startpagina"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr ""
 

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -552,6 +552,30 @@ msgid "email_capture.error.role_account"
 msgstr "Te rugăm să folosești o adresă de email personală, nu una partajată (ex. info@, admin@)."
 
 #, elixir-autogen, elixir-format
+msgid "panl.cta.join.title"
+msgstr "Vrei să participi mai des la cercetare?"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.body"
+msgstr "Alătură-te Panl — comunitatea de participanți care conectează cetățenii cu știința. Tu decizi când participi și primești o recompensă pentru fiecare studiu."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.join.button"
+msgstr "Alătură-te Panl"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.title"
+msgstr "Vezi cât ai câștigat"
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.body"
+msgstr "Portofelul tău, studiile anterioare și cele disponibile sunt toate pe pagina ta principală."
+
+#, elixir-autogen, elixir-format
+msgid "panl.cta.home.button"
+msgstr "Către pagina principală"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.aim.label"
 msgstr ""
 

--- a/core/systems/assignment/finished_view.ex
+++ b/core/systems/assignment/finished_view.ex
@@ -137,6 +137,9 @@ defmodule Systems.Assignment.FinishedView do
             <Button.dynamic {@email_capture.submit_button} testid="email-capture-submit" />
           </form>
         <% end %>
+        <%= if Map.has_key?(@email_capture, :cta_button) do %>
+          <Button.dynamic {@email_capture.cta_button} testid="panl-cta-button" />
+        <% end %>
       </InlineBlock.inline_block>
     </div>
     """

--- a/core/systems/assignment/finished_view.ex
+++ b/core/systems/assignment/finished_view.ex
@@ -88,7 +88,9 @@ defmodule Systems.Assignment.FinishedView do
               <%= @vm.body %>
             </Text.body_large>
             <%= if @vm.email_capture do %>
-              <.email_capture_block email_capture={@vm.email_capture} email_error={@email_error} email_value={@email_value} />
+              <Area.sheet>
+                <.email_capture_block email_capture={@vm.email_capture} email_error={@email_error} email_value={@email_value} />
+              </Area.sheet>
             <% else %>
               <div :if={@vm.illustration} class="flex flex-col items-center w-full pt-4" data-testid="finished-illustration">
                 <img class="block w-[220px] h-[220px] object-cover" src={@vm.illustration} id="zero-todos" alt="All tasks done">

--- a/core/systems/assignment/finished_view_builder.ex
+++ b/core/systems/assignment/finished_view_builder.ex
@@ -40,19 +40,23 @@ defmodule Systems.Assignment.FinishedViewBuilder do
     Assignment.Template.runtime_config(template)
   end
 
-  # The finished-page Panl block. One block, four states — chosen by
-  # feature flags + Panl membership:
+  # The finished-page Panl block. States chosen by feature flags + Panl
+  # membership + user type:
   #
-  #   :panl off                             → no block
-  #   pre-launch (:panl on)                 → email-capture form
-  #                                           (or submitted ack, once the
-  #                                           user has joined)
-  #   post-launch (:panl_post_launch on),
-  #     not yet a Panl member               → "Join Panl" CTA
-  #   post-launch, already a Panl member    → "Home" CTA
+  #   :panl off                            → no block
   #
-  # Only shown to affiliate visitors — non-affiliate direct traffic
-  # (e.g. researcher preview) never sees the block.
+  #   pre-launch (:panl on) — affiliate visitor only:
+  #     already a Panl member              → email-capture submitted ack
+  #     already sent an email sign-up      → email-capture submitted ack
+  #     otherwise                          → email-capture form
+  #
+  #   post-launch (:panl_post_launch on) — any non-creator user:
+  #     already a Panl member              → "Home" CTA
+  #     affiliate synth account            → "Join Panl" CTA → auth flow
+  #                                          (need to link a real email
+  #                                          before joining)
+  #     regular user (has a real email)    → "Join Panl" CTA → straight
+  #                                          to `/pool/:slug/join`
   defp build_email_capture(true = _declined?, _runtime_config, _user, _submitting?), do: nil
   defp build_email_capture(_declined?, %{post_action: nil}, _user, _submitting?), do: nil
 
@@ -62,31 +66,41 @@ defmodule Systems.Assignment.FinishedViewBuilder do
          user,
          submitting?
        ) do
-    with true <- feature_enabled?(:panl),
-         {:ok, _affiliate_user} <- Affiliate.Public.get_user(user) do
-      build_panl_block(pool_slug, action, user, submitting?)
-    else
-      _ -> nil
+    cond do
+      not feature_enabled?(:panl) -> nil
+      creator?(user) -> nil
+      feature_enabled?(:panl_post_launch) -> build_post_launch_block(pool_slug, user)
+      true -> build_pre_launch_block(action, pool_slug, user, submitting?)
     end
   end
 
-  defp build_panl_block(pool_slug, action, user, submitting?) do
-    cond do
-      feature_enabled?(:panl_post_launch) ->
-        if Pool.Public.participant?(pool_slug, user) do
-          build_home_cta()
-        else
-          build_join_cta(pool_slug)
+  defp creator?(%{creator: true}), do: true
+  defp creator?(_), do: false
+
+  # Post-launch block — no affiliate gate. Show a CTA to anyone who
+  # isn't already a Panl member.
+  defp build_post_launch_block(pool_slug, user) do
+    if Pool.Public.participant?(pool_slug, user) do
+      build_home_cta()
+    else
+      build_join_cta(pool_slug, user)
+    end
+  end
+
+  # Pre-launch block — affiliate-only (matches the pre-launch UX; a
+  # regular user already has a real email, so there's nothing for the
+  # email-capture form to collect).
+  defp build_pre_launch_block(action, pool_slug, user, submitting?) do
+    case Affiliate.Public.get_user(user) do
+      {:ok, _affiliate_user} ->
+        cond do
+          Pool.Public.participant?(pool_slug, user) -> build_email_capture_submitted()
+          EmailSignUp.get_by_user(user) != nil -> build_email_capture_submitted()
+          true -> build_email_capture_form(action, submitting?)
         end
 
-      Pool.Public.participant?(pool_slug, user) ->
-        build_email_capture_submitted()
-
-      EmailSignUp.get_by_user(user) != nil ->
-        build_email_capture_submitted()
-
-      true ->
-        build_email_capture_form(action, submitting?)
+      {:error, :user_not_found} ->
+        nil
     end
   end
 
@@ -114,25 +128,33 @@ defmodule Systems.Assignment.FinishedViewBuilder do
     }
   end
 
-  # Post-launch: affiliate visitor is not yet a Panl member. CTA sends them
-  # through auth identify → verify → redeem. `return_to` steers them into
-  # `/pool/<slug>/join` after auth so the join gate + onboarding runs and
-  # they end on Home.
-  defp build_join_cta(pool_slug) do
+  # Post-launch: user is not yet a Panl member. The affiliate synth
+  # variant needs to collect + link a real email first, so we route them
+  # through auth identify → verify → redeem (`return_to` steers them
+  # into `/pool/:slug/join` after auth). A regular user already has a
+  # real email, so we skip auth and go straight to the join gate.
+  defp build_join_cta(pool_slug, user) do
     %{
       title: dgettext("eyra-assignment", "panl.cta.join.title"),
       body: dgettext("eyra-assignment", "panl.cta.join.body"),
       cta_button: %{
-        action: %{
-          type: :http_get,
-          to: "/user/auth/identify?return_to=/pool/#{pool_slug}/join"
-        },
+        action: %{type: :http_get, to: join_url(pool_slug, user)},
         face: %{
           type: :primary,
           label: dgettext("eyra-assignment", "panl.cta.join.button")
         }
       }
     }
+  end
+
+  defp join_url(pool_slug, user) do
+    case Affiliate.Public.get_user(user) do
+      {:ok, _affiliate_user} ->
+        "/user/auth/identify?return_to=/pool/#{pool_slug}/join"
+
+      _ ->
+        "/pool/#{pool_slug}/join"
+    end
   end
 
   # Post-launch: affiliate visitor is already a Panl member. Send them home;

--- a/core/systems/assignment/finished_view_builder.ex
+++ b/core/systems/assignment/finished_view_builder.ex
@@ -1,5 +1,6 @@
 defmodule Systems.Assignment.FinishedViewBuilder do
   use Gettext, backend: CoreWeb.Gettext
+  use Core.FeatureFlags
 
   alias Systems.Assignment
   alias Systems.Affiliate
@@ -39,6 +40,19 @@ defmodule Systems.Assignment.FinishedViewBuilder do
     Assignment.Template.runtime_config(template)
   end
 
+  # The finished-page Panl block. One block, four states — chosen by
+  # feature flags + Panl membership:
+  #
+  #   :panl off                             → no block
+  #   pre-launch (:panl on)                 → email-capture form
+  #                                           (or submitted ack, once the
+  #                                           user has joined)
+  #   post-launch (:panl_post_launch on),
+  #     not yet a Panl member               → "Join Panl" CTA
+  #   post-launch, already a Panl member    → "Home" CTA
+  #
+  # Only shown to affiliate visitors — non-affiliate direct traffic
+  # (e.g. researcher preview) never sees the block.
   defp build_email_capture(true = _declined?, _runtime_config, _user, _submitting?), do: nil
   defp build_email_capture(_declined?, %{post_action: nil}, _user, _submitting?), do: nil
 
@@ -48,16 +62,31 @@ defmodule Systems.Assignment.FinishedViewBuilder do
          user,
          submitting?
        ) do
-    case Affiliate.Public.get_user(user) do
-      {:ok, _affiliate_user} ->
-        cond do
-          Pool.Public.participant?(pool_slug, user) -> build_email_capture_submitted()
-          EmailSignUp.get_by_user(user) != nil -> build_email_capture_submitted()
-          true -> build_email_capture_form(action, submitting?)
+    with true <- feature_enabled?(:panl),
+         {:ok, _affiliate_user} <- Affiliate.Public.get_user(user) do
+      build_panl_block(pool_slug, action, user, submitting?)
+    else
+      _ -> nil
+    end
+  end
+
+  defp build_panl_block(pool_slug, action, user, submitting?) do
+    cond do
+      feature_enabled?(:panl_post_launch) ->
+        if Pool.Public.participant?(pool_slug, user) do
+          build_home_cta()
+        else
+          build_join_cta(pool_slug)
         end
 
-      {:error, :user_not_found} ->
-        nil
+      Pool.Public.participant?(pool_slug, user) ->
+        build_email_capture_submitted()
+
+      EmailSignUp.get_by_user(user) != nil ->
+        build_email_capture_submitted()
+
+      true ->
+        build_email_capture_form(action, submitting?)
     end
   end
 
@@ -82,6 +111,43 @@ defmodule Systems.Assignment.FinishedViewBuilder do
     %{
       title: dgettext("eyra-assignment", "email_capture.success.title"),
       body: dgettext("eyra-assignment", "email_capture.success.body")
+    }
+  end
+
+  # Post-launch: affiliate visitor is not yet a Panl member. CTA sends them
+  # through auth identify → verify → redeem. `return_to` steers them into
+  # `/pool/<slug>/join` after auth so the join gate + onboarding runs and
+  # they end on Home.
+  defp build_join_cta(pool_slug) do
+    %{
+      title: dgettext("eyra-assignment", "panl.cta.join.title"),
+      body: dgettext("eyra-assignment", "panl.cta.join.body"),
+      cta_button: %{
+        action: %{
+          type: :http_get,
+          to: "/user/auth/identify?return_to=/pool/#{pool_slug}/join"
+        },
+        face: %{
+          type: :primary,
+          label: dgettext("eyra-assignment", "panl.cta.join.button")
+        }
+      }
+    }
+  end
+
+  # Post-launch: affiliate visitor is already a Panl member. Send them home;
+  # the home page carries their wallet / rewards summary.
+  defp build_home_cta do
+    %{
+      title: dgettext("eyra-assignment", "panl.cta.home.title"),
+      body: dgettext("eyra-assignment", "panl.cta.home.body"),
+      cta_button: %{
+        action: %{type: :http_get, to: "/"},
+        face: %{
+          type: :primary,
+          label: dgettext("eyra-assignment", "panl.cta.home.button")
+        }
+      }
     }
   end
 

--- a/core/test/bundles/next/account/session_controller_test.exs
+++ b/core/test/bundles/next/account/session_controller_test.exs
@@ -84,4 +84,118 @@ defmodule Next.Account.SessionControllerTest do
       assert {:ok, ^payload} = AuthCodeVerifyPage.decode_redeem_token(token)
     end
   end
+
+  describe "GET /user/auth/redeem — new email, provisional user in session" do
+    # The affiliate → post-launch CTA journey. After the user finishes an
+    # assignment they're already logged in as a provisional synth
+    # Account.User (no password, no confirmed_at). Clicking "Join Panl"
+    # sends them through auth. At redeem, the controller must link the
+    # real email to that existing user — NOT register a fresh duplicate.
+    setup %{conn: conn} do
+      provisional_user =
+        Factories.insert!(:member, %{
+          email: "synth-#{Faker.UUID.v4()}@example.com",
+          hashed_password: "no-password-set",
+          confirmed_at: nil
+        })
+
+      token = Systems.Account.Public.generate_user_session_token(provisional_user)
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Conn.put_session(:user_token, token)
+
+      %{conn: conn, provisional_user: provisional_user}
+    end
+
+    test "links the real email to the provisional user (no new user created)", %{
+      conn: conn,
+      provisional_user: provisional_user
+    } do
+      new_email = "real-#{Faker.UUID.v4()}@example.com"
+      before_count = user_count()
+
+      redeem_token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: nil,
+          email: new_email,
+          return_to: "/pool/panl/join"
+        })
+
+      conn = get(conn, ~p"/user/auth/redeem?token=#{redeem_token}")
+
+      assert redirected_to(conn) == "/pool/panl/join"
+      assert user_count() == before_count
+
+      updated_user = Systems.Account.Public.get_user!(provisional_user.id)
+      assert updated_user.email == new_email
+    end
+
+    test "creates a satellite EmailSignUp record for the linked email", %{
+      conn: conn,
+      provisional_user: provisional_user
+    } do
+      new_email = "real-#{Faker.UUID.v4()}@example.com"
+      refute EmailSignUp.get_by_user(provisional_user)
+
+      redeem_token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: nil,
+          email: new_email,
+          return_to: nil
+        })
+
+      _conn = get(conn, ~p"/user/auth/redeem?token=#{redeem_token}")
+
+      assert EmailSignUp.get_by_user(provisional_user) != nil
+    end
+  end
+
+  describe "GET /user/auth/redeem — new email, activated user in session" do
+    # Guardrail: even if a fully-activated (non-provisional) user is
+    # logged in when the redeem hits, we must NOT hijack their email.
+    # Register a new user, as if there were no session.
+    setup %{conn: conn} do
+      activated_user = Factories.insert!(:member, %{creator: false})
+      original_email = activated_user.email
+
+      token = Systems.Account.Public.generate_user_session_token(activated_user)
+
+      conn =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Conn.put_session(:user_token, token)
+
+      %{conn: conn, activated_user: activated_user, original_email: original_email}
+    end
+
+    test "registers a new user and leaves the logged-in user's email untouched", %{
+      conn: conn,
+      activated_user: activated_user,
+      original_email: original_email
+    } do
+      new_email = "real-#{Faker.UUID.v4()}@example.com"
+      before_count = user_count()
+
+      redeem_token =
+        Phoenix.Token.sign(Endpoint, @token_salt, %{
+          user_id: nil,
+          email: new_email,
+          return_to: nil
+        })
+
+      _conn = get(conn, ~p"/user/auth/redeem?token=#{redeem_token}")
+
+      assert user_count() == before_count + 1
+
+      assert Systems.Account.Public.get_user!(activated_user.id).email ==
+               original_email
+    end
+  end
+
+  defp user_count do
+    import Ecto.Query
+    Core.Repo.aggregate(from(u in Systems.Account.User), :count, :id)
+  end
 end

--- a/core/test/features/panl_finished_cta_test.exs
+++ b/core/test/features/panl_finished_cta_test.exs
@@ -1,0 +1,123 @@
+defmodule CoreWeb.Features.PanlFinishedCTATest do
+  @moduledoc """
+  Feature test for the post-launch Panl block on the finished screen.
+
+  Covers the two CTA variants seen by affiliate participants when
+  `:panl_post_launch` is on:
+
+    * Not yet a Panl member → "Join Panl" CTA that sends them into
+      auth with `?return_to=/pool/panl/join`.
+    * Already a Panl member → "Home" CTA that sends them to `/`.
+
+  The auth flow that runs after the "Join Panl" click (identify →
+  verify → redeem → affiliate-linking) is exercised at the unit level
+  in `Next.Account.SessionControllerTest`. This test verifies the UI
+  plumbing on the finished page — the right block state renders and
+  the CTA points at the right destination.
+  """
+  use CoreWeb.FeatureCase
+  use Core.FeatureFlags.Test
+
+  alias Systems.Pool
+  alias Systems.Assignment
+  alias Systems.Crew
+
+  setup do
+    set_feature_flag(:panl, true)
+    set_feature_flag(:panl_post_launch, true)
+    :ok
+  end
+
+  # Reaching the finished view from `visit/1` requires navigating the
+  # `CrewPage` machinery (intro → consent → activate → tasks) which the
+  # existing `email_capture_test` also punts on (marked `@tag :skip`).
+  # State-machine coverage lives in `Systems.Assignment.FinishedViewBuilderTest`
+  # and `Systems.Assignment.FinishedViewTest`; controller-linking coverage
+  # in `Next.Account.SessionControllerTest`. Unskip this once a shared
+  # helper for "drive a participant to the finished view" exists.
+  @tag :feature
+  @tag :skip
+  feature "affiliate who is not yet a Panl member sees a Join CTA and lands on auth identify",
+          %{session: session} do
+    _panl_pool = Pool.Assembly.get_or_create_panl()
+    {participant, password, assignment} = setup_affiliate_at_finished()
+
+    session
+    |> sign_in(participant, password)
+    |> visit_finished(assignment)
+    |> click(Query.css("[data-testid='panl-cta-button']"))
+    |> assert_path_changed_from("/assignment/#{assignment.id}")
+    |> assert_has(Query.css("[data-testid='auth-email-input']"))
+
+    assert Wallaby.Browser.current_path(session) == "/user/auth/identify"
+
+    return_to =
+      session
+      |> Wallaby.Browser.current_url()
+      |> URI.parse()
+      |> Map.get(:query, "")
+      |> URI.decode_query()
+      |> Map.get("return_to")
+
+    assert return_to == "/pool/panl/join"
+  end
+
+  @tag :feature
+  @tag :skip
+  feature "affiliate who is already a Panl member sees a Home CTA and lands on the home page",
+          %{session: session} do
+    panl_pool = Pool.Assembly.get_or_create_panl()
+    {participant, password, assignment} = setup_affiliate_at_finished()
+    Pool.Public.add_participant!(panl_pool, participant)
+
+    session
+    |> sign_in(participant, password)
+    |> visit_finished(assignment)
+    |> click(Query.css("[data-testid='panl-cta-button']"))
+    |> assert_path_changed_from("/assignment/#{assignment.id}")
+    |> assert_has(Query.css("[data-testid='home-page']"))
+
+    assert Wallaby.Browser.current_path(session) == "/"
+  end
+
+  # Builds a confirmed affiliate participant + a questionnaire assignment
+  # with the participant's single task pre-completed, so hitting
+  # `/assignment/:id` should route straight to the finished view.
+  defp setup_affiliate_at_finished do
+    password = Factories.valid_user_password()
+
+    participant =
+      Factories.insert!(:member, %{
+        password: password,
+        confirmed_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
+        verified_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
+        creator: false
+      })
+
+    assignment =
+      Assignment.Factories.create_questionnaire_assignment()
+      |> Assignment.Factories.add_participant(participant)
+
+    Factories.insert!(:affiliate_user, %{user: participant, identifier: "test_participant"})
+
+    mark_assignment_finished(assignment, participant)
+
+    {participant, password, assignment}
+  end
+
+  defp visit_finished(session, assignment) do
+    session
+    |> visit("/assignment/#{assignment.id}")
+    |> assert_has(Query.css("[data-testid='email-capture-block']"))
+    |> assert_has(Query.css("[data-testid='panl-cta-button']"))
+    |> refute_has(Query.css("[data-testid='email-capture-input']"))
+  end
+
+  defp mark_assignment_finished(assignment, participant) do
+    %{crew: crew, workflow: workflow} = assignment
+    %{items: [item]} = workflow |> Repo.preload([:items])
+    member = Crew.Public.get_member(crew, participant) |> Repo.preload([:user])
+    identifier = Assignment.Private.task_identifier(assignment, item, member)
+    Crew.Factories.create_task(crew, member, identifier, status: :completed)
+  end
+end

--- a/core/test/systems/assignment/finished_view_builder_test.exs
+++ b/core/test/systems/assignment/finished_view_builder_test.exs
@@ -351,8 +351,39 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
                dgettext("eyra-assignment", "panl.cta.home.button")
     end
 
-    test "no block for a non-affiliate user" do
-      user = Factories.insert!(:member)
+    test "renders a Join CTA that skips auth for a non-affiliate user (they already have a real email)" do
+      user = Factories.insert!(:member, %{creator: false})
+      assignment = Assignment.Factories.create_questionnaire_assignment()
+
+      assigns = build_assigns(user)
+      vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
+
+      assert vm.email_capture != nil
+      assert vm.email_capture.title == dgettext("eyra-assignment", "panl.cta.join.title")
+
+      assert vm.email_capture.cta_button.action == %{
+               type: :http_get,
+               to: "/pool/panl/join"
+             }
+    end
+
+    test "renders a Home CTA for a non-affiliate user who is already a pool member" do
+      user = Factories.insert!(:member, %{creator: false})
+      panl_pool = Systems.Pool.Assembly.get_or_create_panl()
+      Systems.Pool.Public.add_participant!(panl_pool, user)
+
+      assignment = Assignment.Factories.create_questionnaire_assignment()
+
+      assigns = build_assigns(user)
+      vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
+
+      assert vm.email_capture != nil
+      assert vm.email_capture.title == dgettext("eyra-assignment", "panl.cta.home.title")
+      assert vm.email_capture.cta_button.action == %{type: :http_get, to: "/"}
+    end
+
+    test "no block for a creator user (researcher preview)" do
+      user = Factories.insert!(:creator)
       assignment = Assignment.Factories.create_questionnaire_assignment()
 
       assigns = build_assigns(user)

--- a/core/test/systems/assignment/finished_view_builder_test.exs
+++ b/core/test/systems/assignment/finished_view_builder_test.exs
@@ -1,5 +1,6 @@
 defmodule Systems.Assignment.FinishedViewBuilderTest do
   use Core.DataCase
+  use Core.FeatureFlags.Test
   use Gettext, backend: CoreWeb.Gettext
 
   alias Systems.Assignment
@@ -204,14 +205,17 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
     end
   end
 
-  describe "email_capture" do
+  describe "panl block (pre-launch: :panl on)" do
     setup do
       affiliate_user = Factories.insert!(:affiliate_user, %{identifier: "test_participant"})
       user = affiliate_user.user
+      set_feature_flag(:panl, true)
+      set_feature_flag(:panl_post_launch, false)
       %{user: user}
     end
 
-    test "includes email_capture for questionnaire assignment", %{user: user} do
+    test "renders the email-capture form for an affiliate on a questionnaire assignment",
+         %{user: user} do
       assignment = Assignment.Factories.create_questionnaire_assignment()
 
       assigns = build_assigns(user)
@@ -226,7 +230,7 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
       assert vm.email_capture.submit_button.face.type == :primary
     end
 
-    test "email_capture is nil for non-affiliate user on questionnaire assignment", %{} do
+    test "no block for a non-affiliate user" do
       user = Factories.insert!(:member)
       assignment = Assignment.Factories.create_questionnaire_assignment()
 
@@ -236,7 +240,7 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
       assert vm.email_capture == nil
     end
 
-    test "email_capture is nil for non-questionnaire assignment", %{user: user} do
+    test "no block for a non-questionnaire assignment", %{user: user} do
       assignment = Assignment.Factories.create_assignment_with_affiliate(nil)
 
       assigns = build_assigns(user)
@@ -245,7 +249,8 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
       assert vm.email_capture == nil
     end
 
-    test "email_capture shows success when user is already a pool member", %{user: user} do
+    test "shows the submitted acknowledgment once the user is a pool member",
+         %{user: user} do
       assignment = Assignment.Factories.create_questionnaire_assignment()
       panl_pool = Systems.Pool.Assembly.get_or_create_panl()
       Systems.Pool.Public.add_participant!(panl_pool, user)
@@ -259,7 +264,7 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
       refute Map.has_key?(vm.email_capture, :submit_button)
     end
 
-    test "email_capture is nil when consent declined", %{} do
+    test "no block when the participant declined consent" do
       user = Factories.insert!(:member)
       consent_agreement = Factories.insert!(:consent_agreement)
       _revision = Factories.insert!(:consent_revision, %{agreement: consent_agreement})
@@ -288,6 +293,86 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
         |> Assignment.Factories.add_participant(user)
 
       Assignment.Public.decline_member(assignment, user)
+
+      assigns = build_assigns(user)
+      vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
+
+      assert vm.email_capture == nil
+    end
+  end
+
+  describe "panl block (post-launch: :panl_post_launch on)" do
+    setup do
+      affiliate_user = Factories.insert!(:affiliate_user, %{identifier: "test_participant"})
+      user = affiliate_user.user
+      set_feature_flag(:panl, true)
+      set_feature_flag(:panl_post_launch, true)
+      %{user: user}
+    end
+
+    test "renders a Join CTA when the affiliate is not yet a pool member",
+         %{user: user} do
+      assignment = Assignment.Factories.create_questionnaire_assignment()
+
+      assigns = build_assigns(user)
+      vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
+
+      assert vm.email_capture != nil
+      assert vm.email_capture.title == dgettext("eyra-assignment", "panl.cta.join.title")
+      assert vm.email_capture.body == dgettext("eyra-assignment", "panl.cta.join.body")
+      refute Map.has_key?(vm.email_capture, :submit_button)
+
+      assert vm.email_capture.cta_button.action == %{
+               type: :http_get,
+               to: "/user/auth/identify?return_to=/pool/panl/join"
+             }
+
+      assert vm.email_capture.cta_button.face.label ==
+               dgettext("eyra-assignment", "panl.cta.join.button")
+    end
+
+    test "renders a Home CTA once the affiliate has joined the pool",
+         %{user: user} do
+      assignment = Assignment.Factories.create_questionnaire_assignment()
+      panl_pool = Systems.Pool.Assembly.get_or_create_panl()
+      Systems.Pool.Public.add_participant!(panl_pool, user)
+
+      assigns = build_assigns(user)
+      vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
+
+      assert vm.email_capture != nil
+      assert vm.email_capture.title == dgettext("eyra-assignment", "panl.cta.home.title")
+      assert vm.email_capture.body == dgettext("eyra-assignment", "panl.cta.home.body")
+      refute Map.has_key?(vm.email_capture, :submit_button)
+
+      assert vm.email_capture.cta_button.action == %{type: :http_get, to: "/"}
+
+      assert vm.email_capture.cta_button.face.label ==
+               dgettext("eyra-assignment", "panl.cta.home.button")
+    end
+
+    test "no block for a non-affiliate user" do
+      user = Factories.insert!(:member)
+      assignment = Assignment.Factories.create_questionnaire_assignment()
+
+      assigns = build_assigns(user)
+      vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
+
+      assert vm.email_capture == nil
+    end
+  end
+
+  describe "panl block (:panl off)" do
+    setup do
+      affiliate_user = Factories.insert!(:affiliate_user, %{identifier: "test_participant"})
+      user = affiliate_user.user
+      set_feature_flag(:panl, false)
+      %{user: user}
+    end
+
+    test "no block regardless of Panl membership or :panl_post_launch state",
+         %{user: user} do
+      assignment = Assignment.Factories.create_questionnaire_assignment()
 
       assigns = build_assigns(user)
       vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)

--- a/core/test/systems/assignment/finished_view_test.exs
+++ b/core/test/systems/assignment/finished_view_test.exs
@@ -1,5 +1,6 @@
 defmodule Systems.Assignment.FinishedViewTest do
   use CoreWeb.ConnCase, async: false
+  use Core.FeatureFlags.Test
   import Phoenix.LiveViewTest
   import Frameworks.Signal.TestHelper
 
@@ -216,9 +217,11 @@ defmodule Systems.Assignment.FinishedViewTest do
     end
   end
 
-  describe "email capture form" do
+  describe "email capture form (pre-launch: :panl on)" do
     setup do
       affiliate_user = Factories.insert!(:affiliate_user, %{identifier: "test_participant"})
+      set_feature_flag(:panl, true)
+      set_feature_flag(:panl_post_launch, false)
       %{user: affiliate_user.user}
     end
 
@@ -348,6 +351,63 @@ defmodule Systems.Assignment.FinishedViewTest do
       view |> render_submit("submit_email", %{"email" => "taken-capture@example.com"})
 
       assert view |> has_element?("[data-testid='email-capture-error']")
+    end
+  end
+
+  describe "panl CTA (post-launch: :panl_post_launch on)" do
+    setup do
+      affiliate_user = Factories.insert!(:affiliate_user, %{identifier: "test_participant"})
+      set_feature_flag(:panl, true)
+      set_feature_flag(:panl_post_launch, true)
+      %{user: affiliate_user.user}
+    end
+
+    test "renders a Join CTA for an affiliate who is not yet a Panl member",
+         %{conn: conn, user: user} do
+      assignment = Assignment.Factories.create_questionnaire_assignment()
+
+      conn = conn |> Map.put(:request_path, "/assignment/finished")
+
+      live_context =
+        Frameworks.Concept.LiveContext.new(%{
+          assignment_id: assignment.id,
+          current_user: user
+        })
+
+      session = %{"live_context" => live_context}
+      {:ok, view, html} = live_isolated(conn, Assignment.FinishedView, session: session)
+
+      assert view |> has_element?("[data-testid='email-capture-block']")
+      assert view |> has_element?("[data-testid='panl-cta-button']")
+      refute view |> has_element?("[data-testid='email-capture-input']")
+
+      # Anchor the destination on the actual HTML so a refactor of the CTA
+      # href surfaces here.
+      assert html =~ "/user/auth/identify?return_to=/pool/panl/join"
+    end
+
+    test "renders a Home CTA for an affiliate who is already a Panl member",
+         %{conn: conn, user: user} do
+      assignment = Assignment.Factories.create_questionnaire_assignment()
+      panl_pool = Systems.Pool.Assembly.get_or_create_panl()
+      Systems.Pool.Public.add_participant!(panl_pool, user)
+
+      conn = conn |> Map.put(:request_path, "/assignment/finished")
+
+      live_context =
+        Frameworks.Concept.LiveContext.new(%{
+          assignment_id: assignment.id,
+          current_user: user
+        })
+
+      session = %{"live_context" => live_context}
+      {:ok, view, html} = live_isolated(conn, Assignment.FinishedView, session: session)
+
+      assert view |> has_element?("[data-testid='email-capture-block']")
+      assert view |> has_element?("[data-testid='panl-cta-button']")
+      refute view |> has_element?("[data-testid='email-capture-input']")
+
+      assert html =~ ~s(href="/")
     end
   end
 


### PR DESCRIPTION
## Summary

- Turns the finished-page Panl block into a state machine chosen by feature flags + Panl membership + user type:
  - `:panl` off → no block
  - pre-launch (`:panl` on) → existing email-capture form (affiliate visitors only — a regular user already has a real email, so the capture form has nothing to collect)
  - post-launch (`:panl_post_launch` on), user is already a Panl member → **"Home" CTA** → `/`
  - post-launch, affiliate synth account, not yet a Panl member → **"Join Panl" CTA** → `/user/auth/identify?return_to=/pool/panl/join` (auth flow needed to link a real email)
  - post-launch, regular user, not yet a Panl member → **"Join Panl" CTA** → `/pool/panl/join` (skip auth — they already have a real email)
  - creator (researcher preview) → no block
- Same `InlineBlock.inline_block` wrapper + Panl logo across all variants — only the interactive content swaps. Wrapped in `Area.sheet` so it matches the 760px column used elsewhere in onboarding + Account.
- `SessionController.do_redeem_otp` now **links** the real email to an existing provisional (`EmailSignUp.provisional?/1`) `current_user` in the session instead of always registering a fresh user. This upgrades the affiliate synth account into a real user after the "Join Panl" auth flow completes, so no duplicate is minted. Fully-activated logged-in users are left untouched (guardrail).
- Adds translations for the six `panl.cta.*` keys across nl / de / es / it / lt / ro (+ `.pot`).

## Test plan

- [ ] `:panl` off, complete a questionnaire assignment → no Panl block on the finished screen (both affiliate + regular participants).
- [ ] `:panl_post_launch` off (pre-launch), affiliate, not yet in Panl → existing email-capture form still shows.
- [ ] `:panl_post_launch` off, regular participant → no block (unchanged pre-launch behaviour).
- [ ] `:panl_post_launch` on, affiliate, not yet in Panl → "Join Panl" CTA. Click → auth identify with `?return_to=/pool/panl/join`. Complete the flow → same user (no duplicate) ends up in `/pool/panl/onboarding` → completes → Home.
- [ ] `:panl_post_launch` on, regular participant, not yet in Panl → "Join Panl" CTA. Click → straight to `/pool/panl/join` (no auth stop) → onboarding → Home.
- [ ] `:panl_post_launch` on, user already in Panl → "Home" CTA → clicking lands on `/`.
- [ ] Researcher/creator preview → never sees the block.
- [ ] Dutch locale renders the actual translations, not the msgid keys.

Fixes: FX#10052792515

🤖 Generated with [Claude Code](https://claude.com/claude-code)