### PR TITLE
fix: split pay-in booking into fund base and platform fee

### DIFF
--- a/core/lib/core/factories.ex
+++ b/core/lib/core/factories.ex
@@ -934,7 +934,8 @@ defmodule Core.Factories do
     %Budget.CurrencyLedgerModel{
       currency: currency,
       inbound: Bookkeeping.AccountModel.create(["ledger", id, "inbound"]),
-      outbound: Bookkeeping.AccountModel.create(["ledger", id, "outbound"])
+      outbound: Bookkeeping.AccountModel.create(["ledger", id, "outbound"]),
+      margin: Bookkeeping.AccountModel.create(["ledger", id, "margin"])
     }
     |> struct!(attributes)
   end

--- a/core/priv/repo/migrations/20260716082319_add_partner_fee_and_ledger_margin.exs
+++ b/core/priv/repo/migrations/20260716082319_add_partner_fee_and_ledger_margin.exs
@@ -1,0 +1,44 @@
+defmodule Core.Repo.Migrations.AddPartnerFeeAndLedgerMargin do
+  use Ecto.Migration
+
+  def up do
+    alter table(:transactions) do
+      add(:partner_fee, :integer, null: false, default: 0)
+    end
+
+    alter table(:currency_ledger) do
+      add(:margin_id, references(:book_accounts), null: true)
+    end
+
+    # Every ledger needs a margin account to book the platform fee into; backfill
+    # one for each existing ledger, then enforce the invariant.
+    execute("""
+    DO $$
+    DECLARE l RECORD; new_id BIGINT;
+    BEGIN
+      FOR l IN SELECT id, lower(currency) AS cur FROM currency_ledger WHERE margin_id IS NULL LOOP
+        INSERT INTO book_accounts (identifier, balance_debit, balance_credit, inserted_at, updated_at)
+          VALUES (ARRAY['ledger', l.cur, 'margin'], 0, 0, now(), now())
+          RETURNING id INTO new_id;
+        UPDATE currency_ledger SET margin_id = new_id WHERE id = l.id;
+      END LOOP;
+    END $$;
+    """)
+
+    execute("ALTER TABLE currency_ledger ALTER COLUMN margin_id SET NOT NULL")
+  end
+
+  def down do
+    alter table(:currency_ledger) do
+      remove(:margin_id)
+    end
+
+    execute(
+      "DELETE FROM book_accounts WHERE identifier[1] = 'ledger' AND identifier[3] = 'margin'"
+    )
+
+    alter table(:transactions) do
+      remove(:partner_fee)
+    end
+  end
+end

--- a/core/systems/budget/_public.ex
+++ b/core/systems/budget/_public.ex
@@ -114,7 +114,8 @@ defmodule Systems.Budget.Public do
              idempotence_key: idempotence_key,
              invoice_id: invoice_id,
              subject_count: subject_count,
-             total_amount: total_amount
+             total_amount: total_amount,
+             partner_fee: partner_fee
            })
            |> Ecto.Changeset.put_change(:user_id, user_id)
            |> Ecto.Changeset.put_change(:target_fund_id, fund.id)
@@ -179,7 +180,9 @@ defmodule Systems.Budget.Public do
   def complete_transaction(provider_uid) when is_binary(provider_uid) do
     transaction =
       get_transaction_by_provider_uid!(provider_uid)
-      |> Repo.preload(target_fund: [:available, :pending, currency_ledger: [:inbound, :outbound]])
+      |> Repo.preload(
+        target_fund: [:available, :pending, currency_ledger: [:inbound, :outbound, :margin]]
+      )
 
     case transaction.status do
       :completed ->
@@ -193,14 +196,18 @@ defmodule Systems.Budget.Public do
   defp do_complete_transaction(
          %Budget.TransactionModel{
            subject_count: subject_count,
+           total_amount: total_amount,
+           partner_fee: partner_fee,
            target_fund: %{
              available: %{identifier: fund_account_id},
-             currency_ledger: %{inbound: %{identifier: inbound_account_id}}
+             currency_ledger: %{
+               inbound: %{identifier: inbound_account_id},
+               margin: %{identifier: margin_account_id}
+             }
            }
          } = transaction
        ) do
-    reward_per_participant = get_reward_per_participant(transaction)
-    total_amount = subject_count * reward_per_participant
+    base_amount = total_amount - partner_fee
 
     Multi.new()
     |> Multi.update(
@@ -211,17 +218,26 @@ defmodule Systems.Budget.Public do
       Bookkeeping.Public.enter(%{
         idempotence_key: "complete:#{transaction.idempotence_key}",
         journal_message:
-          "Pay-in #{total_amount} cents for #{subject_count} participants on fund ##{transaction.target_fund_id}",
-        lines: [
-          %{account: inbound_account_id, debit: total_amount},
-          %{account: fund_account_id, credit: total_amount}
-        ]
+          "Pay-in #{total_amount} cents (#{base_amount} to fund, #{partner_fee} fee) for #{subject_count} participants on fund ##{transaction.target_fund_id}",
+        lines:
+          [
+            %{account: inbound_account_id, debit: total_amount},
+            %{account: fund_account_id, credit: base_amount}
+          ] ++ margin_lines(margin_account_id, partner_fee)
       })
     end)
     |> Multi.run(:update_subject_count, fn _, _ ->
       increment_subject_count(transaction.target_fund_id, subject_count)
     end)
     |> Repo.commit()
+  end
+
+  # The partner fee is platform revenue, booked to the ledger margin — never into
+  # the fund, which only holds what the researcher can pay participants with.
+  defp margin_lines(_margin_account_id, 0), do: []
+
+  defp margin_lines(margin_account_id, partner_fee) do
+    [%{account: margin_account_id, credit: partner_fee}]
   end
 
   def fail_transaction(provider_uid) when is_binary(provider_uid) do
@@ -261,15 +277,6 @@ defmodule Systems.Budget.Public do
   def reconcile_transactions(opts, state), do: Budget.TransactionReconciliation.run(opts, state)
 
   # --- Helpers ---
-
-  defp get_reward_per_participant(%Budget.TransactionModel{target_fund_id: fund_id}) do
-    from(a in Assignment.Model,
-      join: i in assoc(a, :info),
-      where: a.fund_id == ^fund_id,
-      select: i.subject_reward
-    )
-    |> Repo.one() || 0
-  end
 
   defp increment_subject_count(fund_id, additional_count) do
     from(i in Assignment.InfoModel,

--- a/core/systems/budget/currency_ledger_model.ex
+++ b/core/systems/budget/currency_ledger_model.ex
@@ -12,6 +12,7 @@ defmodule Systems.Budget.CurrencyLedgerModel do
 
     belongs_to(:inbound, Bookkeeping.AccountModel)
     belongs_to(:outbound, Bookkeeping.AccountModel)
+    belongs_to(:margin, Bookkeeping.AccountModel)
 
     timestamps()
   end
@@ -24,7 +25,8 @@ defmodule Systems.Budget.CurrencyLedgerModel do
     %__MODULE__{
       currency: currency,
       inbound: Bookkeeping.AccountModel.create(["ledger", id, "inbound"]),
-      outbound: Bookkeeping.AccountModel.create(["ledger", id, "outbound"])
+      outbound: Bookkeeping.AccountModel.create(["ledger", id, "outbound"]),
+      margin: Bookkeeping.AccountModel.create(["ledger", id, "margin"])
     }
   end
 
@@ -47,5 +49,9 @@ defmodule Systems.Budget.CurrencyLedgerModel do
     Core.Repo.get_by(__MODULE__, currency: currency)
   end
 
-  def preload_graph(:full), do: [:inbound, :outbound]
+  def amount_margin(%{margin: margin}) do
+    Bookkeeping.AccountModel.balance(margin)
+  end
+
+  def preload_graph(:full), do: [:inbound, :outbound, :margin]
 end

--- a/core/systems/budget/transaction_model.ex
+++ b/core/systems/budget/transaction_model.ex
@@ -15,6 +15,7 @@ defmodule Systems.Budget.TransactionModel do
     field(:invoice_id, :string)
     field(:subject_count, :integer)
     field(:total_amount, :integer, default: 0)
+    field(:partner_fee, :integer, default: 0)
 
     belongs_to(:user, Account.User)
     belongs_to(:target_fund, Fund.Model)
@@ -22,8 +23,8 @@ defmodule Systems.Budget.TransactionModel do
     timestamps()
   end
 
-  @fields ~w(transaction_id status idempotence_key invoice_id subject_count total_amount)a
-  @required_fields @fields
+  @fields ~w(transaction_id status idempotence_key invoice_id subject_count total_amount partner_fee)a
+  @required_fields ~w(transaction_id status idempotence_key invoice_id subject_count total_amount)a
 
   def changeset(%__MODULE__{} = transaction, attrs) do
     transaction

--- a/core/test/systems/budget/complete_transaction_test.exs
+++ b/core/test/systems/budget/complete_transaction_test.exs
@@ -31,9 +31,47 @@ defmodule Systems.Budget.CompleteTransactionTest do
       assert {:error, "Transaction already completed"} =
                Budget.Public.complete_transaction(transaction.transaction_id)
     end
+
+    test "credits the fund the base amount and books the partner fee to the ledger margin" do
+      # total_amount is base (5000) + partner fee (500).
+      %{transaction: transaction, fund: fund, currency_ledger: ledger} =
+        setup_transaction(status: :pending, total_amount: 5500, partner_fee: 500)
+
+      {:ok, _} = Budget.Public.complete_transaction(transaction.transaction_id)
+
+      assert available_credit(fund) == 5000
+      assert margin_credit(ledger) == 500
+    end
+
+    test "credits the paid base even after the assignment reward changed since pay-in" do
+      %{transaction: transaction, fund: fund} =
+        setup_transaction(status: :pending, total_amount: 5500, partner_fee: 500)
+
+      # A lower live reward must not change the booking: 10 x 100 = 1000 would be
+      # booked if completion re-derived from the reward instead of the paid amount.
+      info = Factories.insert!(:assignment_info, %{subject_count: 10, subject_reward: 100})
+      Factories.insert!(:assignment, %{info: info, fund: fund, status: :online})
+
+      {:ok, _} = Budget.Public.complete_transaction(transaction.transaction_id)
+
+      assert available_credit(fund) == 5000
+    end
   end
 
-  defp setup_transaction(status: status) do
+  defp available_credit(%Fund.Model{available: account}) do
+    %{credit: credit} = Bookkeeping.Public.balance(account)
+    credit
+  end
+
+  defp margin_credit(%Budget.CurrencyLedgerModel{margin: margin}) do
+    %{credit: credit} = Bookkeeping.Public.balance(margin)
+    credit
+  end
+
+  defp setup_transaction(opts) do
+    status = Keyword.fetch!(opts, :status)
+    total_amount = Keyword.get(opts, :total_amount, 0)
+    partner_fee = Keyword.get(opts, :partner_fee, 0)
     currency_ledger = ensure_currency_ledger(:EUR)
     user = Factories.insert!(:member)
 
@@ -59,13 +97,15 @@ defmodule Systems.Budget.CompleteTransactionTest do
         status: status,
         idempotence_key: Ecto.UUID.generate(),
         invoice_id: "NEXT-TEST-#{System.unique_integer([:positive])}",
-        subject_count: 10
+        subject_count: 10,
+        total_amount: total_amount,
+        partner_fee: partner_fee
       })
       |> Ecto.Changeset.put_change(:user_id, user.id)
       |> Ecto.Changeset.put_change(:target_fund_id, fund.id)
       |> Repo.insert()
 
-    %{transaction: transaction, fund: fund, user: user}
+    %{transaction: transaction, fund: fund, user: user, currency_ledger: currency_ledger}
   end
 
   defp ensure_currency_ledger(currency) do
@@ -74,7 +114,7 @@ defmodule Systems.Budget.CompleteTransactionTest do
         Budget.CurrencyLedgerModel.create(currency) |> Repo.insert!()
 
       existing ->
-        existing |> Repo.preload([:inbound, :outbound])
+        existing |> Repo.preload([:inbound, :outbound, :margin])
     end
   end
 end


### PR DESCRIPTION
**Draft** — money bookkeeping change (adds a migration + a new ledger account); worth a careful look before merge.

`do_complete_transaction` re-derived the credited amount as `subject_count × live subject_reward`, which had two problems:

- **BUG 5** — it read the *current* `subject_reward`, so lowering the reward between payment and confirmation credited the wrong amount.
- **BUG 1** — the partner fee the researcher paid was never booked anywhere.

**Corrected accounting** (per review): the researcher pays `total = base + partner_fee`. The fund's `available` may only be credited **base** — what they can pay participants with — and the **fee is platform revenue** that the ledger must record.

Changes:
- Persist `partner_fee` on the transaction (migration), so completion books the **immutable paid amount** instead of re-deriving from the live reward.
- Add a per-currency **`margin`** account to `currency_ledger` (backfilled for existing ledgers), hanging off the ledger alongside `inbound`/`outbound`.
- Split the completion entry:
  ```
  debit  inbound  total   (full amount received)
  credit fund     base    (base → participants)
  credit margin   fee     (partner fee → platform revenue)
  ```
  When `partner_fee` is 0 the margin line is omitted.

`partner_fee_percentage` defaults to `0`, so with no fee configured this is purely the BUG 5 immutability fix; the split only diverges once a fee is set.

Fixes Flux [10088720661](https://app.basecamp.com/5734045/buckets/35926565/todos/10088720661). Surfaced by the money-flow assurance audit (BUG 1 + BUG 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)