### PR TITLE
fix: show 'study full' page instead of 500 on affiliate recruit link

### DIFF
--- a/core/systems/affiliate/controller.ex
+++ b/core/systems/affiliate/controller.ex
@@ -179,14 +179,21 @@ defmodule Systems.Affiliate.Controller do
     participant_id = get_participant(params)
     %{user: user} = affiliate_user = Affiliate.Public.obtain_user!(participant_id, affiliate)
 
-    conn
-    |> assign(:current_user, user)
-    |> log_in_user_without_redirect(user)
-    |> authorize_user(assignment)
-    |> ensure_user_info(params, affiliate_user)
-    |> obtain_instance(assignment)
-    |> add_panel_info_for_participant(params, affiliate, affiliate_user)
-    |> redirect(to: path(assignment))
+    conn =
+      conn
+      |> assign(:current_user, user)
+      |> log_in_user_without_redirect(user)
+
+    if full?(assignment) and not returning_participant?(conn, assignment) do
+      assignment_full(conn)
+    else
+      conn
+      |> authorize_user(assignment)
+      |> ensure_user_info(params, affiliate_user)
+      |> obtain_instance(assignment)
+      |> add_panel_info_for_participant(params, affiliate, affiliate_user)
+      |> redirect(to: path(assignment))
+    end
   end
 
   defp path(%{id: id}), do: "/assignment/#{id}"
@@ -210,6 +217,20 @@ defmodule Systems.Affiliate.Controller do
     |> put_status(:service_unavailable)
     |> put_view(html: CoreWeb.ErrorHTML)
     |> render(:"503")
+  end
+
+  defp assignment_full(conn) do
+    conn
+    |> put_view(html: Assignment.ErrorHTML)
+    |> render(:assignment_full)
+  end
+
+  defp full?(%Assignment.Model{} = assignment) do
+    not Assignment.Public.has_budget_capacity?(assignment)
+  end
+
+  defp returning_participant?(%{assigns: %{current_user: user}}, %Assignment.Model{} = assignment) do
+    Assignment.Public.member?(assignment, user)
   end
 
   defp authorize_user(%{assigns: %{current_user: user}} = conn, assignment) do

--- a/core/test/systems/affiliate/recruit_test.exs
+++ b/core/test/systems/affiliate/recruit_test.exs
@@ -5,6 +5,7 @@ defmodule Systems.Affiliate.RecruitTest do
 
   alias Systems.Assignment
   alias Systems.Affiliate
+  alias Systems.Fund
 
   describe "GET /r/:sqid" do
     setup do
@@ -59,5 +60,47 @@ defmodule Systems.Affiliate.RecruitTest do
 
       assert conn.status == 503
     end
+  end
+
+  describe "GET /a/:sqid (participant start)" do
+    setup do
+      assignment = Assignment.Factories.create_assignment_with_affiliate()
+      %{assignment: assignment}
+    end
+
+    test "shows a friendly 'study is full' page when the budget cannot cover one more reward",
+         %{conn: conn, assignment: assignment} do
+      make_paid(assignment, 6000)
+      sqid = Affiliate.Sqids.encode!([0, assignment.id])
+
+      conn = get(conn, "/a/#{sqid}?p=participant-full-1")
+
+      response = html_response(conn, 200)
+      assert response =~ "error-assignment_full"
+      assert response =~ "This study is full"
+    end
+
+    test "starts the participant when the budget can cover one more reward",
+         %{conn: conn, assignment: assignment} do
+      make_paid(assignment, 100)
+      sqid = Affiliate.Sqids.encode!([0, assignment.id])
+
+      conn = get(conn, "/a/#{sqid}?p=participant-ok-1")
+
+      assert redirected_to(conn) == "/assignment/#{assignment.id}"
+    end
+  end
+
+  defp make_paid(%{info: info} = assignment, subject_reward) do
+    currency = Fund.Factories.create_currency("eur_aff_#{subject_reward}", :legal, "€", 2)
+    fund = Fund.Factories.create_fund("aff_fund_#{subject_reward}", currency)
+
+    assignment
+    |> Assignment.Model.changeset(fund)
+    |> Core.Repo.update!()
+
+    info
+    |> Ecto.Changeset.change(subject_reward: subject_reward)
+    |> Core.Repo.update!()
   end
 end


### PR DESCRIPTION
## Problem

Clicking a Panl recruit link for a study that is **full** (or underfunded) returned an **internal server error (500)** to the participant. `Systems.Assignment.Public.reserve_reward!/2` raises a `RuntimeError` when the fund can't cover another reward (`fund_balance: :no_funding`), and the affiliate controller called it unguarded via `add_participant!/2`.

Observed in Appsignal:
> `[Assignment] reserve_reward! failed at fund_balance: :no_funding` → `(RuntimeError) reserve_reward! failed at fund_balance: :no_funding (assignment=124 ...)` in `Systems.Affiliate.Controller.start_participant/3`.

## Fix

Guard `start_participant/3` with the same capacity check the assignment controller (`/assignment/:id/apply`) already uses: when the fund can't cover one more reward **and** the visitor is not a returning member, render the friendly `Assignment.ErrorHTML :assignment_full` page instead of crashing. Returning participants (already reserved) still pass through; `reserve_reward!` remains as the safety-net raise for the rare capacity race.

## Tests

Added two atomic integration tests to `recruit_test.exs` covering the affiliate `/a/:sqid?p=...` path: full study → friendly page (200), and sufficient budget → participant starts (redirect).

Fixes Flux issue 10052894092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)