### PR TITLE
fix: store payment adapter so reconciliation skips local-only records

### DIFF
--- a/core/lib/core/factories.ex
+++ b/core/lib/core/factories.ex
@@ -1002,6 +1002,7 @@ defmodule Core.Factories do
       user: user,
       amount_cents: 1000,
       currency: "eur",
+      payment_adapter: "opp",
       status: :pending
     }
     |> struct!(attributes)

--- a/core/priv/repo/migrations/20260720082133_add_payment_adapter_to_transactions_and_payouts.exs
+++ b/core/priv/repo/migrations/20260720082133_add_payment_adapter_to_transactions_and_payouts.exs
@@ -1,0 +1,47 @@
+defmodule Core.Repo.Migrations.AddPaymentAdapterToTransactionsAndPayouts do
+  use Ecto.Migration
+
+  # Records which payment adapter realized each transaction/payout ("opp" or
+  # "local"), set at creation, so reconciliation can skip local-only records
+  # instead of guessing from the "free_" id prefix.
+  def up do
+    alter table(:transactions) do
+      add(:payment_adapter, :string)
+    end
+
+    alter table(:fund_payouts) do
+      add(:payment_adapter, :string)
+    end
+
+    flush()
+
+    # Legacy rows: free pay-ins were local-only; everything else was OPP.
+    execute("""
+    UPDATE transactions
+    SET payment_adapter = CASE
+      WHEN transaction_id LIKE 'free_%' THEN 'local'
+      ELSE 'opp'
+    END
+    """)
+
+    execute("UPDATE fund_payouts SET payment_adapter = 'opp'")
+
+    alter table(:transactions) do
+      modify(:payment_adapter, :string, null: false)
+    end
+
+    alter table(:fund_payouts) do
+      modify(:payment_adapter, :string, null: false)
+    end
+  end
+
+  def down do
+    alter table(:transactions) do
+      remove(:payment_adapter)
+    end
+
+    alter table(:fund_payouts) do
+      remove(:payment_adapter)
+    end
+  end
+end

--- a/core/priv/repo/migrations/20260720082133_add_payment_adapter_to_transactions_and_payouts.exs
+++ b/core/priv/repo/migrations/20260720082133_add_payment_adapter_to_transactions_and_payouts.exs
@@ -5,34 +5,23 @@ defmodule Core.Repo.Migrations.AddPaymentAdapterToTransactionsAndPayouts do
   # "local"), set at creation, so reconciliation can skip local-only records
   # instead of guessing from the "free_" id prefix.
   def up do
+    # Default "opp" (NOT NULL) so existing rows — and any created by old app
+    # instances still live during a rolling deploy, before the new code sets the
+    # adapter — satisfy the constraint. Only local-only rows deviate.
     alter table(:transactions) do
-      add(:payment_adapter, :string)
+      add(:payment_adapter, :string, null: false, default: "opp")
     end
 
     alter table(:fund_payouts) do
-      add(:payment_adapter, :string)
+      add(:payment_adapter, :string, null: false, default: "opp")
     end
 
     flush()
 
-    # Legacy rows: free pay-ins were local-only; everything else was OPP.
-    execute("""
-    UPDATE transactions
-    SET payment_adapter = CASE
-      WHEN transaction_id LIKE 'free_%' THEN 'local'
-      ELSE 'opp'
-    END
-    """)
-
-    execute("UPDATE fund_payouts SET payment_adapter = 'opp'")
-
-    alter table(:transactions) do
-      modify(:payment_adapter, :string, null: false)
-    end
-
-    alter table(:fund_payouts) do
-      modify(:payment_adapter, :string, null: false)
-    end
+    # Legacy free pay-ins were local-only, not OPP.
+    execute(
+      "UPDATE transactions SET payment_adapter = 'local' WHERE transaction_id LIKE 'free_%'"
+    )
   end
 
   def down do

--- a/core/systems/budget/_public.ex
+++ b/core/systems/budget/_public.ex
@@ -110,6 +110,7 @@ defmodule Systems.Budget.Public do
            %Budget.TransactionModel{}
            |> Budget.TransactionModel.changeset(%{
              transaction_id: provider_result.uid,
+             payment_adapter: Payment.Public.adapter_name(),
              status: :pending,
              idempotence_key: idempotence_key,
              invoice_id: invoice_id,
@@ -144,6 +145,7 @@ defmodule Systems.Budget.Public do
            %Budget.TransactionModel{}
            |> Budget.TransactionModel.changeset(%{
              transaction_id: "free_#{Ecto.UUID.generate()}",
+             payment_adapter: "local",
              status: :completed,
              idempotence_key: idempotence_key,
              invoice_id: invoice_id,

--- a/core/systems/budget/transaction_model.ex
+++ b/core/systems/budget/transaction_model.ex
@@ -10,6 +10,7 @@ defmodule Systems.Budget.TransactionModel do
 
   schema "transactions" do
     field(:transaction_id, :string)
+    field(:payment_adapter, :string)
     field(:status, Ecto.Enum, values: @statuses)
     field(:idempotence_key, :string)
     field(:invoice_id, :string)
@@ -22,7 +23,7 @@ defmodule Systems.Budget.TransactionModel do
     timestamps()
   end
 
-  @fields ~w(transaction_id status idempotence_key invoice_id subject_count total_amount)a
+  @fields ~w(transaction_id payment_adapter status idempotence_key invoice_id subject_count total_amount)a
   @required_fields @fields
 
   def changeset(%__MODULE__{} = transaction, attrs) do

--- a/core/systems/budget/transaction_reconciliation.ex
+++ b/core/systems/budget/transaction_reconciliation.ex
@@ -46,6 +46,12 @@ defmodule Systems.Budget.TransactionReconciliation do
     |> Repo.all()
   end
 
+  # Local-only (free pay-ins, local simulator) never existed at the provider, so
+  # there is nothing to reconcile against.
+  defp reconcile_transaction(%Budget.TransactionModel{payment_adapter: "local"}, state) do
+    State.tally(state, :verified)
+  end
+
   defp reconcile_transaction(
          %Budget.TransactionModel{transaction_id: nil, id: id, status: status},
          state
@@ -55,10 +61,6 @@ defmodule Systems.Budget.TransactionReconciliation do
     )
 
     record(state, :unresolvable, id, nil, status, nil, %{reason: "no provider uid"})
-  end
-
-  defp reconcile_transaction(%Budget.TransactionModel{transaction_id: "free_" <> _}, state) do
-    State.tally(state, :verified)
   end
 
   defp reconcile_transaction(

--- a/core/systems/budget/transaction_reconciliation.ex
+++ b/core/systems/budget/transaction_reconciliation.ex
@@ -38,18 +38,14 @@ defmodule Systems.Budget.TransactionReconciliation do
     age_cutoff = NaiveDateTime.add(now, -min_age_minutes * 60, :second)
     lookback_cutoff = NaiveDateTime.add(now, -max_age_days * 24 * 60 * 60, :second)
 
+    # Local-only rows (free pay-ins, local simulator) never existed at the
+    # provider, so they are excluded here rather than fetched and skipped.
     from(t in Budget.TransactionModel,
       where:
-        t.status in [:pending, :failed, :completed] and t.inserted_at < ^age_cutoff and
-          t.inserted_at > ^lookback_cutoff
+        t.status in [:pending, :failed, :completed] and t.payment_adapter != "local" and
+          t.inserted_at < ^age_cutoff and t.inserted_at > ^lookback_cutoff
     )
     |> Repo.all()
-  end
-
-  # Local-only (free pay-ins, local simulator) never existed at the provider, so
-  # there is nothing to reconcile against.
-  defp reconcile_transaction(%Budget.TransactionModel{payment_adapter: "local"}, state) do
-    State.tally(state, :verified)
   end
 
   defp reconcile_transaction(

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -1201,6 +1201,7 @@ defmodule Systems.Fund.Public do
     Fund.PayoutModel.changeset(%Fund.PayoutModel{}, %{
       user_id: user_id,
       amount_cents: total,
+      payment_adapter: Payment.Public.adapter_name(),
       status: :pending
     })
   end

--- a/core/systems/fund/payout_model.ex
+++ b/core/systems/fund/payout_model.ex
@@ -17,6 +17,7 @@ defmodule Systems.Fund.PayoutModel do
   schema "fund_payouts" do
     field(:amount_cents, :integer)
     field(:currency, :string, default: "eur")
+    field(:payment_adapter, :string)
     field(:status, Ecto.Enum, values: @statuses, default: :pending)
     field(:provider_uid, :string)
     field(:failure_reason, :string)
@@ -36,7 +37,7 @@ defmodule Systems.Fund.PayoutModel do
   def idempotence_key(%__MODULE__{id: id}) when is_integer(id), do: "payout=#{id}"
 
   @required_fields ~w(user_id amount_cents)a
-  @optional_fields ~w(currency status provider_uid failure_reason)a
+  @optional_fields ~w(currency payment_adapter status provider_uid failure_reason)a
   @fields @required_fields ++ @optional_fields
 
   def changeset(payout, attrs) do

--- a/core/systems/fund/payout_reconciliation.ex
+++ b/core/systems/fund/payout_reconciliation.ex
@@ -45,6 +45,12 @@ defmodule Systems.Fund.PayoutReconciliation do
     |> Repo.all()
   end
 
+  # Local-only payouts (local simulator) never existed at the provider, so there
+  # is nothing to reconcile against.
+  defp reconcile_payout(%Fund.PayoutModel{payment_adapter: "local"}, state) do
+    State.tally(state, :verified)
+  end
+
   defp reconcile_payout(%Fund.PayoutModel{id: id, status: status, provider_uid: nil}, state) do
     Logger.error(
       "[Fund] reconcile: payout ##{id} (#{status}) has no provider_uid — manual review"

--- a/core/systems/fund/payout_reconciliation.ex
+++ b/core/systems/fund/payout_reconciliation.ex
@@ -38,19 +38,16 @@ defmodule Systems.Fund.PayoutReconciliation do
 
     # A :failed payout whose funds moved (:withdrawal_retryable) is still open;
     # one that moved nothing already released its lock and is terminal.
+    # Local-only payouts (local simulator) never existed at the provider, so they
+    # are excluded here rather than fetched and skipped.
     from(p in Fund.PayoutModel,
       where:
         (p.status in [:pending, :completed] or
            (p.status == :failed and not is_nil(p.funds_committed_at))) and
+          p.payment_adapter != "local" and
           p.inserted_at < ^age_cutoff and p.inserted_at > ^lookback_cutoff
     )
     |> Repo.all()
-  end
-
-  # Local-only payouts (local simulator) never existed at the provider, so there
-  # is nothing to reconcile against.
-  defp reconcile_payout(%Fund.PayoutModel{payment_adapter: "local"}, state) do
-    State.tally(state, :verified)
   end
 
   defp reconcile_payout(%Fund.PayoutModel{} = payout, state) do

--- a/core/systems/payment/_public.ex
+++ b/core/systems/payment/_public.ex
@@ -282,6 +282,14 @@ defmodule Systems.Payment.Public do
     div(base_amount * partner_fee_percentage(), 100)
   end
 
+  @doc """
+  Short name of the currently configured payment adapter ("opp" or "local"),
+  stored on transactions and payouts at creation so reconciliation can skip
+  local-only records instead of guessing from the id.
+  """
+  @spec adapter_name() :: String.t()
+  def adapter_name, do: provider_name()
+
   defp provider do
     Application.fetch_env!(:core, :payment_provider)
   end

--- a/core/systems/payment/_public.ex
+++ b/core/systems/payment/_public.ex
@@ -293,12 +293,25 @@ defmodule Systems.Payment.Public do
   end
 
   @doc """
-  Short name of the currently configured payment adapter ("opp" or "local"),
-  stored on transactions and payouts at creation so reconciliation can skip
-  local-only records instead of guessing from the id.
+  Canonical name of the currently configured payment adapter (e.g. "opp" or
+  "local"), stored on transactions and payouts at creation so reconciliation can
+  skip local-only records instead of guessing from the id.
+
+  Resolved from the `:payment_providers` registry, whose keys are the canonical
+  names reconciliation filters on. Real deployments always select their provider
+  through that registry (see `Core.Config.payment_provider/0`), so the name is
+  guaranteed; only a provider configured outside it — the test mock — falls back
+  to its own short module name.
   """
   @spec adapter_name() :: String.t()
-  def adapter_name, do: provider_name()
+  def adapter_name do
+    provider = provider()
+
+    Application.fetch_env!(:core, :payment_providers)
+    |> Enum.find_value(provider_name(), fn {name, module} ->
+      if module == provider, do: name
+    end)
+  end
 
   defp provider do
     Application.fetch_env!(:core, :payment_provider)

--- a/core/test/systems/account/payouts_view_builder_test.exs
+++ b/core/test/systems/account/payouts_view_builder_test.exs
@@ -204,6 +204,7 @@ defmodule Systems.Account.PayoutsViewBuilderTest do
       user_id: user.id,
       amount_cents: cents,
       currency: "eur",
+      payment_adapter: "opp",
       status: status,
       inserted_at: inserted_at,
       updated_at: inserted_at

--- a/core/test/systems/account/payouts_view_test.exs
+++ b/core/test/systems/account/payouts_view_test.exs
@@ -26,6 +26,7 @@ defmodule Systems.Account.PayoutsViewTest do
       user_id: user.id,
       amount_cents: cents,
       currency: "eur",
+      payment_adapter: "opp",
       status: status,
       inserted_at: inserted_at,
       updated_at: inserted_at

--- a/core/test/systems/budget/complete_transaction_test.exs
+++ b/core/test/systems/budget/complete_transaction_test.exs
@@ -56,6 +56,7 @@ defmodule Systems.Budget.CompleteTransactionTest do
       %Budget.TransactionModel{}
       |> Budget.TransactionModel.changeset(%{
         transaction_id: "provider-" <> Ecto.UUID.generate(),
+        payment_adapter: "opp",
         status: status,
         idempotence_key: Ecto.UUID.generate(),
         invoice_id: "NEXT-TEST-#{System.unique_integer([:positive])}",

--- a/core/test/systems/budget/create_pay_in_test.exs
+++ b/core/test/systems/budget/create_pay_in_test.exs
@@ -69,9 +69,19 @@ defmodule Systems.Budget.CreatePayInTest do
       assert %{status: :failed} = Repo.get!(Budget.TransactionModel, failed.id)
       assert %{status: :pending} = Repo.get!(Budget.TransactionModel, retry.id)
     end
+
+    test "stores the local adapter on a free (zero-reward) pay-in, so reconciliation skips it" do
+      %{assignment: assignment, user: user} = setup_assignment(0)
+
+      # Zero reward → no provider call; the transaction is realized locally.
+      {:ok, %{transaction: transaction}} = Budget.Public.create_pay_in(assignment, user, 10)
+
+      assert transaction.payment_adapter == "local"
+      assert String.starts_with?(transaction.transaction_id, "free_")
+    end
   end
 
-  defp setup_assignment do
+  defp setup_assignment(subject_reward \\ 500) do
     ensure_currency_ledger(:EUR)
 
     user =
@@ -84,7 +94,8 @@ defmodule Systems.Budget.CreatePayInTest do
     currency = Factories.insert!(:currency, %{name: "eur_pay_in"})
     fund = Fund.Factories.create_fund("pay_in_fund", currency)
 
-    info = Factories.insert!(:assignment_info, %{subject_count: 10, subject_reward: 500})
+    info =
+      Factories.insert!(:assignment_info, %{subject_count: 10, subject_reward: subject_reward})
 
     assignment =
       Factories.insert!(:assignment, %{

--- a/core/test/systems/budget/fail_transaction_test.exs
+++ b/core/test/systems/budget/fail_transaction_test.exs
@@ -42,6 +42,7 @@ defmodule Systems.Budget.FailTransactionTest do
       %Budget.TransactionModel{}
       |> Budget.TransactionModel.changeset(%{
         transaction_id: "provider-" <> Ecto.UUID.generate(),
+        payment_adapter: "opp",
         status: status,
         idempotence_key: Ecto.UUID.generate(),
         invoice_id: "NEXT-TEST-#{unique}",

--- a/core/test/systems/budget/pay_in_expiration_test.exs
+++ b/core/test/systems/budget/pay_in_expiration_test.exs
@@ -45,6 +45,7 @@ defmodule Systems.Budget.PayInExpirationTest do
       %Budget.TransactionModel{}
       |> Budget.TransactionModel.changeset(%{
         transaction_id: Ecto.UUID.generate(),
+        payment_adapter: "opp",
         status: status,
         idempotence_key: Ecto.UUID.generate(),
         invoice_id: "NEXT-TEST-#{System.unique_integer([:positive])}",

--- a/core/test/systems/budget/reconcile_transactions_test.exs
+++ b/core/test/systems/budget/reconcile_transactions_test.exs
@@ -172,13 +172,13 @@ defmodule Systems.Budget.ReconcileTransactionsTest do
     assert %{scanned: 0} = reconcile()
   end
 
-  test "skips a local-only transaction without querying the provider" do
+  test "does not scan a local-only transaction" do
     # Free pay-ins and local-simulator transactions never existed at OPP; the
-    # stored adapter — not the id — tells reconciliation to leave them alone.
+    # stored adapter — not the id — keeps them out of the scan entirely.
     transaction = setup_transaction(:completed, adapter: "local")
 
     # No ProviderMock stub: verify_on_exit! fails if the provider is queried.
-    assert %{scanned: 1, verified: 1} = reconcile()
+    assert %{scanned: 0} = reconcile()
     assert %{status: :completed} = Repo.reload!(transaction)
   end
 

--- a/core/test/systems/budget/reconcile_transactions_test.exs
+++ b/core/test/systems/budget/reconcile_transactions_test.exs
@@ -22,6 +22,7 @@ defmodule Systems.Budget.ReconcileTransactionsTest do
   defp setup_transaction(status, opts \\ []) do
     minutes_ago = Keyword.get(opts, :minutes_ago, 120)
     with_ledger? = Keyword.get(opts, :ledger, true)
+    adapter = Keyword.get(opts, :adapter, "opp")
     user = Factories.insert!(:member)
 
     fund =
@@ -45,6 +46,7 @@ defmodule Systems.Budget.ReconcileTransactionsTest do
       %Budget.TransactionModel{}
       |> Budget.TransactionModel.changeset(%{
         transaction_id: uid,
+        payment_adapter: adapter,
         status: status,
         idempotence_key: Ecto.UUID.generate(),
         invoice_id: "NEXT-TEST-#{System.unique_integer([:positive])}",
@@ -168,6 +170,16 @@ defmodule Systems.Budget.ReconcileTransactionsTest do
     # default min_age is 60 minutes; no OPP call expected.
 
     assert %{scanned: 0} = reconcile()
+  end
+
+  test "skips a local-only transaction without querying the provider" do
+    # Free pay-ins and local-simulator transactions never existed at OPP; the
+    # stored adapter — not the id — tells reconciliation to leave them alone.
+    transaction = setup_transaction(:completed, adapter: "local")
+
+    # No ProviderMock stub: verify_on_exit! fails if the provider is queried.
+    assert %{scanned: 1, verified: 1} = reconcile()
+    assert %{status: :completed} = Repo.reload!(transaction)
   end
 
   test "counts an OPP query error and leaves the transaction untouched" do

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -1414,6 +1414,7 @@ defmodule Systems.Fund.PublicTest do
           user_id: user.id,
           amount_cents: total,
           currency: "eur",
+          payment_adapter: "opp",
           status: :pending,
           provider_uid: provider_uid
         })

--- a/core/test/systems/fund/reconcile_payouts_test.exs
+++ b/core/test/systems/fund/reconcile_payouts_test.exs
@@ -36,12 +36,14 @@ defmodule Systems.Fund.ReconcilePayoutsTest do
   defp insert_payout(user, fund, amount, provider_uid, opts \\ []) do
     minutes_ago = Keyword.get(opts, :minutes_ago, 120)
     status = Keyword.get(opts, :status, :pending)
+    adapter = Keyword.get(opts, :adapter, "opp")
 
     payout =
       Factories.insert!(:payout, %{
         user: user,
         amount_cents: amount,
         currency: "eur",
+        payment_adapter: adapter,
         status: status,
         provider_uid: provider_uid
       })
@@ -112,6 +114,16 @@ defmodule Systems.Fund.ReconcilePayoutsTest do
     # No ProviderMock stub: Mox would raise if get_withdrawal were called.
 
     assert %{scanned: 1, unresolvable: 1} = reconcile()
+    assert %{status: :pending} = Repo.reload!(payout)
+  end
+
+  test "skips a local-only payout without querying the provider", %{user: user, fund: fund} do
+    # A payout realized by the local simulator never existed at OPP; the stored
+    # adapter tells reconciliation to leave it alone.
+    {payout, _reward} = insert_payout(user, fund, 1000, "w_local", adapter: "local")
+
+    # No ProviderMock stub: verify_on_exit! fails if the provider is queried.
+    assert %{scanned: 1, verified: 1} = reconcile()
     assert %{status: :pending} = Repo.reload!(payout)
   end
 

--- a/core/test/systems/fund/reconcile_payouts_test.exs
+++ b/core/test/systems/fund/reconcile_payouts_test.exs
@@ -122,13 +122,13 @@ defmodule Systems.Fund.ReconcilePayoutsTest do
     assert %{status: :pending} = Repo.reload!(payout)
   end
 
-  test "skips a local-only payout without querying the provider", %{user: user, fund: fund} do
+  test "does not scan a local-only payout", %{user: user, fund: fund} do
     # A payout realized by the local simulator never existed at OPP; the stored
-    # adapter tells reconciliation to leave it alone.
+    # adapter keeps it out of the scan entirely.
     {payout, _reward} = insert_payout(user, fund, 1000, "w_local", adapter: "local")
 
     # No ProviderMock stub: verify_on_exit! fails if the provider is queried.
-    assert %{scanned: 1, verified: 1} = reconcile()
+    assert %{scanned: 0} = reconcile()
     assert %{status: :pending} = Repo.reload!(payout)
   end
 

--- a/core/test/systems/payment/_public_test.exs
+++ b/core/test/systems/payment/_public_test.exs
@@ -243,4 +243,21 @@ defmodule Systems.Payment.PublicTest do
       assert Payment.Public.platform_merchant_uid() == "mer_platform_test"
     end
   end
+
+  describe "adapter_name/0" do
+    setup do
+      original = Application.fetch_env!(:core, :payment_provider)
+      on_exit(fn -> Application.put_env(:core, :payment_provider, original) end)
+    end
+
+    test ~s(resolves the OPP provider to its registry key "opp") do
+      Application.put_env(:core, :payment_provider, Systems.Payment.Provider.OPP)
+      assert Payment.Public.adapter_name() == "opp"
+    end
+
+    test ~s(resolves the Local provider to its registry key "local") do
+      Application.put_env(:core, :payment_provider, Systems.Payment.Provider.Local)
+      assert Payment.Public.adapter_name() == "local"
+    end
+  end
 end

--- a/core/test/systems/payment/controller_test.exs
+++ b/core/test/systems/payment/controller_test.exs
@@ -38,6 +38,7 @@ defmodule Systems.Payment.ControllerTest do
         user_id: user.id,
         amount_cents: amount,
         currency: "eur",
+        payment_adapter: "opp",
         status: :pending,
         provider_uid: provider_uid
       })

--- a/core/test/systems/payment/reconciliation_worker_test.exs
+++ b/core/test/systems/payment/reconciliation_worker_test.exs
@@ -47,6 +47,7 @@ defmodule Systems.Payment.ReconciliationWorkerTest do
         user_id: user.id,
         amount_cents: 1000,
         currency: "eur",
+        payment_adapter: "opp",
         status: :pending,
         provider_uid: "w_payout"
       })
@@ -92,6 +93,7 @@ defmodule Systems.Payment.ReconciliationWorkerTest do
       %Budget.TransactionModel{}
       |> Budget.TransactionModel.changeset(%{
         transaction_id: "tx_payin",
+        payment_adapter: "opp",
         status: :pending,
         idempotence_key: Ecto.UUID.generate(),
         invoice_id: "NEXT-W-#{System.unique_integer([:positive])}",


### PR DESCRIPTION
Reconciliation flagged local-only records (free pay-ins, local-simulator transactions) as missing because it guessed locality from a "free_" id prefix. Now each transaction and payout stores its creating adapter ("opp"/"local") and both reconcilers skip the local ones.

Fixes Flux 10005117814.