### PR TITLE
fix: reject non-positive reward amounts at the boundary

### DIFF
--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -276,6 +276,11 @@ defmodule Systems.Fund.Public do
     |> Repo.commit()
   end
 
+  def create_reward(multi, %Fund.Model{}, amount, _user, idempotence_key)
+      when is_integer(amount) and amount <= 0 and is_binary(idempotence_key) do
+    Multi.error(multi, :create_reward, :non_positive_amount)
+  end
+
   def create_reward(
         multi,
         %Fund.Model{} = fund,
@@ -283,7 +288,7 @@ defmodule Systems.Fund.Public do
         user,
         idempotence_key
       )
-      when is_integer(amount) and is_binary(idempotence_key) do
+      when is_integer(amount) and amount > 0 and is_binary(idempotence_key) do
     multi
     |> guard_fund_balance(fund, amount)
     |> upsert_reward(fund, amount, user, idempotence_key)

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -264,8 +264,13 @@ defmodule Systems.Fund.Public do
     not wallet_is_passive?(wallet)
   end
 
+  def create_reward(%Fund.Model{}, amount, _user, idempotence_key)
+      when is_integer(amount) and amount <= 0 and is_binary(idempotence_key) do
+    {:error, :non_positive_amount}
+  end
+
   def create_reward(%Fund.Model{} = fund, amount, user, idempotence_key)
-      when is_integer(amount) and is_binary(idempotence_key) do
+      when is_integer(amount) and amount > 0 and is_binary(idempotence_key) do
     Multi.new()
     |> create_reward(fund, amount, user, idempotence_key)
     |> Repo.commit()

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -69,6 +69,8 @@ defmodule Systems.Fund.PublicTest do
 
     assert {:error, :non_positive_amount} =
              Fund.Public.create_reward(fund, -500, participant, "neg-key")
+
+    assert Repo.all(Fund.RewardModel) == []
   end
 
   test "create_reward/4 rejects a zero amount", %{fund: fund} do
@@ -76,6 +78,19 @@ defmodule Systems.Fund.PublicTest do
 
     assert {:error, :non_positive_amount} =
              Fund.Public.create_reward(fund, 0, participant, "zero-key")
+
+    assert Repo.all(Fund.RewardModel) == []
+  end
+
+  test "create_reward/5 injects a clean failure for a non-positive amount", %{fund: fund} do
+    participant = Factories.insert!(:member, %{creator: false})
+
+    assert {:error, :create_reward, :non_positive_amount, _changes} =
+             Ecto.Multi.new()
+             |> Fund.Public.create_reward(fund, -500, participant, "neg-key-multi")
+             |> Repo.commit()
+
+    assert Repo.all(Fund.RewardModel) == []
   end
 
   test "rollback_deposit/4 fails without deposit", %{fund: fund} do

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -64,6 +64,20 @@ defmodule Systems.Fund.PublicTest do
            } = reward
   end
 
+  test "create_reward/4 rejects a negative amount without touching the ledger", %{fund: fund} do
+    participant = Factories.insert!(:member, %{creator: false})
+
+    assert {:error, :non_positive_amount} =
+             Fund.Public.create_reward(fund, -500, participant, "neg-key")
+  end
+
+  test "create_reward/4 rejects a zero amount", %{fund: fund} do
+    participant = Factories.insert!(:member, %{creator: false})
+
+    assert {:error, :non_positive_amount} =
+             Fund.Public.create_reward(fund, 0, participant, "zero-key")
+  end
+
   test "rollback_deposit/4 fails without deposit", %{fund: fund} do
     participant = Factories.insert!(:member, %{creator: false})
 


### PR DESCRIPTION
`create_reward` only guarded `is_integer(amount)`, so a negative amount reached a debit ledger line and crashed on the Postgres CHECK (`book_balance_debit_must_be_positive`), and a zero amount silently booked a no-op reward. This adds a boundary clause returning a clean `{:error, :non_positive_amount}` for `amount <= 0`.

Fixes Flux [10100771866](https://app.basecamp.com/5734045/buckets/35926565/todos/10100771866). Surfaced by the money-flow assurance audit (BUG 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)