### PR TITLE
fix: scope payouts to euro rewards, never sum across currencies

### DIFF
--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -975,7 +975,6 @@ defmodule Systems.Fund.Public do
 
   @doc """
   Pure pre-flight threshold check (no side effects), used by `prepare_payout/2`.
-  Scoped to `currency` (the payable currency is decided by the UI layer).
   """
   def payout_eligibility(%Account.User{id: user_id}, currency) do
     total =
@@ -1252,8 +1251,6 @@ defmodule Systems.Fund.Public do
     )
   end
 
-  # Scoped to euro funds so rewards in other currencies are never summed into a
-  # EUR withdrawal; they stay :approved until multi-currency payouts exist.
   defp list_approved_rewards(user_id, currency) do
     reward_query_in_currency(user_id, currency)
     |> where([reward: r], r.status == :approved)

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -947,6 +947,10 @@ defmodule Systems.Fund.Public do
 
   @payout_threshold_cents 500
 
+  # OPP settles payouts to a EUR bank account, so only euro-fund rewards are
+  # payable. The canonical euro currency is named "euro" (see Fund.Assembly).
+  @payout_currency_name "euro"
+
   @doc """
   Minimum approved balance (in cents) required to request a payout — €5.
   """
@@ -1253,9 +1257,17 @@ defmodule Systems.Fund.Public do
     )
   end
 
+  # Scoped to euro funds so rewards in other currencies are never summed into a
+  # EUR withdrawal; they stay :approved until multi-currency payouts exist.
   defp list_approved_rewards(user_id) do
     from(r in Fund.RewardModel,
-      where: r.user_id == ^user_id and r.status == :approved
+      join: f in Fund.Model,
+      on: f.id == r.fund_id,
+      join: c in Fund.CurrencyModel,
+      on: c.id == f.currency_id,
+      where:
+        r.user_id == ^user_id and r.status == :approved and
+          c.name == ^@payout_currency_name
     )
     |> Repo.all()
   end

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -926,15 +926,9 @@ defmodule Systems.Fund.Public do
   """
   def summarize_rewards(%Account.User{id: user_id}, currency) do
     totals =
-      from(r in Fund.RewardModel,
-        join: f in Fund.Model,
-        on: f.id == r.fund_id,
-        join: c in Fund.CurrencyModel,
-        on: c.id == f.currency_id,
-        where: r.user_id == ^user_id and c.name == ^currency,
-        group_by: r.status,
-        select: {r.status, sum(r.amount)}
-      )
+      reward_query_in_currency(user_id, currency)
+      |> group_by([reward: r], r.status)
+      |> select([reward: r], {r.status, sum(r.amount)})
       |> Repo.all()
       |> Enum.into(%{})
 
@@ -1261,15 +1255,8 @@ defmodule Systems.Fund.Public do
   # Scoped to euro funds so rewards in other currencies are never summed into a
   # EUR withdrawal; they stay :approved until multi-currency payouts exist.
   defp list_approved_rewards(user_id, currency) do
-    from(r in Fund.RewardModel,
-      join: f in Fund.Model,
-      on: f.id == r.fund_id,
-      join: c in Fund.CurrencyModel,
-      on: c.id == f.currency_id,
-      where:
-        r.user_id == ^user_id and r.status == :approved and
-          c.name == ^currency
-    )
+    reward_query_in_currency(user_id, currency)
+    |> where([reward: r], r.status == :approved)
     |> Repo.all()
   end
 

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -924,10 +924,14 @@ defmodule Systems.Fund.Public do
   @doc """
   Per-status reward totals (in cents) for the home rewards-summary card.
   """
-  def summarize_rewards(%Account.User{id: user_id}) do
+  def summarize_rewards(%Account.User{id: user_id}, currency) do
     totals =
       from(r in Fund.RewardModel,
-        where: r.user_id == ^user_id,
+        join: f in Fund.Model,
+        on: f.id == r.fund_id,
+        join: c in Fund.CurrencyModel,
+        on: c.id == f.currency_id,
+        where: r.user_id == ^user_id and c.name == ^currency,
         group_by: r.status,
         select: {r.status, sum(r.amount)}
       )
@@ -947,10 +951,6 @@ defmodule Systems.Fund.Public do
 
   @payout_threshold_cents 500
 
-  # OPP settles payouts to a EUR bank account, so only euro-fund rewards are
-  # payable. The canonical euro currency is named "euro" (see Fund.Assembly).
-  @payout_currency_name "euro"
-
   @doc """
   Minimum approved balance (in cents) required to request a payout — €5.
   """
@@ -961,14 +961,14 @@ defmodule Systems.Fund.Public do
   them, then charges and withdraws via OPP. Returns `{:ok, result}` or
   `{:error, reason}`.
   """
-  def request_payout(%Account.User{} = user) do
+  def request_payout(%Account.User{} = user, currency) do
     # Reload: the caller may hold a struct from before prepare_payout/1 set merchant_uid.
     case Repo.reload!(user) do
       %Account.User{merchant_uid: nil} ->
         {:error, :no_merchant}
 
       %Account.User{id: user_id, merchant_uid: merchant_uid} ->
-        approved = list_approved_rewards(user_id)
+        approved = list_approved_rewards(user_id, currency)
         total = Enum.reduce(approved, 0, fn %{amount: amount}, acc -> acc + amount end)
 
         if total < @payout_threshold_cents do
@@ -980,11 +980,12 @@ defmodule Systems.Fund.Public do
   end
 
   @doc """
-  Pure pre-flight threshold check (no side effects), used by `prepare_payout/1`.
+  Pure pre-flight threshold check (no side effects), used by `prepare_payout/2`.
+  Scoped to `currency` (the payable currency is decided by the UI layer).
   """
-  def payout_eligibility(%Account.User{id: user_id}) do
+  def payout_eligibility(%Account.User{id: user_id}, currency) do
     total =
-      list_approved_rewards(user_id)
+      list_approved_rewards(user_id, currency)
       |> Enum.reduce(0, fn %{amount: amount}, acc -> acc + amount end)
 
     if total < @payout_threshold_cents do
@@ -998,8 +999,8 @@ defmodule Systems.Fund.Public do
   Side-effecting pre-handoff check (UC-OPP-06.A1): ensures merchant + bank
   account exist, then reports payout readiness via `payout_ready_for/1`.
   """
-  def prepare_payout(%Account.User{} = user) do
-    with :ok <- payout_eligibility(user),
+  def prepare_payout(%Account.User{} = user, currency) do
+    with :ok <- payout_eligibility(user, currency),
          {:ok, {_user, merchant}} <- Payment.Public.ensure_merchant_for(user),
          {:ok, bank_account} <- Payment.Public.ensure_bank_account_for(merchant.uid) do
       payout_ready_for(bank_account)
@@ -1259,7 +1260,7 @@ defmodule Systems.Fund.Public do
 
   # Scoped to euro funds so rewards in other currencies are never summed into a
   # EUR withdrawal; they stay :approved until multi-currency payouts exist.
-  defp list_approved_rewards(user_id) do
+  defp list_approved_rewards(user_id, currency) do
     from(r in Fund.RewardModel,
       join: f in Fund.Model,
       on: f.id == r.fund_id,
@@ -1267,7 +1268,7 @@ defmodule Systems.Fund.Public do
       on: c.id == f.currency_id,
       where:
         r.user_id == ^user_id and r.status == :approved and
-          c.name == ^@payout_currency_name
+          c.name == ^currency
     )
     |> Repo.all()
   end

--- a/core/systems/fund/_queries.ex
+++ b/core/systems/fund/_queries.ex
@@ -32,4 +32,17 @@ defmodule Systems.Fund.Queries do
       status == ^status
     ])
   end
+
+  # Rewards for a user, scoped to a currency via the reward's fund. Shared base
+  # for the per-status summary and the approved-payout list, both of which only
+  # ever consider rewards payable in a single currency.
+  def reward_query_in_currency(user_id, currency_name)
+      when is_integer(user_id) and is_binary(currency_name) do
+    from(reward in Fund.RewardModel,
+      as: :reward,
+      join: fund in assoc(reward, :fund),
+      join: cur in assoc(fund, :currency),
+      where: reward.user_id == ^user_id and cur.name == ^currency_name
+    )
+  end
 end

--- a/core/systems/home/page_builder.ex
+++ b/core/systems/home/page_builder.ex
@@ -20,6 +20,13 @@ defmodule Systems.Home.PageBuilder do
   # Number of studies shown on the home page before linking to the marketplace
   @home_card_limit 3
 
+  # The currency participants are paid out in. Hardcoded to euro for now: OPP
+  # settles to a EUR bank account, so only euro-fund rewards are payable and
+  # listed. This is the single place to change when multi-currency payouts land —
+  # the currency is supplied from here (the UI layer) into Fund.Public, never
+  # pinned inside the domain.
+  @payout_currency "euro"
+
   # For guest users
   def view_model(_, %{current_user: nil}) do
     %{
@@ -72,7 +79,7 @@ defmodule Systems.Home.PageBuilder do
   end
 
   defp block(:rewards_summary, %Account.User{} = user, _assigns, _opts) do
-    case Fund.Public.summarize_rewards(user) do
+    case Fund.Public.summarize_rewards(user, @payout_currency) do
       %{pending_cents: 0, approved_cents: 0, rejected_cents: 0} ->
         nil
 
@@ -83,6 +90,7 @@ defmodule Systems.Home.PageBuilder do
             totals
             |> Map.put(:labels, rewards_summary_labels(approved_cents))
             |> Map.put(:user, user)
+            |> Map.put(:payout_currency, @payout_currency)
         }
     end
   end

--- a/core/systems/home/page_builder.ex
+++ b/core/systems/home/page_builder.ex
@@ -20,11 +20,6 @@ defmodule Systems.Home.PageBuilder do
   # Number of studies shown on the home page before linking to the marketplace
   @home_card_limit 3
 
-  # The currency participants are paid out in. Hardcoded to euro for now: OPP
-  # settles to a EUR bank account, so only euro-fund rewards are payable and
-  # listed. This is the single place to change when multi-currency payouts land —
-  # the currency is supplied from here (the UI layer) into Fund.Public, never
-  # pinned inside the domain.
   @payout_currency "euro"
 
   # For guest users

--- a/core/systems/home/rewards_summary_view.ex
+++ b/core/systems/home/rewards_summary_view.ex
@@ -33,7 +33,8 @@ defmodule Systems.Home.RewardsSummaryView do
           approved_cents: approved_cents,
           rejected_cents: rejected_cents,
           labels: labels,
-          user: user
+          user: user,
+          payout_currency: payout_currency
         },
         socket
       ) do
@@ -45,7 +46,8 @@ defmodule Systems.Home.RewardsSummaryView do
         approved_cents: approved_cents,
         rejected_cents: rejected_cents,
         labels: labels,
-        user: user
+        user: user,
+        payout_currency: payout_currency
       )
       |> assign_new(:handoff_mode, fn -> :payout end)
     }
@@ -84,8 +86,12 @@ defmodule Systems.Home.RewardsSummaryView do
   end
 
   @impl true
-  def handle_event("request_payout", _params, %{assigns: %{user: user, labels: labels}} = socket) do
-    case Fund.Public.prepare_payout(user) do
+  def handle_event(
+        "request_payout",
+        _params,
+        %{assigns: %{user: user, payout_currency: payout_currency, labels: labels}} = socket
+      ) do
+    case Fund.Public.prepare_payout(user, payout_currency) do
       :ok ->
         {:noreply, present_handoff(socket, :payout)}
 
@@ -106,11 +112,11 @@ defmodule Systems.Home.RewardsSummaryView do
   def handle_event(
         "confirmed",
         %{source: %{name: :handoff_modal}},
-        %{assigns: %{user: user}} = socket
+        %{assigns: %{user: user, payout_currency: payout_currency}} = socket
       ) do
     socket = hide_modal(socket, :handoff_modal)
 
-    case Fund.Public.request_payout(user) do
+    case Fund.Public.request_payout(user, payout_currency) do
       {:ok, _result} ->
         # Redirecting here is forbidden — this handler runs inside the
         # component's update/2 lifecycle (Fabric delivers the modal event via
@@ -148,12 +154,12 @@ defmodule Systems.Home.RewardsSummaryView do
     |> show_modal(:handoff_modal, :compact)
   end
 
-  defp refresh_totals(socket, user) do
+  defp refresh_totals(%{assigns: %{payout_currency: payout_currency}} = socket, user) do
     %{
       pending_cents: pending_cents,
       approved_cents: approved_cents,
       rejected_cents: rejected_cents
-    } = Fund.Public.summarize_rewards(user)
+    } = Fund.Public.summarize_rewards(user, payout_currency)
 
     assign(socket,
       pending_cents: pending_cents,

--- a/core/systems/payment/provider/opp.ex
+++ b/core/systems/payment/provider/opp.ex
@@ -6,9 +6,7 @@ defmodule Systems.Payment.Provider.OPP do
   alias Systems.Payment.Provider.OPP.HTTP
 
   @currency_mapping %{
-    EUR: "EUR",
-    USD: "USD",
-    GBP: "GBP"
+    EUR: "EUR"
   }
 
   @default_withdrawal_description "Payout"

--- a/core/test/features/payout_flow_test.exs
+++ b/core/test/features/payout_flow_test.exs
@@ -105,7 +105,7 @@ defmodule CoreWeb.Features.PayoutFlowTest do
     auth_node = Factories.insert!(:auth_node)
     info = Factories.insert!(:assignment_info, %{subject_count: 10, subject_reward: 500})
 
-    currency = Factories.insert!(:currency, %{name: "eur_journey"})
+    currency = Factories.insert!(:currency, %{name: "euro"})
     fund = Fund.Factories.create_fund("journey_fund", currency)
 
     assignment =

--- a/core/test/features/request_payout_test.exs
+++ b/core/test/features/request_payout_test.exs
@@ -65,7 +65,7 @@ defmodule CoreWeb.Features.RequestPayoutTest do
         merchant_uid: merchant_uid
       })
 
-    currency = Factories.insert!(:currency, %{name: "eur_test"})
+    currency = Factories.insert!(:currency, %{name: "euro"})
     fund = Fund.Factories.create_fund("payout_fund_#{participant.id}", currency)
 
     # Approved reward — what makes `payout-button` visible on the home page.

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -859,9 +859,16 @@ defmodule Systems.Fund.PublicTest do
   end
 
   describe "request_payout/1" do
-    setup %{fund: fund} do
+    setup do
       user = Factories.insert!(:member, %{creator: false, merchant_uid: "m_test_123"})
-      {:ok, fund: fund, user: user}
+      {:ok, fund: euro_fund(), user: user}
+    end
+
+    # Payouts settle in EUR, so the payout paths only see euro-fund rewards
+    # (see list_approved_rewards); tests exercise them against a euro fund.
+    defp euro_fund do
+      euro = Fund.Factories.create_currency("euro", :legal, "€", 2)
+      Fund.Factories.create_fund("euro-fund-#{System.unique_integer([:positive])}", euro)
     end
 
     defp insert_reward(user, fund, amount, status) do
@@ -948,6 +955,33 @@ defmodule Systems.Fund.PublicTest do
 
       assert {:ok, %{amount: 1000, withdrawal: %{uid: "w_2"}}} =
                Fund.Public.request_payout(user)
+    end
+
+    test "pays out only euro rewards, leaving other-currency rewards :approved",
+         %{user: %{merchant_uid: merchant_uid} = user, fund: euro_fund} do
+      insert_reward(user, euro_fund, 600, :approved)
+
+      dollar = Fund.Factories.create_currency("dollar", :legal, "$", 2)
+
+      dollar_fund =
+        Fund.Factories.create_fund("usd-fund-#{System.unique_integer([:positive])}", dollar)
+
+      %{id: dollar_reward_id} = insert_reward(user, dollar_fund, 600, :approved)
+
+      stub_payout_ready(merchant_uid)
+
+      # Only the 600 euro cents move — the 600 dollar cents are not summed in.
+      expect(ProviderMock, :create_charge, fn _from, ^merchant_uid, 600, _key ->
+        {:ok, %{uid: "chg_eur", status: "created", amount: 600}}
+      end)
+
+      expect(ProviderMock, :create_withdrawal, fn ^merchant_uid, :EUR, %{amount: 600}, _key ->
+        {:ok, %{uid: "w_eur", status: "created", amount: 600}}
+      end)
+
+      assert {:ok, %{amount: 600}} = Fund.Public.request_payout(user)
+
+      assert %{status: :approved} = Fund.Public.get_reward(reward_key(dollar_reward_id), [])
     end
 
     test "reverts the lock when OPP returns an error", %{user: user, fund: fund} do
@@ -1060,9 +1094,9 @@ defmodule Systems.Fund.PublicTest do
   end
 
   describe "payout_eligibility/1" do
-    setup %{fund: fund} do
+    setup do
       user = Factories.insert!(:member, %{creator: false, merchant_uid: "m_elig_1"})
-      {:ok, fund: fund, user: user}
+      {:ok, fund: euro_fund(), user: user}
     end
 
     test "returns :below_threshold with the current total when under €5", %{
@@ -1111,9 +1145,9 @@ defmodule Systems.Fund.PublicTest do
   end
 
   describe "prepare_payout/1" do
-    setup %{fund: fund} do
+    setup do
       user = Factories.insert!(:member, %{creator: false, merchant_uid: "m_prep_1"})
-      {:ok, fund: fund, user: user}
+      {:ok, fund: euro_fund(), user: user}
     end
 
     defp eligible_reward(user, fund, amount \\ 1000) do

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -713,15 +713,18 @@ defmodule Systems.Fund.PublicTest do
     end
   end
 
-  describe "summarize_rewards/1" do
-    test "returns all zeros when the user has no rewards" do
+  describe "summarize_rewards/2" do
+    test "returns all zeros when the user has no rewards", %{currency: currency} do
       user = Factories.insert!(:member, %{creator: false})
 
       assert %{pending_cents: 0, approved_cents: 0, rejected_cents: 0} =
-               Fund.Public.summarize_rewards(user)
+               Fund.Public.summarize_rewards(user, currency.name)
     end
 
-    test "sums :reserved and :pending_approval into pending_cents", %{fund: fund} do
+    test "sums :reserved and :pending_approval into pending_cents", %{
+      currency: currency,
+      fund: fund
+    } do
       user = Factories.insert!(:member, %{creator: false})
 
       Factories.insert!(:reward, %{
@@ -741,10 +744,13 @@ defmodule Systems.Fund.PublicTest do
       })
 
       assert %{pending_cents: 350, approved_cents: 0, rejected_cents: 0} =
-               Fund.Public.summarize_rewards(user)
+               Fund.Public.summarize_rewards(user, currency.name)
     end
 
-    test "approved_cents only counts :approved rewards (excludes :paid)", %{fund: fund} do
+    test "approved_cents only counts :approved rewards (excludes :paid)", %{
+      currency: currency,
+      fund: fund
+    } do
       user = Factories.insert!(:member, %{creator: false})
 
       Factories.insert!(:reward, %{
@@ -764,10 +770,10 @@ defmodule Systems.Fund.PublicTest do
       })
 
       assert %{approved_cents: 100, paid_out_cents: 400} =
-               Fund.Public.summarize_rewards(user)
+               Fund.Public.summarize_rewards(user, currency.name)
     end
 
-    test "pending_payout_cents sums rewards locked for payout", %{fund: fund} do
+    test "pending_payout_cents sums rewards locked for payout", %{currency: currency, fund: fund} do
       user = Factories.insert!(:member, %{creator: false})
 
       Factories.insert!(:reward, %{
@@ -779,10 +785,10 @@ defmodule Systems.Fund.PublicTest do
       })
 
       assert %{approved_cents: 0, pending_payout_cents: 250} =
-               Fund.Public.summarize_rewards(user)
+               Fund.Public.summarize_rewards(user, currency.name)
     end
 
-    test "sums :rejected into rejected_cents", %{fund: fund} do
+    test "sums :rejected into rejected_cents", %{currency: currency, fund: fund} do
       user = Factories.insert!(:member, %{creator: false})
 
       Factories.insert!(:reward, %{
@@ -794,7 +800,7 @@ defmodule Systems.Fund.PublicTest do
       })
 
       assert %{pending_cents: 0, approved_cents: 0, rejected_cents: 75} =
-               Fund.Public.summarize_rewards(user)
+               Fund.Public.summarize_rewards(user, currency.name)
     end
   end
 
@@ -901,17 +907,17 @@ defmodule Systems.Fund.PublicTest do
       user = Factories.insert!(:member, %{creator: false, merchant_uid: nil})
       insert_reward(user, fund, 1000, :approved)
 
-      assert {:error, :no_merchant} = Fund.Public.request_payout(user)
+      assert {:error, :no_merchant} = Fund.Public.request_payout(user, "euro")
     end
 
     test "returns :below_threshold when approved balance is under €5", %{user: user, fund: fund} do
       insert_reward(user, fund, 499, :approved)
 
-      assert {:error, {:below_threshold, 499}} = Fund.Public.request_payout(user)
+      assert {:error, {:below_threshold, 499}} = Fund.Public.request_payout(user, "euro")
     end
 
     test "returns :below_threshold with 0 when participant has no approved rewards", %{user: user} do
-      assert {:error, {:below_threshold, 0}} = Fund.Public.request_payout(user)
+      assert {:error, {:below_threshold, 0}} = Fund.Public.request_payout(user, "euro")
     end
 
     test "locks approved rewards as :pending_payout on success", %{user: user, fund: fund} do
@@ -925,7 +931,7 @@ defmodule Systems.Fund.PublicTest do
         {:ok, %{uid: "w_1", status: "created", amount: 1000}}
       end)
 
-      assert {:ok, _} = Fund.Public.request_payout(user)
+      assert {:ok, _} = Fund.Public.request_payout(user, "euro")
 
       assert %{status: :pending_payout} = Fund.Public.get_reward(reward_key(id1), [])
       assert %{status: :pending_payout} = Fund.Public.get_reward(reward_key(id2), [])
@@ -954,7 +960,7 @@ defmodule Systems.Fund.PublicTest do
       end)
 
       assert {:ok, %{amount: 1000, withdrawal: %{uid: "w_2"}}} =
-               Fund.Public.request_payout(user)
+               Fund.Public.request_payout(user, "euro")
     end
 
     test "pays out only euro rewards, leaving other-currency rewards :approved",
@@ -979,7 +985,7 @@ defmodule Systems.Fund.PublicTest do
         {:ok, %{uid: "w_eur", status: "created", amount: 600}}
       end)
 
-      assert {:ok, %{amount: 600}} = Fund.Public.request_payout(user)
+      assert {:ok, %{amount: 600}} = Fund.Public.request_payout(user, "euro")
 
       assert %{status: :approved} = Fund.Public.get_reward(reward_key(dollar_reward_id), [])
     end
@@ -994,7 +1000,8 @@ defmodule Systems.Fund.PublicTest do
         {:error, %Systems.Payment.Error{code: :http_error, message: "boom"}}
       end)
 
-      assert {:error, {:opp_failed, %Systems.Payment.Error{}}} = Fund.Public.request_payout(user)
+      assert {:error, {:opp_failed, %Systems.Payment.Error{}}} =
+               Fund.Public.request_payout(user, "euro")
 
       assert %{status: :approved} = Fund.Public.get_reward(reward_key(id), [])
     end
@@ -1017,7 +1024,7 @@ defmodule Systems.Fund.PublicTest do
       # No create_charge / create_withdrawal expectations: the compare-and-swap
       # lock must find 0 approved rows and bail before any money moves. Mox's
       # verify_on_exit! raises if either OPP call is made.
-      assert {:error, :lock_failed} = Fund.Public.request_payout(user)
+      assert {:error, :lock_failed} = Fund.Public.request_payout(user, "euro")
 
       # The losing attempt's payout insert was rolled back with the failed lock.
       assert Core.Repo.all(Fund.PayoutModel) == []
@@ -1035,7 +1042,7 @@ defmodule Systems.Fund.PublicTest do
         {:ok, %{uid: "w_3", status: "created", amount: 1000}}
       end)
 
-      assert {:ok, %{amount: 1000}} = Fund.Public.request_payout(user)
+      assert {:ok, %{amount: 1000}} = Fund.Public.request_payout(user, "euro")
     end
 
     test "creates a Fund.Payout aggregate linked to the locked rewards on success",
@@ -1050,7 +1057,7 @@ defmodule Systems.Fund.PublicTest do
         {:ok, %{uid: "w_aggregate_1", status: "created", amount: 1000}}
       end)
 
-      assert {:ok, %{payout: payout}} = Fund.Public.request_payout(user)
+      assert {:ok, %{payout: payout}} = Fund.Public.request_payout(user, "euro")
 
       assert %Fund.PayoutModel{
                user_id: ^user_id,
@@ -1076,7 +1083,7 @@ defmodule Systems.Fund.PublicTest do
         {:error, %Systems.Payment.Error{code: :http_error, message: "boom"}}
       end)
 
-      assert {:error, {:opp_failed, _}} = Fund.Public.request_payout(user)
+      assert {:error, {:opp_failed, _}} = Fund.Public.request_payout(user, "euro")
 
       reward = Core.Repo.get!(Fund.RewardModel, r_id)
       assert reward.status == :approved
@@ -1111,7 +1118,7 @@ defmodule Systems.Fund.PublicTest do
         idempotence_key: "elig-#{System.unique_integer([:positive])}"
       })
 
-      assert {:error, {:below_threshold, 499}} = Fund.Public.payout_eligibility(user)
+      assert {:error, {:below_threshold, 499}} = Fund.Public.payout_eligibility(user, "euro")
     end
 
     test "returns :ok when at or above €5", %{user: user, fund: fund} do
@@ -1123,7 +1130,7 @@ defmodule Systems.Fund.PublicTest do
         idempotence_key: "elig-#{System.unique_integer([:positive])}"
       })
 
-      assert :ok = Fund.Public.payout_eligibility(user)
+      assert :ok = Fund.Public.payout_eligibility(user, "euro")
     end
 
     test "does not lock rewards or create a Payout row", %{user: user, fund: fund} do
@@ -1135,7 +1142,7 @@ defmodule Systems.Fund.PublicTest do
         idempotence_key: "elig-#{System.unique_integer([:positive])}"
       })
 
-      assert :ok = Fund.Public.payout_eligibility(user)
+      assert :ok = Fund.Public.payout_eligibility(user, "euro")
 
       [reward] = Core.Repo.all(Fund.RewardModel)
       assert reward.status == :approved
@@ -1185,7 +1192,7 @@ defmodule Systems.Fund.PublicTest do
 
       stub_existing_bank_account("m_prep_1")
 
-      assert :ok = Fund.Public.prepare_payout(user)
+      assert :ok = Fund.Public.prepare_payout(user, "euro")
     end
 
     test ~s(is :ok with an approved bank even when merchant compliance_status != "verified"),
@@ -1205,7 +1212,7 @@ defmodule Systems.Fund.PublicTest do
 
       stub_existing_bank_account("m_prep_1")
 
-      assert :ok = Fund.Public.prepare_payout(user)
+      assert :ok = Fund.Public.prepare_payout(user, "euro")
     end
 
     test ~s(is :ok with an approved bank even when merchant.status != "live"),
@@ -1225,7 +1232,7 @@ defmodule Systems.Fund.PublicTest do
 
       stub_existing_bank_account("m_prep_1")
 
-      assert :ok = Fund.Public.prepare_payout(user)
+      assert :ok = Fund.Public.prepare_payout(user, "euro")
     end
 
     test "creates a merchant for users with no merchant_uid and persists the uid",
@@ -1248,7 +1255,7 @@ defmodule Systems.Fund.PublicTest do
 
       stub_existing_bank_account("m_created_inline")
 
-      assert :ok = Fund.Public.prepare_payout(user)
+      assert :ok = Fund.Public.prepare_payout(user, "euro")
 
       assert %{merchant_uid: "m_created_inline"} = Core.Repo.reload!(user)
     end
@@ -1281,7 +1288,7 @@ defmodule Systems.Fund.PublicTest do
 
       # Freshly created bank account is not yet approved -> drive the iDEAL flow.
       assert {:error, {:kyc_required, :bank, "https://opp.test/ba/verify"}} =
-               Fund.Public.prepare_payout(user)
+               Fund.Public.prepare_payout(user, "euro")
     end
 
     test "returns :below_threshold WITHOUT calling OPP when balance is too low",
@@ -1289,7 +1296,7 @@ defmodule Systems.Fund.PublicTest do
       eligible_reward(user, fund, 100)
       # No ProviderMock expectation -> Mox would fail if get_merchant was called.
 
-      assert {:error, {:below_threshold, 100}} = Fund.Public.prepare_payout(user)
+      assert {:error, {:below_threshold, 100}} = Fund.Public.prepare_payout(user, "euro")
     end
 
     test "returns :kyc_unavailable when not ready and OPP gives no usable URL",
@@ -1312,7 +1319,7 @@ defmodule Systems.Fund.PublicTest do
         {:ok, [%{uid: "ba", status: "new", verification_url: nil}]}
       end)
 
-      assert {:error, :kyc_unavailable} = Fund.Public.prepare_payout(user)
+      assert {:error, :kyc_unavailable} = Fund.Public.prepare_payout(user, "euro")
     end
 
     test "falls back to the bank verification_url when the merchant has no overview_url",
@@ -1336,7 +1343,7 @@ defmodule Systems.Fund.PublicTest do
       end)
 
       assert {:error, {:kyc_required, :bank, "https://opp.test/ba/verify"}} =
-               Fund.Public.prepare_payout(user)
+               Fund.Public.prepare_payout(user, "euro")
     end
 
     test "is :kyc_unavailable when the bank is not approved, ignoring any merchant overview_url",
@@ -1360,7 +1367,7 @@ defmodule Systems.Fund.PublicTest do
         {:ok, [%{uid: "ba_pending", status: "new", verification_url: nil}]}
       end)
 
-      assert {:error, :kyc_unavailable} = Fund.Public.prepare_payout(user)
+      assert {:error, :kyc_unavailable} = Fund.Public.prepare_payout(user, "euro")
     end
   end
 

--- a/core/test/systems/home/page_builder_test.exs
+++ b/core/test/systems/home/page_builder_test.exs
@@ -5,6 +5,7 @@ defmodule Systems.Home.PageBuilderTest do
   alias Systems.Pool
   alias Systems.Advert
   alias Systems.Assignment
+  alias Systems.Fund
 
   alias Core.Factories
 
@@ -38,9 +39,17 @@ defmodule Systems.Home.PageBuilderTest do
   defp give_reward(user, amount \\ 1500) do
     Factories.insert!(:reward, %{
       user: user,
+      fund: euro_fund(),
       amount: amount,
       idempotence_key: "test=#{System.unique_integer([:positive])}"
     })
+  end
+
+  # The rewards-summary card lists payable (euro) rewards only, so tests that
+  # expect the card to appear must fund their rewards in euro.
+  defp euro_fund do
+    euro = Fund.Factories.create_currency("euro", :legal, "€", 2)
+    Fund.Factories.create_fund("euro-fund-#{System.unique_integer([:positive])}", euro)
   end
 
   defp make_panl_participant(user) do
@@ -107,6 +116,7 @@ defmodule Systems.Home.PageBuilderTest do
 
       Factories.insert!(:reward, %{
         user: user,
+        fund: euro_fund(),
         amount: 2000,
         status: :approved,
         idempotence_key: "approved=#{System.unique_integer([:positive])}"

--- a/core/test/systems/home/page_builder_test.exs
+++ b/core/test/systems/home/page_builder_test.exs
@@ -45,8 +45,6 @@ defmodule Systems.Home.PageBuilderTest do
     })
   end
 
-  # The rewards-summary card lists payable (euro) rewards only, so tests that
-  # expect the card to appear must fund their rewards in euro.
   defp euro_fund do
     euro = Fund.Factories.create_currency("euro", :legal, "€", 2)
     Fund.Factories.create_fund("euro-fund-#{System.unique_integer([:positive])}", euro)

--- a/core/test/systems/home/rewards_summary_view_handlers_test.exs
+++ b/core/test/systems/home/rewards_summary_view_handlers_test.exs
@@ -49,6 +49,7 @@ defmodule Systems.Home.RewardsSummaryViewHandlersTest do
           user: user,
           labels: @labels,
           handoff_mode: :payout,
+          payout_currency: "euro",
           pending_cents: 0,
           approved_cents: 1000,
           rejected_cents: 0

--- a/core/test/systems/home/rewards_summary_view_handlers_test.exs
+++ b/core/test/systems/home/rewards_summary_view_handlers_test.exs
@@ -60,13 +60,9 @@ defmodule Systems.Home.RewardsSummaryViewHandlersTest do
   end
 
   defp user_with_reward(amount, merchant_uid) do
-    currency =
-      Fund.Factories.create_currency(
-        "h_cur_#{System.unique_integer([:positive])}",
-        :legal,
-        "ƒ",
-        2
-      )
+    # Payouts settle in EUR, so rewards must live in a euro fund to be payable
+    # (see Fund.Public list_approved_rewards).
+    currency = Fund.Factories.create_currency("euro", :legal, "€", 2)
 
     fund = Fund.Factories.create_fund("h_fund_#{System.unique_integer([:positive])}", currency)
     user = Factories.insert!(:member, %{creator: false, merchant_uid: merchant_uid})

--- a/core/test/systems/home/rewards_summary_view_handlers_test.exs
+++ b/core/test/systems/home/rewards_summary_view_handlers_test.exs
@@ -61,8 +61,6 @@ defmodule Systems.Home.RewardsSummaryViewHandlersTest do
   end
 
   defp user_with_reward(amount, merchant_uid) do
-    # Payouts settle in EUR, so rewards must live in a euro fund to be payable
-    # (see Fund.Public list_approved_rewards).
     currency = Fund.Factories.create_currency("euro", :legal, "€", 2)
 
     fund = Fund.Factories.create_fund("h_fund_#{System.unique_integer([:positive])}", currency)


### PR DESCRIPTION
`request_payout` summed a participant's approved rewards across *every* currency and paid the total out as a single EUR withdrawal — `list_approved_rewards` was keyed only on `user_id` + `status`, and the withdrawal hardcoded `:EUR`. So 600 cents in a USD fund and 600 cents in a EUR fund became one €12.00 payout.

This scopes `list_approved_rewards` (used by both `request_payout` and `payout_eligibility`) to euro-fund rewards, so other-currency rewards are never conflated into a EUR withdrawal. Per product decision, non-euro approved rewards simply stay `:approved` until real multi-currency payouts are built (OPP settles to a EUR bank account today). Payout test fixtures now use the canonical euro currency.

Fixes Flux [10100771704](https://app.basecamp.com/5734045/buckets/35926565/todos/10100771704). Surfaced by the money-flow assurance audit (BUG 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)