### PR TITLE
fix: crash when PAYMENT_PROVIDER is unset instead of defaulting to local

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -112,7 +112,6 @@ config :core,
   greenlight_auth_module: Core.Authorization,
   image_catalog: Core.ImageCatalog.Unsplash,
   banking_backend: Systems.Banking.Dummy,
-  payment_provider: Systems.Payment.Provider.Local,
   payment_providers: %{
     "opp" => Systems.Payment.Provider.OPP,
     "local" => Systems.Payment.Provider.Local

--- a/core/lib/core/config.ex
+++ b/core/lib/core/config.ex
@@ -1,6 +1,21 @@
 defmodule Core.Config do
   def payment_provider do
-    name = System.get_env("PAYMENT_PROVIDER", "local")
+    name =
+      case System.get_env("PAYMENT_PROVIDER") do
+        value when is_binary(value) and value != "" ->
+          value
+
+        _ ->
+          raise """
+          PAYMENT_PROVIDER is not set.
+
+          Set it to one of the configured payment providers (see :payment_providers,
+          e.g. "opp" or "local"). Refusing to boot rather than silently falling back
+          to a default, which would route real payments through the wrong adapter and
+          exclude them from reconciliation.
+          """
+      end
+
     providers = Application.fetch_env!(:core, :payment_providers)
     Map.fetch!(providers, name)
   end


### PR DESCRIPTION
Core.Config.payment_provider/0 now raises when PAYMENT_PROVIDER is unset or blank rather than silently falling back to "local", which would route real payments through the wrong adapter and exclude them from reconciliation. Also removed the compile-time payment_provider default in config.exs; the value is resolved per environment (test mock, or PAYMENT_PROVIDER at runtime).