### PR TITLE
fix(account): handle close_modal event on the account page

### DIFF
--- a/core/systems/account/page.ex
+++ b/core/systems/account/page.ex
@@ -73,6 +73,11 @@ defmodule Systems.Account.Page do
   end
 
   @impl true
+  def handle_event("close_modal", %{"item" => modal_id}, socket) do
+    {:noreply, socket |> handle_close_modal(modal_id)}
+  end
+
+  @impl true
   def handle_view_model_updated(socket), do: socket
 
   @impl true


### PR DESCRIPTION
## Summary

Closing any modal presented from an embedded view on **/user/account** (e.g. Payouts → phone_form) crashed the page with a **FunctionClauseError** — Account.Page uses **routed_live_view** but was missing the **handle_event(\"close_modal\", …)** clause that routes the browser click into LiveNest's **handle_close_modal/2**.

Mirrors the same 2-line clause already present in **Assignment.CrewPage** and **Admin.ConfigPage**.

Fixes: FX#10090984843

## Test plan

- [ ] Sign in as a participant, open Payouts, click **Verify bank account**, then close the phone form modal — page stays alive, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)