### PR TITLE
fix: read fund balance under a row lock so concurrent reservations ca…

### DIFF
--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -291,18 +291,22 @@ defmodule Systems.Fund.Public do
          amount
        )
        when is_integer(amount) do
-    multi
-    |> Multi.run(:fund_balance, fn _, _ ->
-      if Fund.Model.amount_available(fund) >= amount do
-        {:ok, true}
-      else
-        Logger.warning("Fund has not enough funds to make reward reservation")
-        {:error, :no_funding}
-      end
-    end)
+    Multi.run(multi, :fund_balance, fn repo, _ -> verify_fund_balance(repo, fund, amount) end)
   end
 
   defp guard_fund_balance(multi, _, _), do: multi
+
+  defp verify_fund_balance(repo, %Fund.Model{available: %{id: account_id}}, amount) do
+    query = from(a in Bookkeeping.AccountModel, where: a.id == ^account_id, lock: "FOR UPDATE")
+    account = repo.one!(query)
+
+    if Bookkeeping.AccountModel.balance(account) >= amount do
+      {:ok, true}
+    else
+      Logger.warning("Fund has not enough funds to make reward reservation")
+      {:error, :no_funding}
+    end
+  end
 
   def payout_reward(idempotence_key) when is_binary(idempotence_key) do
     case get_reward(idempotence_key, Fund.RewardModel.preload_graph(:full)) do

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -625,9 +625,11 @@ defmodule Systems.Fund.PublicTest do
       [u1, u2, u3] =
         for _ <- 1..3, do: Factories.insert!(:member, %{creator: false})
 
+      # Total (4500) must fit the fund's 5000 available: the balance guard now
+      # reads the live balance, so an over-budget reservation is refused.
       {:ok, _} = Fund.Public.create_reward(fund, 1000, u1, "k1")
       {:ok, _} = Fund.Public.create_reward(fund, 2000, u2, "k2")
-      {:ok, _} = Fund.Public.create_reward(fund, 3000, u3, "k3")
+      {:ok, _} = Fund.Public.create_reward(fund, 1500, u3, "k3")
 
       {:ok, _} = Fund.Public.mark_pending_approval("k1")
       {:ok, _} = Fund.Public.approve_reward("k2")


### PR DESCRIPTION
…nnot overdraw

guard_fund_balance decided against the balance carried by the fund struct passed in, never consulting the database. Two participants starting the same assignment concurrently both passed the check against the same stale value and both reservations went through, driving the fund negative.

The balance is now re-read from the book_accounts row the reservation debits, inside the transaction and under SELECT ... FOR UPDATE. Only one row is involved (the same row the reservation writes), so reservations on one fund serialize briefly and no deadlock ordering is possible.

The list_pending_approvals/1 setup was relying on the bug: it reserved 6000 against a fund seeded with 5000 available and passed only because each check read the same stale balance. Its third reward is lowered so the scenario fits the fund.