### PR TITLE
fix(auth): vertically center the identify and verify pages on mobile too

### DIFF
--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -81,8 +81,8 @@ defmodule Next.Account.AuthCodeVerifyPage do
   @impl true
   def render(assigns) do
     ~H"""
-    <.stripped menus={@menus}>
-      <div class="h-full flex flex-col justify-center">
+    <.stripped menus={@menus} centered?>
+      <div class="h-full flex flex-col justify-center pb-16">
       <Area.content>
         <Area.form>
           <Text.title2 align="text-center"><%= dgettext("eyra-account", "auth.code.title") %></Text.title2>

--- a/core/bundles/next/lib/account/auth_page.ex
+++ b/core/bundles/next/lib/account/auth_page.ex
@@ -112,8 +112,8 @@ defmodule Next.Account.AuthPage do
   @impl true
   def render(assigns) do
     ~H"""
-    <.stripped menus={@menus}>
-      <div class="h-full flex flex-col justify-center">
+    <.stripped menus={@menus} centered?>
+      <div class="h-full flex flex-col justify-center pb-16">
       <Area.content>
         <Area.form>
           <Text.title2 align="text-center"><%= dgettext("eyra-account", "auth.title") %></Text.title2>

--- a/core/lib/core_web/controllers/layouts/stripped/html.ex
+++ b/core/lib/core_web/controllers/layouts/stripped/html.ex
@@ -12,6 +12,12 @@ defmodule CoreWeb.Layouts.Stripped.Html do
   attr(:title, :string, default: nil)
   attr(:menus, :map, required: true)
   attr(:footer?, :boolean, default: true)
+  # When true, `#main-content` is locked to viewport height on all breakpoints
+  # so pages with short, vertically centered content (e.g. the auth flow) get
+  # a resolved height for `h-full` chains. Default keeps `min-h-viewport
+  # md:h-viewport` to protect pages whose content grows past viewport on
+  # mobile and relies on natural browser scroll.
+  attr(:centered?, :boolean, default: false)
 
   attr(:privacy_text, :string, default: dgettext("eyra-ui", "privacy.link"))
   attr(:terms_text, :string, default: dgettext("eyra-ui", "terms.link"))
@@ -20,11 +26,16 @@ defmodule CoreWeb.Layouts.Stripped.Html do
   slot(:inner_block, required: true)
 
   def stripped(assigns) do
+    assigns =
+      assign_new(assigns, :main_height_class, fn ->
+        if assigns.centered?, do: "h-viewport", else: "min-h-viewport md:h-viewport"
+      end)
+
     ~H"""
     <div class="flex flex-row">
       <div class="flex-1">
         <div class="bg-grey5 lg:px-16">
-          <div id="main-content" class="flex flex-col w-full min-h-viewport md:h-viewport lg:max-w-[1536px] lg:mx-auto">
+          <div id="main-content" class={"flex flex-col w-full #{@main_height_class} lg:max-w-[1536px] lg:mx-auto"}>
               <div class="flex-wrap lg:hidden">
                 <Navigation.mobile_navbar {@menus.mobile_navbar} />
               </div>


### PR DESCRIPTION
## Summary

The vertical-centering added in PR #1627 worked above md but not on mobile — \`#main-content\` is \`min-h-viewport md:h-viewport\`, so below md the \`h-full\` chain collapsed to auto and content stuck to the top under the topbar.

Give \`.stripped\` a \`centered?\` opt-in. When set, \`#main-content\` becomes \`h-viewport\` on all breakpoints so the \`h-full\` chain resolves everywhere and true vertical centering works. Default stays \`min-h-viewport md:h-viewport\` so long-content Stripped pages keep natural browser scroll on mobile.

Auth wrapper is back to the clean \`h-full flex flex-col justify-center pb-16\` (the \`pb-16\` is a mild optical-centering nudge upward).

Fixes: FX#10089177450

## Test plan

- [ ] \`/user/auth/identify\` — content vertically centered on mobile (< 640), tablet (640–767), and desktop; illustration + footer remain visible in the initial viewport.
- [ ] \`/user/auth/verify\` — same.
- [ ] Other Stripped pages (\`/user/account\`, \`/pool/panl/join\`, signup, onboarding) — no visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)