### PR TITLE
fix(pixel): align clickable_card inner_block to bottom for equal-height cards

### DIFF
--- a/core/frameworks/pixel/components/clickable_card.ex
+++ b/core/frameworks/pixel/components/clickable_card.ex
@@ -92,7 +92,7 @@ defmodule Frameworks.Pixel.ClickableCard do
       <div class="flex flex-col h-full">
         <div class="flex-grow">
           <div
-            class="flex flex-col cursor-pointer"
+            class="flex flex-col cursor-pointer h-full"
             phx-target={@target}
             phx-click="card_clicked"
             phx-value-item={@id}
@@ -106,7 +106,7 @@ defmodule Frameworks.Pixel.ClickableCard do
             <% else %>
               <div class="pt-6 px-6 lg:pl-8 lg:pr-8 lg:pt-8" />
             <% end %>
-            <div>
+            <div class="mt-auto">
               <div
                 class="relative pl-6 pr-6 pb-6 lg:pl-8 lg:pr-8 lg:pb-8"
               >


### PR DESCRIPTION
## Summary
- On the Pool marketplace, cards in a grid share row height. A longer title pushed the "Duur | Beloning" line down relative to sibling cards, so info didn't align across a row.
- `clickable_card` now anchors its `inner_block` at the bottom: the inner vertical flex gets `h-full`, the inner_block wrapper gets `mt-auto`.
- Universal change — applies to every `clickable_card` consumer (Advert, Project, Org, Onyx). Info block always sits at the bottom of the card regardless of title length.

## Test plan
- [x] `mix test test/systems/pool/marketplace_*_test.exs` — 19 pass
- [x] Pre-commit hook: format / compile --force / test / credo / dialyzer all pass
- [ ] Manual: browse marketplace with a mix of short and long titles; the info line should sit at the same vertical position across all cards in a row
- [ ] Manual: sanity-check other card views (Project overview, Org list, Onyx) — no visual regression

Fixes: https://3.basecamp.com/5734045/buckets/35926565/todos/9932522885