### PR TITLE
i18n(account): translate Payouts tab strings in DE, ES, IT, LT, RO

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-account.po
@@ -281,75 +281,75 @@ msgstr "Zu viele Anfragen. Bitte versuche es gleich erneut."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.button.add"
-msgstr ""
+msgstr "Hinzufügen"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.error.flash"
-msgstr ""
+msgstr "Bei der Verifizierung deines Bankkontos ist etwas schiefgelaufen. Bitte versuche es später erneut."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.intro"
-msgstr ""
+msgstr "Auszahlungen werden über unseren Zahlungspartner Online Payment Platform abgewickelt"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.not_verified"
-msgstr ""
+msgstr "Nicht verifiziert"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.pending"
-msgstr ""
+msgstr "Wird verifiziert"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.verified"
-msgstr ""
+msgstr "Verifiziert"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.title"
-msgstr ""
+msgstr "Bankkonto"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.verified.flash"
-msgstr ""
+msgstr "Dein Bankkonto wurde verifiziert."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.empty"
-msgstr ""
+msgstr "Es wurden noch keine Auszahlungen vorgenommen. Sobald Auszahlungen erfolgt sind, findest du hier eine Übersicht."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.intro"
-msgstr ""
+msgstr "Unten findest du eine Übersicht aller deiner Auszahlungen."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.title"
-msgstr ""
+msgstr "Übersicht"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.total"
-msgstr ""
+msgstr "Gesamt"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.completed"
-msgstr ""
+msgstr "Ausgezahlt"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.failed"
-msgstr ""
+msgstr "Fehlgeschlagen"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.pending"
-msgstr ""
+msgstr "Ausstehend"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.amount"
-msgstr ""
+msgstr "Betrag"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.date"
-msgstr ""
+msgstr "Datum"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.status"
-msgstr ""
+msgstr "Status"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.title"
@@ -373,11 +373,11 @@ msgstr "Bankkonto verifizieren"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.error.flash"
-msgstr ""
+msgstr "Bei der Verifizierung deines Bankkontos ist etwas schiefgelaufen. Bitte versuche es später erneut."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.label"
-msgstr ""
+msgstr "Mobiltelefonnummer"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.body"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-account.po
@@ -281,75 +281,75 @@ msgstr "Demasiadas solicitudes. Inténtalo de nuevo en un momento."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.button.add"
-msgstr ""
+msgstr "Añadir"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.error.flash"
-msgstr ""
+msgstr "Algo salió mal al verificar tu cuenta bancaria. Inténtalo de nuevo más tarde."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.intro"
-msgstr ""
+msgstr "Los pagos se gestionan a través de nuestro socio de pagos Online Payment Platform"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.not_verified"
-msgstr ""
+msgstr "No verificada"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.pending"
-msgstr ""
+msgstr "Verificando"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.verified"
-msgstr ""
+msgstr "Verificada"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.title"
-msgstr ""
+msgstr "Cuenta bancaria"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.verified.flash"
-msgstr ""
+msgstr "Tu cuenta bancaria ha sido verificada."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.empty"
-msgstr ""
+msgstr "Todavía no se han realizado pagos. Una vez efectuados, encontrarás aquí un resumen."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.intro"
-msgstr ""
+msgstr "A continuación encontrarás un resumen de todos tus pagos."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.title"
-msgstr ""
+msgstr "Resumen"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.total"
-msgstr ""
+msgstr "Total"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.completed"
-msgstr ""
+msgstr "Pagado"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.failed"
-msgstr ""
+msgstr "Fallido"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.pending"
-msgstr ""
+msgstr "Pendiente"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.amount"
-msgstr ""
+msgstr "Importe"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.date"
-msgstr ""
+msgstr "Fecha"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.status"
-msgstr ""
+msgstr "Estado"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.title"
@@ -373,11 +373,11 @@ msgstr "Verificar cuenta bancaria"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.error.flash"
-msgstr ""
+msgstr "Algo salió mal al verificar tu cuenta bancaria. Inténtalo de nuevo más tarde."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.label"
-msgstr ""
+msgstr "Número de teléfono móvil"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.body"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-account.po
@@ -281,75 +281,75 @@ msgstr "Troppe richieste. Riprova tra un attimo."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.button.add"
-msgstr ""
+msgstr "Aggiungi"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.error.flash"
-msgstr ""
+msgstr "Si è verificato un errore durante la verifica del tuo conto bancario. Riprova più tardi."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.intro"
-msgstr ""
+msgstr "I pagamenti sono gestiti dal nostro partner di pagamento Online Payment Platform"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.not_verified"
-msgstr ""
+msgstr "Non verificato"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.pending"
-msgstr ""
+msgstr "In verifica"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.verified"
-msgstr ""
+msgstr "Verificato"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.title"
-msgstr ""
+msgstr "Conto bancario"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.verified.flash"
-msgstr ""
+msgstr "Il tuo conto bancario è stato verificato."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.empty"
-msgstr ""
+msgstr "Non sono ancora stati effettuati pagamenti. Una volta effettuati, troverai qui un riepilogo."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.intro"
-msgstr ""
+msgstr "Di seguito trovi un riepilogo di tutti i tuoi pagamenti."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.title"
-msgstr ""
+msgstr "Riepilogo"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.total"
-msgstr ""
+msgstr "Totale"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.completed"
-msgstr ""
+msgstr "Pagato"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.failed"
-msgstr ""
+msgstr "Fallito"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.pending"
-msgstr ""
+msgstr "In attesa"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.amount"
-msgstr ""
+msgstr "Importo"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.date"
-msgstr ""
+msgstr "Data"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.status"
-msgstr ""
+msgstr "Stato"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.title"
@@ -373,11 +373,11 @@ msgstr "Verifica conto bancario"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.error.flash"
-msgstr ""
+msgstr "Si è verificato un errore durante la verifica del tuo conto bancario. Riprova più tardi."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.label"
-msgstr ""
+msgstr "Numero di cellulare"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.body"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-account.po
@@ -290,75 +290,75 @@ msgstr "Per daug užklausų. Pabandykite dar kartą po akimirkos."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.button.add"
-msgstr ""
+msgstr "Pridėti"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.error.flash"
-msgstr ""
+msgstr "Tikrinant tavo banko sąskaitą įvyko klaida. Pabandyk vėliau dar kartą."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.intro"
-msgstr ""
+msgstr "Išmokas tvarko mūsų mokėjimo partneris „Online Payment Platform“"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.not_verified"
-msgstr ""
+msgstr "Nepatvirtinta"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.pending"
-msgstr ""
+msgstr "Tikrinama"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.verified"
-msgstr ""
+msgstr "Patvirtinta"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.title"
-msgstr ""
+msgstr "Banko sąskaita"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.verified.flash"
-msgstr ""
+msgstr "Tavo banko sąskaita patvirtinta."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.empty"
-msgstr ""
+msgstr "Kol kas nėra atliktų išmokų. Kai išmokos bus atliktos, čia rasi apžvalgą."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.intro"
-msgstr ""
+msgstr "Žemiau rasi visų tavo išmokų apžvalgą."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.title"
-msgstr ""
+msgstr "Apžvalga"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.total"
-msgstr ""
+msgstr "Iš viso"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.completed"
-msgstr ""
+msgstr "Išmokėta"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.failed"
-msgstr ""
+msgstr "Nepavyko"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.pending"
-msgstr ""
+msgstr "Laukiama"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.amount"
-msgstr ""
+msgstr "Suma"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.date"
-msgstr ""
+msgstr "Data"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.status"
-msgstr ""
+msgstr "Būsena"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.title"
@@ -382,11 +382,11 @@ msgstr "Patvirtinti banko sąskaitą"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.error.flash"
-msgstr ""
+msgstr "Tikrinant tavo banko sąskaitą įvyko klaida. Pabandyk vėliau dar kartą."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.label"
-msgstr ""
+msgstr "Mobiliojo telefono numeris"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.body"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-account.po
@@ -290,75 +290,75 @@ msgstr "Prea multe solicitări. Încearcă din nou într-un moment."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.button.add"
-msgstr ""
+msgstr "Adaugă"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.error.flash"
-msgstr ""
+msgstr "Ceva nu a mers bine la verificarea contului bancar. Încearcă din nou mai târziu."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.intro"
-msgstr ""
+msgstr "Plățile sunt gestionate de partenerul nostru de plăți Online Payment Platform"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.not_verified"
-msgstr ""
+msgstr "Neverificat"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.pending"
-msgstr ""
+msgstr "Se verifică"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.status.verified"
-msgstr ""
+msgstr "Verificat"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.title"
-msgstr ""
+msgstr "Cont bancar"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.bank.verified.flash"
-msgstr ""
+msgstr "Contul tău bancar a fost verificat."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.empty"
-msgstr ""
+msgstr "Nu au fost efectuate plăți încă. Odată efectuate, vei găsi aici o listă."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.intro"
-msgstr ""
+msgstr "Mai jos vei găsi o listă cu toate plățile tale."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.title"
-msgstr ""
+msgstr "Listă"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.overview.total"
-msgstr ""
+msgstr "Total"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.completed"
-msgstr ""
+msgstr "Plătit"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.failed"
-msgstr ""
+msgstr "Eșuat"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.status.pending"
-msgstr ""
+msgstr "În așteptare"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.amount"
-msgstr ""
+msgstr "Sumă"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.date"
-msgstr ""
+msgstr "Data"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.table.status"
-msgstr ""
+msgstr "Stare"
 
 #, elixir-autogen, elixir-format
 msgid "payouts.title"
@@ -382,11 +382,11 @@ msgstr "Verifică contul bancar"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.error.flash"
-msgstr ""
+msgstr "Ceva nu a mers bine la verificarea contului bancar. Încearcă din nou mai târziu."
 
 #, elixir-autogen, elixir-format
 msgid "payouts.phone.label"
-msgstr ""
+msgstr "Număr de telefon mobil"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "payouts.phone.modal.body"


### PR DESCRIPTION
## Summary

Iris reported the Payouts tab under **/user/account** was showing raw msgid strings (\`payouts.bank.title\`, \`payouts.overview.title\`, etc.) in DE and IT. Same 20 \`payouts.*\` keys were also empty in ES, LT, RO — only EN and NL were complete.

Filled all 20 keys × 5 locales = **100 translations added**. Nothing else changed; the code already calls the right \`dgettext\` keys.

Keys covered:
- \`bank.button.add\`, \`bank.error.flash\`, \`bank.intro\`, \`bank.status.{not_verified, pending, verified}\`, \`bank.title\`, \`bank.verified.flash\`
- \`overview.{empty, intro, title, total}\`
- \`status.{completed, failed, pending}\`
- \`table.{amount, date, status}\`
- \`phone.{error.flash, label}\`

Fixes: FX#10098012243

## Test plan

- [ ] Switch browser language to **DE** → visit \`/user/account\` → open the Payouts tab. All labels should be German, no raw \`payouts.*\` strings.
- [ ] Repeat for **ES**, **IT**, **LT**, **RO**.
- [ ] EN and NL unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)