### PR TITLE
fix(pixel): add mobile horizontal margin to Area.sheet

### DIFF
--- a/core/lib/core_web/ui/area.ex
+++ b/core/lib/core_web/ui/area.ex
@@ -65,7 +65,7 @@ defmodule CoreWeb.UI.Area do
   def sheet(assigns) do
     ~H"""
     <div class={"flex justify-center items-start #{@class}"}>
-      <div class="flex-grow sm:max-w-sheet">
+      <div class="flex-grow mx-6 sm:mx-0 sm:max-w-sheet">
         <%= render_slot(@inner_block) %>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Area.sheet had no horizontal margin at all on mobile — content sat flush against the viewport edges. Added \`mx-6 sm:mx-0\` so mobile gets the same 24px side margin Area.content already uses; sm+ behaviour unchanged.

Fixes: FX#10089232255

## Test plan

- [ ] Open **/user/account** on a mobile viewport as a participant — text no longer clips against the edges, matches the padding used on the tabbar row above.
- [ ] Spot-check other Area.sheet callers on mobile (assignment finished view, alliance/feldspar tool views, activate_account_view, await_confirmation) — none regress.
- [ ] Desktop view (≥sm) of the same pages is visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)