### PR TITLE
refactor(auth): welcoming identify title, verify title + email-echo body

### DIFF
--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -86,6 +86,8 @@ defmodule Next.Account.AuthCodeVerifyPage do
       <Area.content>
         <Area.form>
           <Text.title2 align="text-center"><%= dgettext("eyra-account", "auth.code.title") %></Text.title2>
+          <.spacing value="XS" />
+          <Text.body_medium align="text-center"><%= dgettext("eyra-account", "auth.code.body", email: @email) %></Text.body_medium>
           <.spacing value="L" />
           <.form id="auth_code_form" for={@form} phx-submit="verify">
             <div

--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -86,8 +86,6 @@ defmodule Next.Account.AuthCodeVerifyPage do
       <Area.content>
         <Area.form>
           <Text.title2 align="text-center"><%= dgettext("eyra-account", "auth.code.title") %></Text.title2>
-          <.spacing value="XS" />
-          <Text.body_medium align="text-center"><%= dgettext("eyra-account", "auth.code.body", email: @email) %></Text.body_medium>
           <.spacing value="L" />
           <.form id="auth_code_form" for={@form} phx-submit="verify">
             <div
@@ -121,6 +119,10 @@ defmodule Next.Account.AuthCodeVerifyPage do
               bg_color="bg-grey1"
               testid="auth-code-verify-button"
             />
+            <.spacing value="S" />
+            <div class="text-center">
+              <Text.footnote color="text-grey3"><%= dgettext("eyra-account", "auth.code.body") %></Text.footnote>
+            </div>
           </.form>
         </Area.form>
       </Area.content>

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -393,4 +393,4 @@ msgstr "Bankkonto verifizieren"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.body"
-msgstr "Wir haben einen Code an %{email} geschickt"
+msgstr "Wir haben dir einen Code geschickt"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -257,7 +257,7 @@ msgstr "Zu viele falsche Versuche. Bitte fordere einen neuen Code an."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr "Überprüfe deine E-Mails"
+msgstr "E-Mail bestätigen"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
@@ -269,7 +269,7 @@ msgstr "Bitte gib eine gültige E-Mail-Adresse ein."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"
-msgstr "Wie lautet deine E-Mail-Adresse?"
+msgstr "Los geht's"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.placeholder"
@@ -390,3 +390,7 @@ msgstr "Weiter"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.title"
 msgstr "Bankkonto verifizieren"
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr "Wir haben einen Code an %{email} geschickt"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
@@ -394,4 +394,4 @@ msgstr "Verify bank account"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.body"
-msgstr "We sent a code to %{email}"
+msgstr "We've emailed you a code"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-account.po
@@ -256,7 +256,7 @@ msgstr "Too many incorrect attempts. Please request a new code."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr "Check your email"
+msgstr "Verify email"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
@@ -268,7 +268,7 @@ msgstr "Please enter a valid email address."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"
-msgstr "What is your email?"
+msgstr "Get started"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.placeholder"
@@ -391,3 +391,7 @@ msgstr "Continue"
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.modal.title"
 msgstr "Verify bank account"
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr "We sent a code to %{email}"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -257,7 +257,7 @@ msgstr "Demasiados intentos incorrectos. Solicita un nuevo código."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr "Revisa tu correo electrónico"
+msgstr "Verificar email"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
@@ -269,7 +269,7 @@ msgstr "Introduce una dirección de correo electrónico válida."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"
-msgstr "¿Cuál es tu correo electrónico?"
+msgstr "Empezar"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.placeholder"
@@ -390,3 +390,7 @@ msgstr "Continuar"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.title"
 msgstr "Verificar cuenta bancaria"
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr "Enviamos un código a %{email}"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -393,4 +393,4 @@ msgstr "Verificar cuenta bancaria"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.body"
-msgstr "Enviamos un código a %{email}"
+msgstr "Te enviamos un código"

--- a/core/priv/gettext/eyra-account.pot
+++ b/core/priv/gettext/eyra-account.pot
@@ -389,3 +389,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.modal.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -257,7 +257,7 @@ msgstr "Troppi tentativi errati. Richiedi un nuovo codice."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr "Controlla la tua email"
+msgstr "Verifica email"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
@@ -269,7 +269,7 @@ msgstr "Inserisci un indirizzo email valido."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"
-msgstr "Qual è la tua email?"
+msgstr "Iniziamo"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.placeholder"
@@ -390,3 +390,7 @@ msgstr "Continua"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.title"
 msgstr "Verifica conto bancario"
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr "Abbiamo inviato un codice a %{email}"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -393,4 +393,4 @@ msgstr "Verifica conto bancario"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.body"
-msgstr "Abbiamo inviato un codice a %{email}"
+msgstr "Ti abbiamo inviato un codice"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -402,4 +402,4 @@ msgstr "Patvirtinti banko sąskaitą"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.body"
-msgstr "Kodą išsiuntėme adresu %{email}"
+msgstr "Išsiuntėme tau kodą"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -266,7 +266,7 @@ msgstr "Per daug neteisingų bandymų. Prašykite naujo kodo."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr "Patikrinkite el. paštą"
+msgstr "Patvirtinti el. paštą"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
@@ -278,7 +278,7 @@ msgstr "Įveskite galiojantį el. pašto adresą."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"
-msgstr "Koks tavo el. paštas?"
+msgstr "Pradėkime"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.placeholder"
@@ -399,3 +399,7 @@ msgstr "Tęsti"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.title"
 msgstr "Patvirtinti banko sąskaitą"
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr "Kodą išsiuntėme adresu %{email}"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
@@ -394,4 +394,4 @@ msgstr "Bankrekening verifiëren"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.body"
-msgstr "We hebben een code gestuurd naar %{email}"
+msgstr "We hebben je een code gestuurd"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-account.po
@@ -256,7 +256,7 @@ msgstr "Te veel onjuiste pogingen. Vraag een nieuwe code aan."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr "Controleer je e-mail"
+msgstr "E-mail verifiëren"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
@@ -268,7 +268,7 @@ msgstr "Voer een geldig e-mailadres in."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"
-msgstr "Wat is je e-mailadres?"
+msgstr "Aan de slag"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.placeholder"
@@ -391,3 +391,7 @@ msgstr "Doorgaan"
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.modal.title"
 msgstr "Bankrekening verifiëren"
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr "We hebben een code gestuurd naar %{email}"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -402,4 +402,4 @@ msgstr "Verifică contul bancar"
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.body"
-msgstr "Am trimis un cod la %{email}"
+msgstr "Ți-am trimis un cod"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -266,7 +266,7 @@ msgstr "Prea multe încercări incorecte. Te rugăm să soliciți un cod nou."
 
 #, elixir-autogen, elixir-format
 msgid "auth.code.title"
-msgstr "Verifică-ți emailul"
+msgstr "Verifică emailul"
 
 #, elixir-autogen, elixir-format
 msgid "auth.continue.button"
@@ -278,7 +278,7 @@ msgstr "Te rugăm să introduci o adresă de email validă."
 
 #, elixir-autogen, elixir-format
 msgid "auth.title"
-msgstr "Care este adresa ta de email?"
+msgstr "Să începem"
 
 #, elixir-autogen, elixir-format
 msgid "auth.email.placeholder"
@@ -399,3 +399,7 @@ msgstr "Continuă"
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.title"
 msgstr "Verifică contul bancar"
+
+#, elixir-autogen, elixir-format
+msgid "auth.code.body"
+msgstr "Am trimis un cod la %{email}"


### PR DESCRIPTION
## Summary

The auth titles were doing double duty as big headings AND instructions — so long question-form translations (**\"Wie lautet deine E-Mail-Adresse?\"**, **\"Wat is je e-mailadres?\"**) blew up the layout on narrow viewports.

### Identify (\`/user/auth/identify\`)
- Title becomes **\"Get started\"** style (\"Aan de slag\", \"Los geht's\", \"Empezar\", ...). Input placeholder + Continue button already carry the actual instruction; the title now just sets a welcoming tone.

### Verify (\`/user/auth/verify\`)
- Title becomes **\"Verify email\"** style — honest about the moment without overpromising completion (new users still have onboarding after).
- Small footnote below the Continue button: **\"We've emailed you a code\"** (Text.footnote, text-grey3). Reads as a helpful reminder instead of an instruction competing with the primary action.

Same welcoming voice + note across all 7 locales (en, nl, de, es, it, lt, ro).

Fixes: FX#10093077239

## Test plan

- [ ] \`/user/auth/identify\` — title reads \"Get started\" (or locale equivalent), no wrap on any viewport width.
- [ ] \`/user/auth/verify\` — title reads \"Verify email\" (or locale equivalent). A small grey note below the Continue button reads \"We've emailed you a code\" (or locale equivalent).
- [ ] Switch language to Dutch / German → all copy translates cleanly, nothing wraps on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)