### PR TITLE
fix: refuse to fail an already-completed pay-in transaction

### DIFF
--- a/core/systems/budget/_public.ex
+++ b/core/systems/budget/_public.ex
@@ -183,7 +183,7 @@ defmodule Systems.Budget.Public do
 
     case transaction.status do
       :completed ->
-        {:error, "Transaction already completed"}
+        {:error, :already_completed}
 
       _ ->
         do_complete_transaction(transaction)
@@ -234,7 +234,7 @@ defmodule Systems.Budget.Public do
             "fund stays credited"
         )
 
-        {:error, "Transaction already completed"}
+        {:error, :already_completed}
 
       _ ->
         transaction

--- a/core/systems/budget/_public.ex
+++ b/core/systems/budget/_public.ex
@@ -227,9 +227,20 @@ defmodule Systems.Budget.Public do
   def fail_transaction(provider_uid) when is_binary(provider_uid) do
     transaction = get_transaction_by_provider_uid!(provider_uid)
 
-    transaction
-    |> Budget.TransactionModel.changeset(%{status: :failed})
-    |> Repo.update()
+    case transaction.status do
+      :completed ->
+        Logger.error(
+          "[Budget] refusing late 'failed' for already-completed transaction #{provider_uid}; " <>
+            "fund stays credited"
+        )
+
+        {:error, "Transaction already completed"}
+
+      _ ->
+        transaction
+        |> Budget.TransactionModel.changeset(%{status: :failed})
+        |> Repo.update()
+    end
   end
 
   @pay_in_expiration_minutes 15

--- a/core/systems/budget/transaction_reconciliation.ex
+++ b/core/systems/budget/transaction_reconciliation.ex
@@ -117,6 +117,9 @@ defmodule Systems.Budget.TransactionReconciliation do
   defp resolve(%{status: :pending, transaction_id: uid}, "failed") do
     case Budget.Public.fail_transaction(uid) do
       {:ok, _} -> {:ok, :resolved_failed}
+      # Provider completed the transaction in the gap between our read and this
+      # write; the guard refused the stale "failed" — a benign no-op, not an error.
+      {:error, :already_completed} -> {:ok, :verified}
       other -> {:error, other}
     end
   rescue

--- a/core/test/systems/budget/complete_transaction_test.exs
+++ b/core/test/systems/budget/complete_transaction_test.exs
@@ -28,7 +28,7 @@ defmodule Systems.Budget.CompleteTransactionTest do
     test "refuses a transaction that is already :completed" do
       %{transaction: transaction} = setup_transaction(status: :completed)
 
-      assert {:error, "Transaction already completed"} =
+      assert {:error, :already_completed} =
                Budget.Public.complete_transaction(transaction.transaction_id)
     end
   end

--- a/core/test/systems/budget/fail_transaction_test.exs
+++ b/core/test/systems/budget/fail_transaction_test.exs
@@ -21,7 +21,7 @@ defmodule Systems.Budget.FailTransactionTest do
 
       log =
         capture_log(fn ->
-          assert {:error, "Transaction already completed"} =
+          assert {:error, :already_completed} =
                    Budget.Public.fail_transaction(transaction.transaction_id)
         end)
 

--- a/core/test/systems/budget/fail_transaction_test.exs
+++ b/core/test/systems/budget/fail_transaction_test.exs
@@ -1,0 +1,57 @@
+defmodule Systems.Budget.FailTransactionTest do
+  use Core.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Core.Factories
+  alias Core.Repo
+  alias Systems.Budget
+  alias Systems.Fund
+
+  describe "fail_transaction/1" do
+    test "fails a :pending transaction via the normal path" do
+      transaction = insert_transaction(:pending)
+
+      assert {:ok, %{status: :failed}} =
+               Budget.Public.fail_transaction(transaction.transaction_id)
+    end
+
+    test "refuses a late 'failed' webhook on an already-:completed transaction" do
+      transaction = insert_transaction(:completed)
+
+      log =
+        capture_log(fn ->
+          assert {:error, "Transaction already completed"} =
+                   Budget.Public.fail_transaction(transaction.transaction_id)
+        end)
+
+      assert log =~ "refusing late 'failed' for already-completed transaction"
+
+      # The fund stays credited, so the status must not contradict it by flipping to :failed.
+      assert %{status: :completed} = Repo.get!(Budget.TransactionModel, transaction.id)
+    end
+  end
+
+  defp insert_transaction(status) do
+    unique = System.unique_integer([:positive])
+    user = Factories.insert!(:member)
+    currency = Fund.Factories.create_currency("fail_tx_#{unique}", :legal, "€", 2)
+    fund = Fund.Factories.create_fund("fail_tx_fund_#{unique}", currency)
+
+    {:ok, transaction} =
+      %Budget.TransactionModel{}
+      |> Budget.TransactionModel.changeset(%{
+        transaction_id: "provider-" <> Ecto.UUID.generate(),
+        status: status,
+        idempotence_key: Ecto.UUID.generate(),
+        invoice_id: "NEXT-TEST-#{unique}",
+        subject_count: 10,
+        total_amount: 5000
+      })
+      |> Ecto.Changeset.put_change(:user_id, user.id)
+      |> Ecto.Changeset.put_change(:target_fund_id, fund.id)
+      |> Repo.insert()
+
+    transaction
+  end
+end

--- a/core/test/systems/budget/reconcile_transactions_test.exs
+++ b/core/test/systems/budget/reconcile_transactions_test.exs
@@ -138,6 +138,23 @@ defmodule Systems.Budget.ReconcileTransactionsTest do
     assert %{status: :failed} = Repo.reload!(transaction)
   end
 
+  test "verifies (does not error) a pending transaction the provider completes mid-sweep" do
+    transaction = setup_transaction(:pending)
+
+    # The provider reports "failed", but between our scan and the fail write the
+    # transaction completes (a winning "completed" webhook). The guard refuses the
+    # stale "failed"; that benign race must be tallied as verified, not as an error.
+    expect(ProviderMock, :get_transaction, fn uid ->
+      from(t in Budget.TransactionModel, where: t.transaction_id == ^uid)
+      |> Repo.update_all(set: [status: :completed])
+
+      {:ok, %{uid: uid, status: "failed", payment_url: nil, amount: 0}}
+    end)
+
+    assert %{scanned: 1, verified: 1, errors: 0, resolved_failed: 0} = reconcile()
+    assert %{status: :completed} = Repo.reload!(transaction)
+  end
+
   test "leaves a pending transaction that OPP is still processing" do
     transaction = setup_transaction(:pending)
     stub_opp_status(transaction.transaction_id, "new")


### PR DESCRIPTION
`fail_transaction` flipped a transaction to `:failed` unconditionally, so a stale or out-of-order "failed" webhook arriving *after* a pay-in had already completed left the transaction `:failed` while the fund stayed credited — the stored status and the ledger contradicting each other. This guards it the way `complete_transaction` already guards re-completion: it refuses when the transaction is `:completed`.

The reconciler already only fails `:pending` transactions, so the exposed path was the webhook (`apply_transaction_status("failed", …)`).

Fixes Flux [10100771736](https://app.basecamp.com/5734045/buckets/35926565/todos/10100771736). Surfaced by the money-flow assurance audit (BUG 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)