### PR TITLE
fix(advert): route promotion apply through /pool/:slug/join instead of silently joining

### DIFF
--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -10,6 +10,7 @@ defmodule Next.Account.AuthCodeVerifyPage do
   import CoreWeb.Menus
 
   alias CoreWeb.Endpoint
+  alias CoreWeb.ReturnTo
   alias Frameworks.Pixel.Button
   alias Systems.Account
 
@@ -26,7 +27,7 @@ defmodule Next.Account.AuthCodeVerifyPage do
           email: email,
           form: to_form(%{"code" => ""}),
           error: nil,
-          return_to: sanitize_return_to(Map.get(params, "return_to"))
+          return_to: ReturnTo.sanitize(Map.get(params, "return_to"))
         )
         |> update_menus()
       }
@@ -34,9 +35,6 @@ defmodule Next.Account.AuthCodeVerifyPage do
       {:ok, redirect(socket, to: ~p"/user/signin")}
     end
   end
-
-  defp sanitize_return_to("/" <> _rest = path), do: path
-  defp sanitize_return_to(_), do: nil
 
   def update_menus(%{assigns: %{current_user: user, uri: uri}} = socket) do
     menus = build_menus(stripped_menus_config(), user, uri)

--- a/core/bundles/next/lib/account/auth_page.ex
+++ b/core/bundles/next/lib/account/auth_page.ex
@@ -10,6 +10,7 @@ defmodule Next.Account.AuthPage do
   import CoreWeb.Menus
   import Frameworks.Pixel.Form
 
+  alias CoreWeb.ReturnTo
   alias Frameworks.Pixel.Button
   alias Systems.Account
 
@@ -23,7 +24,7 @@ defmodule Next.Account.AuthPage do
           form: to_form(%{"email" => ""}),
           error: nil,
           loading: false,
-          return_to: sanitize_return_to(Map.get(params, "return_to"))
+          return_to: ReturnTo.sanitize(Map.get(params, "return_to"))
         )
         |> update_menus()
       }
@@ -31,11 +32,6 @@ defmodule Next.Account.AuthPage do
       {:ok, redirect(socket, to: ~p"/user/signin")}
     end
   end
-
-  # Only same-origin paths are accepted, so an attacker cannot craft a link
-  # that ends up bouncing the user to an external site after login.
-  defp sanitize_return_to("/" <> _rest = path), do: path
-  defp sanitize_return_to(_), do: nil
 
   def update_menus(%{assigns: %{current_user: user, uri: uri}} = socket) do
     menus = build_menus(stripped_menus_config(), user, uri)
@@ -73,10 +69,10 @@ defmodule Next.Account.AuthPage do
 
     case Account.EmailRouter.route(email) do
       :google ->
-        {:noreply, redirect(socket, to: append_return_to(google_url(email), return_to))}
+        {:noreply, redirect(socket, to: ReturnTo.append(google_url(email), return_to))}
 
       :surfconext ->
-        {:noreply, redirect(socket, to: append_return_to("/auth/surfconext", return_to))}
+        {:noreply, redirect(socket, to: ReturnTo.append("/auth/surfconext", return_to))}
 
       :otp ->
         case Account.Public.generate_otp(email) do
@@ -99,13 +95,6 @@ defmodule Next.Account.AuthPage do
 
   defp verify_url(email, return_to),
     do: ~p"/user/auth/verify?email=#{email}&return_to=#{return_to}"
-
-  defp append_return_to(url, nil), do: url
-
-  defp append_return_to(url, return_to) do
-    sep = if String.contains?(url, "?"), do: "&", else: "?"
-    "#{url}#{sep}return_to=#{URI.encode_www_form(return_to)}"
-  end
 
   defp valid_email?(email), do: String.match?(email, ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/)
 

--- a/core/lib/core_web/return_to.ex
+++ b/core/lib/core_web/return_to.ex
@@ -1,0 +1,29 @@
+defmodule CoreWeb.ReturnTo do
+  @moduledoc """
+  Same-origin `return_to` handling shared across auth, onboarding, and
+  pool-join flows.
+
+    * `sanitize/1` — accept only same-origin (`/`-prefixed) paths so a
+      hostile CTA can't bounce the user to an external site after the
+      flow completes. Everything else becomes `nil`.
+    * `append/2` — URL-encode and attach a `return_to=<path>` query
+      param to a URL, picking `?` or `&` based on whether the target
+      already has a query string. `nil` is a no-op.
+    * `resolve/2` — pick `return_to` when present, otherwise fall back
+      to the caller-provided default. Convenient at "flow finish" call
+      sites that would otherwise write `return_to || default`.
+  """
+
+  def sanitize("/" <> _rest = path), do: path
+  def sanitize(_), do: nil
+
+  def append(path, nil), do: path
+
+  def append(path, return_to) when is_binary(return_to) do
+    sep = if String.contains?(path, "?"), do: "&", else: "?"
+    "#{path}#{sep}return_to=#{URI.encode_www_form(return_to)}"
+  end
+
+  def resolve(return_to, _default) when is_binary(return_to), do: return_to
+  def resolve(_, default), do: default
+end

--- a/core/systems/account/onboarding_page.ex
+++ b/core/systems/account/onboarding_page.ex
@@ -12,6 +12,7 @@ defmodule Systems.Account.OnboardingPage do
 
   import LiveNest.HTML
 
+  alias CoreWeb.ReturnTo
   alias Frameworks.Pixel.Button
   alias Frameworks.Pixel.Text
   alias Systems.Account
@@ -30,14 +31,9 @@ defmodule Systems.Account.OnboardingPage do
      |> assign(
        current_step_index: 0,
        modal_toolbar_buttons: [],
-       return_to: sanitize_return_to(Map.get(params, "return_to"))
+       return_to: ReturnTo.sanitize(Map.get(params, "return_to"))
      )}
   end
-
-  # Same-origin paths only, so a hostile CTA can't bounce the user to an
-  # external site after login.
-  defp sanitize_return_to("/" <> _rest = path), do: path
-  defp sanitize_return_to(_), do: nil
 
   @impl true
   def handle_view_model_updated(socket) do
@@ -90,11 +86,8 @@ defmodule Systems.Account.OnboardingPage do
     {:noreply, socket |> push_navigate(to: post_onboarding_path(socket, user))}
   end
 
-  defp post_onboarding_path(%{assigns: %{return_to: return_to}}, _user)
-       when is_binary(return_to),
-       do: return_to
-
-  defp post_onboarding_path(_socket, user), do: Account.UserAuth.signed_in_path(user)
+  defp post_onboarding_path(%{assigns: %{return_to: return_to}}, user),
+    do: ReturnTo.resolve(return_to, Account.UserAuth.signed_in_path(user))
 
   defp activated?(%{assigns: %{current_user: %{id: user_id}}}) do
     user_id

--- a/core/systems/account/user_auth.ex
+++ b/core/systems/account/user_auth.ex
@@ -5,6 +5,7 @@ defmodule Systems.Account.UserAuth do
   import Phoenix.Controller
   use Gettext, backend: CoreWeb.Gettext
 
+  alias CoreWeb.ReturnTo
   alias Systems.Account
 
   # Make the remember me cookie valid for 60 days.
@@ -36,7 +37,7 @@ defmodule Systems.Account.UserAuth do
     # straight to their return_to via `redirect_path_after_signin/2`.
     redirect_to =
       if first_time? do
-        with_return_to(~p"/user/onboarding", get_session(conn, :user_return_to))
+        ReturnTo.append(~p"/user/onboarding", get_session(conn, :user_return_to))
       else
         redirect_path_after_signin(conn, user)
       end
@@ -47,13 +48,6 @@ defmodule Systems.Account.UserAuth do
     |> put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: redirect_to)
-  end
-
-  defp with_return_to(path, nil), do: path
-
-  defp with_return_to(path, return_to) when is_binary(return_to) do
-    sep = if String.contains?(path, "?"), do: "&", else: "?"
-    "#{path}#{sep}return_to=#{URI.encode_www_form(return_to)}"
   end
 
   def log_in_user_without_redirect(conn, user) do

--- a/core/systems/advert/promotion_landing_page_builder.ex
+++ b/core/systems/advert/promotion_landing_page_builder.ex
@@ -75,6 +75,11 @@ defmodule Systems.Advert.PromotionLandingPageBuilder do
   defp cta_label(true), do: dgettext("eyra-advert", "promotion.apply.button")
   defp cta_label(false), do: dgettext("eyra-advert", "promotion.full.button")
 
+  # Existing pool members bypass the consent screen and go straight
+  # to the assignment; non-members are routed through the pool join
+  # gate with a `return_to` so they land on the same assignment after
+  # accepting the join consent, instead of being silently added and
+  # sent straight in.
   def handle_apply(
         %{
           assigns: %{
@@ -87,8 +92,14 @@ defmodule Systems.Advert.PromotionLandingPageBuilder do
           }
         } = socket
       ) do
-    Pool.Public.add_participant!(pool, user)
     Promotion.Private.log_performance_event(promotion, :clicks)
-    LiveView.push_navigate(socket, to: ~p"/assignment/#{id}/apply")
+    apply_path = ~p"/assignment/#{id}/apply"
+
+    if Pool.Public.participant?(pool, user) do
+      LiveView.push_navigate(socket, to: apply_path)
+    else
+      slug = Pool.Model.slug(pool)
+      LiveView.push_navigate(socket, to: ~p"/pool/#{slug}/join?return_to=#{apply_path}")
+    end
   end
 end

--- a/core/systems/pool/controller.ex
+++ b/core/systems/pool/controller.ex
@@ -12,27 +12,19 @@ defmodule Systems.Pool.Controller do
   """
   use CoreWeb, {:controller, [formats: [:html]]}
 
+  alias CoreWeb.ReturnTo
   alias Systems.Pool
   alias Systems.Account
 
   def join(conn, %{"slug" => slug} = params) do
     user = conn.assigns.current_user
     %Pool.Model{} = pool = Pool.Public.get_by_slug(String.to_existing_atom(slug))
-    return_to = sanitize_return_to(Map.get(params, "return_to"))
+    return_to = ReturnTo.sanitize(Map.get(params, "return_to"))
 
     if Pool.Public.participant?(pool, user) do
-      redirect(conn, to: return_to || Account.UserAuth.signed_in_path(user))
+      redirect(conn, to: ReturnTo.resolve(return_to, Account.UserAuth.signed_in_path(user)))
     else
-      redirect(conn, to: with_return_to(~p"/pool/#{slug}/onboarding", return_to))
+      redirect(conn, to: ReturnTo.append(~p"/pool/#{slug}/onboarding", return_to))
     end
-  end
-
-  defp sanitize_return_to("/" <> _rest = path), do: path
-  defp sanitize_return_to(_), do: nil
-
-  defp with_return_to(path, nil), do: path
-
-  defp with_return_to(path, return_to) do
-    "#{path}?return_to=#{URI.encode_www_form(return_to)}"
   end
 end

--- a/core/systems/pool/controller.ex
+++ b/core/systems/pool/controller.ex
@@ -15,14 +15,24 @@ defmodule Systems.Pool.Controller do
   alias Systems.Pool
   alias Systems.Account
 
-  def join(conn, %{"slug" => slug}) do
+  def join(conn, %{"slug" => slug} = params) do
     user = conn.assigns.current_user
     %Pool.Model{} = pool = Pool.Public.get_by_slug(String.to_existing_atom(slug))
+    return_to = sanitize_return_to(Map.get(params, "return_to"))
 
     if Pool.Public.participant?(pool, user) do
-      redirect(conn, to: Account.UserAuth.signed_in_path(user))
+      redirect(conn, to: return_to || Account.UserAuth.signed_in_path(user))
     else
-      redirect(conn, to: ~p"/pool/#{slug}/onboarding")
+      redirect(conn, to: with_return_to(~p"/pool/#{slug}/onboarding", return_to))
     end
+  end
+
+  defp sanitize_return_to("/" <> _rest = path), do: path
+  defp sanitize_return_to(_), do: nil
+
+  defp with_return_to(path, nil), do: path
+
+  defp with_return_to(path, return_to) do
+    "#{path}?return_to=#{URI.encode_www_form(return_to)}"
   end
 end

--- a/core/systems/pool/onboarding_page.ex
+++ b/core/systems/pool/onboarding_page.ex
@@ -42,7 +42,14 @@ defmodule Systems.Pool.OnboardingPage do
   end
 
   @impl true
-  def mount(_params, _session, socket), do: {:ok, socket}
+  def mount(params, _session, socket) do
+    {:ok, socket |> assign(return_to: sanitize_return_to(Map.get(params, "return_to")))}
+  end
+
+  # Same-origin paths only, so a hostile CTA can't bounce the user to an
+  # external site after the flow completes.
+  defp sanitize_return_to("/" <> _rest = path), do: path
+  defp sanitize_return_to(_), do: nil
 
   @impl true
   def consume_event(

--- a/core/systems/pool/onboarding_page.ex
+++ b/core/systems/pool/onboarding_page.ex
@@ -29,6 +29,7 @@ defmodule Systems.Pool.OnboardingPage do
 
   import LiveNest.HTML
 
+  alias CoreWeb.ReturnTo
   alias Frameworks.Pixel.Button
   alias Frameworks.Pixel.Logo
   alias Frameworks.Pixel.Text
@@ -43,13 +44,8 @@ defmodule Systems.Pool.OnboardingPage do
 
   @impl true
   def mount(params, _session, socket) do
-    {:ok, socket |> assign(return_to: sanitize_return_to(Map.get(params, "return_to")))}
+    {:ok, socket |> assign(return_to: ReturnTo.sanitize(Map.get(params, "return_to")))}
   end
-
-  # Same-origin paths only, so a hostile CTA can't bounce the user to an
-  # external site after the flow completes.
-  defp sanitize_return_to("/" <> _rest = path), do: path
-  defp sanitize_return_to(_), do: nil
 
   @impl true
   def consume_event(

--- a/core/systems/pool/onboarding_page_builder.ex
+++ b/core/systems/pool/onboarding_page_builder.ex
@@ -27,6 +27,7 @@ defmodule Systems.Pool.OnboardingPageBuilder do
   def view_model(%Pool.Model{} = pool, assigns) do
     current_step_index = Map.get(assigns, :current_step_index, 0)
     user = Map.get(assigns, :current_user)
+    return_to = Map.get(assigns, :return_to)
     steps = build_steps(pool, user, current_step_index)
     current_step = Enum.at(steps, current_step_index)
     live_context = build_live_context(user)
@@ -41,7 +42,7 @@ defmodule Systems.Pool.OnboardingPageBuilder do
       step_body: build_step_body(current_step, pool),
       continue_button: build_continue_button(current_step),
       is_last_step: current_step_index >= length(steps) - 1,
-      finish_path: build_finish_path(user),
+      finish_path: build_finish_path(return_to, user),
       hero_title: build_hero_title(current_step, pool),
       progress_dots: build_progress_dots(steps, current_step_index)
     }
@@ -64,11 +65,13 @@ defmodule Systems.Pool.OnboardingPageBuilder do
   defp build_hero_title(_step, %Pool.Model{}),
     do: dgettext("eyra-pool", "onboarding.hero.title")
 
-  # Where the flow exits — the user's signed-in landing. Owned by the
-  # builder so the page never has to know the URL scheme; a decline or
-  # a "continue" on the last step just reads `vm.finish_path`.
-  defp build_finish_path(%Account.User{} = user), do: Account.UserAuth.signed_in_path(user)
-  defp build_finish_path(_), do: "/"
+  # Where the flow exits. When a caller (e.g. Promotion apply) sent the
+  # user through the join gate with a `?return_to=<path>`, we honour it
+  # so they land back where they started instead of on the generic home.
+  # Otherwise fall back to the user's signed-in landing.
+  defp build_finish_path(return_to, _user) when is_binary(return_to), do: return_to
+  defp build_finish_path(_, %Account.User{} = user), do: Account.UserAuth.signed_in_path(user)
+  defp build_finish_path(_, _), do: "/"
 
   # `show_title: false` hides each step view's own title so the page-level
   # `hero_title` is the sole visual anchor across the flow.

--- a/core/systems/pool/onboarding_page_builder.ex
+++ b/core/systems/pool/onboarding_page_builder.ex
@@ -20,6 +20,7 @@ defmodule Systems.Pool.OnboardingPageBuilder do
   """
   use Gettext, backend: CoreWeb.Gettext
 
+  alias CoreWeb.ReturnTo
   alias Frameworks.Concept.LiveContext
   alias Systems.Pool
   alias Systems.Account
@@ -65,13 +66,10 @@ defmodule Systems.Pool.OnboardingPageBuilder do
   defp build_hero_title(_step, %Pool.Model{}),
     do: dgettext("eyra-pool", "onboarding.hero.title")
 
-  # Where the flow exits. When a caller (e.g. Promotion apply) sent the
-  # user through the join gate with a `?return_to=<path>`, we honour it
-  # so they land back where they started instead of on the generic home.
-  # Otherwise fall back to the user's signed-in landing.
-  defp build_finish_path(return_to, _user) when is_binary(return_to), do: return_to
-  defp build_finish_path(_, %Account.User{} = user), do: Account.UserAuth.signed_in_path(user)
-  defp build_finish_path(_, _), do: "/"
+  defp build_finish_path(return_to, %Account.User{} = user),
+    do: ReturnTo.resolve(return_to, Account.UserAuth.signed_in_path(user))
+
+  defp build_finish_path(return_to, _user), do: ReturnTo.resolve(return_to, "/")
 
   # `show_title: false` hides each step view's own title so the page-level
   # `hero_title` is the sole visual anchor across the flow.

--- a/core/test/systems/advert/promotion_landing_page_builder_test.exs
+++ b/core/test/systems/advert/promotion_landing_page_builder_test.exs
@@ -37,19 +37,48 @@ defmodule Systems.Advert.PromotionLandingPageBuilderTest do
       assert html =~ "promotion-apply-button-hero-disabled"
     end
 
-    test "Participate", %{conn: %{assigns: %{current_user: participant}} = conn} do
+    test "non-member Apply routes through the pool join gate", %{
+      conn: %{assigns: %{current_user: participant}} = conn
+    } do
       creator = Factories.insert!(:creator)
 
       %{promotion_id: promotion_id, submission_id: submission_id, assignment_id: assignment_id} =
         Advert.Factories.create_advert(creator, :accepted, 1)
 
+      pool = Pool.Public.get_by_submission!(submission_id)
+      refute Pool.Public.participant?(pool, participant)
+
       {:ok, view, _html} = live(conn, ~p"/promotion/#{promotion_id}")
 
-      view
-      |> render_click("call-to-action-1")
+      view |> render_click("call-to-action-1")
+
+      slug = Pool.Model.slug(pool)
+
+      assert_redirected(
+        view,
+        "/pool/#{slug}/join?return_to=%2Fassignment%2F#{assignment_id}%2Fapply"
+      )
+
+      # User is NOT silently added — join happens on the consent screen.
+      refute Pool.Public.participant?(pool, participant)
+    end
+
+    test "existing member Apply goes straight to the assignment", %{
+      conn: %{assigns: %{current_user: participant}} = conn
+    } do
+      creator = Factories.insert!(:creator)
+
+      %{promotion_id: promotion_id, submission_id: submission_id, assignment_id: assignment_id} =
+        Advert.Factories.create_advert(creator, :accepted, 1)
+
+      pool = Pool.Public.get_by_submission!(submission_id)
+      Pool.Public.add_participant!(pool, participant)
+
+      {:ok, view, _html} = live(conn, ~p"/promotion/#{promotion_id}")
+
+      view |> render_click("call-to-action-1")
 
       assert_redirected(view, "/assignment/#{assignment_id}/apply")
-      assert Pool.Public.participant?(Pool.Public.get_by_submission!(submission_id), participant)
     end
   end
 end

--- a/core/test/systems/pool/controller_test.exs
+++ b/core/test/systems/pool/controller_test.exs
@@ -22,6 +22,18 @@ defmodule Systems.Pool.ControllerTest do
       assert redirected_to(conn) == "/pool/panl/onboarding"
     end
 
+    test "forwards return_to to the onboarding page for non-participants", %{
+      conn: conn,
+      user: user
+    } do
+      pool = panl_pool()
+      refute Pool.Public.participant?(pool, user)
+
+      conn = get(conn, ~p"/pool/panl/join?return_to=/assignment/42/apply")
+
+      assert redirected_to(conn) == "/pool/panl/onboarding?return_to=%2Fassignment%2F42%2Fapply"
+    end
+
     test "redirects existing participants to the home page", %{conn: conn, user: user} do
       pool = panl_pool()
       Pool.Public.add_participant!(pool, user)
@@ -30,6 +42,24 @@ defmodule Systems.Pool.ControllerTest do
 
       # Home lives at "/" for members via Account.UserAuth.signed_in_path/1.
       assert redirected_to(conn) == "/"
+    end
+
+    test "redirects existing participants to return_to when provided", %{conn: conn, user: user} do
+      pool = panl_pool()
+      Pool.Public.add_participant!(pool, user)
+
+      conn = get(conn, ~p"/pool/panl/join?return_to=/assignment/42/apply")
+
+      assert redirected_to(conn) == "/assignment/42/apply"
+    end
+
+    test "ignores off-site return_to (only same-origin paths allowed)", %{conn: conn, user: user} do
+      pool = panl_pool()
+      refute Pool.Public.participant?(pool, user)
+
+      conn = get(conn, ~p"/pool/panl/join?return_to=https://evil.example.com/steal")
+
+      assert redirected_to(conn) == "/pool/panl/onboarding"
     end
   end
 

--- a/core/test/systems/pool/onboarding_page_builder_test.exs
+++ b/core/test/systems/pool/onboarding_page_builder_test.exs
@@ -171,5 +171,15 @@ defmodule Systems.Pool.OnboardingPageBuilderTest do
 
       assert vm.finish_path == "/"
     end
+
+    test "prefers return_to over the signed-in landing when present", %{user: user, pool: pool} do
+      vm =
+        Pool.OnboardingPageBuilder.view_model(pool, %{
+          current_user: user,
+          return_to: "/assignment/42/apply"
+        })
+
+      assert vm.finish_path == "/assignment/42/apply"
+    end
   end
 end


### PR DESCRIPTION
## Summary

Clicking Apply on a promotion landing page used to call \`Pool.Public.add_participant!\` directly — dropping the user into the pool with **no consent screen**. Now the CTA routes through the informed-consent join gate that shipped in PR #1626 for other pool entry points.

- **\`PromotionLandingPageBuilder.handle_apply/1\`** — checks Pool participation. Existing members go straight to \`/assignment/:id/apply\`; non-members are redirected to \`/pool/:slug/join?return_to=/assignment/:id/apply\`.
- **\`Pool.Controller.join/2\`** — accepts a \`return_to\` query param and forwards it to the onboarding page (or uses it directly for existing members).
- **\`Pool.OnboardingPage.mount/3\`** — reads and stores \`return_to\` in socket assigns.
- **\`Pool.OnboardingPageBuilder.build_finish_path/2\`** — prefers \`return_to\` over \`signed_in_path\` so the flow lands back on the assignment.

## Also in this PR: extract \`CoreWeb.ReturnTo\`

\`sanitize_return_to\` and its URL-append sibling were duplicated across auth pages, onboarding pages, \`Account.UserAuth\`, and now the pool controller. Consolidated into one module:

- \`CoreWeb.ReturnTo.sanitize/1\` — same-origin path guard.
- \`CoreWeb.ReturnTo.append/2\` — attach \`?return_to=<path>\` (or \`&\` when the base URL already has a query string).
- \`CoreWeb.ReturnTo.resolve/2\` — collapses \`return_to || default\` at flow-finish call sites.

Seven callers updated: \`Account.UserAuth\`, \`Account.OnboardingPage\`, \`Pool.Controller\`, \`Pool.OnboardingPage\`, \`Pool.OnboardingPageBuilder\`, \`Next.Account.AuthPage\`, \`Next.Account.AuthCodeVerifyPage\`.

## Out of scope

Anonymous-user click on the Apply button still crashes on nil user — filed as **FX#10094100454** for a follow-up PR.

Fixes: FX#10083277800

## Test plan

- [ ] As a signed-in non-Panl user, open a Panl promotion → click Apply → land on \`/pool/panl/join\` (the consent screen with the Panl logo).
- [ ] Accept the consent → complete features → land on \`/assignment/<id>/apply\` (not Home).
- [ ] As a signed-in Panl member, open the same promotion → click Apply → land directly on \`/assignment/<id>/apply\` (no consent screen).
- [ ] Sanity-check existing auth flows (identify/verify with \`?return_to=...\`) still forward the return-to correctly through the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)