### PR TITLE
fix(e2e): drop stale :features step from PaNL onboarding spec

### DIFF
--- a/core/test/e2e/panl_onboarding.spec.ts
+++ b/core/test/e2e/panl_onboarding.spec.ts
@@ -80,33 +80,25 @@ test.describe('PaNL Onboarding Flow', () => {
     console.log('[TEST] Step 6: Checking for profile view...');
     await expect(page.locator('[data-testid="profile-view"]')).toBeVisible({ timeout: 3000 });
 
-    // Step 7: Click continue to features step
-    console.log('[TEST] Step 7: Continue to features...');
+    // Step 7: Continue to activate account step
+    console.log('[TEST] Step 7: Continue to activate account...');
     await page.locator('[data-testid="onboarding-continue"]').click();
 
-    // Step 8: Verify features view
-    console.log('[TEST] Step 8: Checking for features view...');
-    await expect(page.locator('[data-testid="features-view"]')).toBeVisible({ timeout: 3000 });
-
-    // Step 9: Continue to activate account step
-    console.log('[TEST] Step 9: Continue to activate account...');
-    await page.locator('[data-testid="onboarding-continue"]').click();
-
-    // Step 10: Wait for activate account view to appear
-    console.log('[TEST] Step 10: Waiting for activate account view...');
+    // Step 8: Wait for activate account view to appear
+    console.log('[TEST] Step 8: Waiting for activate account view...');
     await expect(page.locator('[data-testid="activate-account-view"]')).toBeVisible({ timeout: 3000 });
 
-    // Step 11: Finish onboarding - click and wait for navigation together
-    console.log('[TEST] Step 11: Finish onboarding...');
+    // Step 9: Finish onboarding - click and wait for navigation together
+    console.log('[TEST] Step 9: Finish onboarding...');
     await Promise.all([
       page.waitForURL('**/', { timeout: 5000 }),
       page.locator('[data-testid="onboarding-continue"]').click()
     ]);
-    console.log('[TEST] Step 12: On home page...');
+    console.log('[TEST] Step 10: On home page...');
     console.log(`[TEST] On home page: ${page.url()}`);
 
-    // Step 13: Verify PaNL advert card
-    console.log('[TEST] Step 13: Checking for PaNL advert...');
+    // Step 11: Verify PaNL advert card
+    console.log('[TEST] Step 11: Checking for PaNL advert...');
     await expect(page.locator('[data-testid^="card_"]').first()).toBeVisible({ timeout: 3000 });
 
     console.log('[TEST] Success!');


### PR DESCRIPTION
## Summary

PR #1626 removed the \`:features\` onboarding step from Systems.Account.OnboardingPageBuilder — the flow is now just \`[:profile, :activate_account]\`. The PaNL e2e spec still asserted a \`features-view\` between profile and activate_account, which is why the daily E2E Tests (dev) run against \`eyra-next-dev\` has been failing.

Update the spec to walk profile → activate_account → home, matching current product behaviour.

## Test plan

- [ ] CI e2e run against \`eyra-next-dev\` goes green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)