### PR TITLE
fix(assignment): forgiving fee parser + inline error on invalid input

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -590,6 +590,10 @@ msgid "budget_form.fee.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Bitte einen Betrag eingeben, z. B. 3,75"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -589,6 +589,10 @@ msgid "budget_form.fee.hint"
 msgstr "Please note that the minimum fee is €8,00 per hour"
 
 #, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Please enter a plain amount, like 3.75"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr "Participant fee"
 
@@ -654,7 +658,7 @@ msgstr "Service fee"
 
 #, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr "Subtotal (%{count} × %{reward} reward)"
+msgstr "Subtotal (%{count} × %{reward} fee)"
 
 #, elixir-autogen, elixir-format
 msgid "budget_form.total.label"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -590,6 +590,10 @@ msgid "budget_form.fee.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Introduce un importe, p. ej., 3,75"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -590,6 +590,10 @@ msgid "budget_form.fee.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Inserisci un importo, es. 3,75"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -600,6 +600,10 @@ msgid "budget_form.fee.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Įveskite sumą, pvz., 3,75"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -589,6 +589,10 @@ msgid "budget_form.fee.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Voer een bedrag in, bijv. 3,75"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -600,6 +600,10 @@ msgid "budget_form.fee.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Introdu o sumă, de ex. 3,75"
+
+#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 

--- a/core/systems/assignment/budget_form.ex
+++ b/core/systems/assignment/budget_form.ex
@@ -30,7 +30,7 @@ defmodule Systems.Assignment.BudgetForm do
       {%{subject_count: 0}, %{subject_count: :integer}}
       |> Ecto.Changeset.change()
 
-    fee_changeset = Assignment.InfoModel.changeset(info, :create, %{})
+    reward_changeset = Assignment.InfoModel.changeset(info, :create, %{})
 
     {
       :ok,
@@ -43,9 +43,10 @@ defmodule Systems.Assignment.BudgetForm do
         active_currency: active_currency,
         reward_locked?: reward_locked?,
         slots_changeset: slots_changeset,
-        fee_changeset: fee_changeset,
+        reward_changeset: reward_changeset,
         subject_count: 0,
         reward_cents: reward_cents,
+        reward_input: CurrencyHelpers.cents_to_display(reward_cents),
         partner_fee_percentage: Payment.Public.partner_fee_percentage()
       )
       |> assign_totals(0, reward_cents)
@@ -66,31 +67,47 @@ defmodule Systems.Assignment.BudgetForm do
 
   @impl true
   def handle_event(
-        "save_fee",
-        %{"info_model" => attrs},
+        "save_reward",
+        %{"info_model" => %{"subject_reward" => raw_reward} = attrs},
         %{assigns: %{assignment: assignment, info: info, subject_count: subject_count}} = socket
       ) do
-    attrs = convert_subject_reward(attrs)
-    changeset = Assignment.InfoModel.changeset(info, :auto_save, attrs)
+    case CurrencyHelpers.display_to_cents(raw_reward) do
+      {:ok, cents} ->
+        attrs = Map.put(attrs, "subject_reward", cents)
+        changeset = Assignment.InfoModel.changeset(info, :auto_save, attrs)
 
-    case Core.Persister.save(changeset.data, changeset) do
-      {:ok, updated_info} ->
-        reward_cents = updated_info.subject_reward || 0
+        case Core.Persister.save(changeset.data, changeset) do
+          {:ok, updated_info} ->
+            reward_cents = updated_info.subject_reward || 0
 
-        {
-          :noreply,
-          socket
-          |> assign(
-            assignment: %{assignment | info: updated_info},
-            info: updated_info,
-            fee_changeset: Assignment.InfoModel.changeset(updated_info, :create, %{}),
-            reward_cents: reward_cents
+            {
+              :noreply,
+              socket
+              |> assign(
+                assignment: %{assignment | info: updated_info},
+                info: updated_info,
+                reward_changeset: Assignment.InfoModel.changeset(updated_info, :create, %{}),
+                reward_cents: reward_cents,
+                reward_input: raw_reward
+              )
+              |> assign_totals(subject_count, reward_cents)
+            }
+
+          {:error, changeset} ->
+            {:noreply, assign(socket, reward_changeset: changeset, reward_input: raw_reward)}
+        end
+
+      :error ->
+        changeset =
+          info
+          |> Assignment.InfoModel.changeset(:create, %{})
+          |> Ecto.Changeset.add_error(
+            :subject_reward,
+            dgettext("eyra-assignment", "budget_form.fee.invalid")
           )
-          |> assign_totals(subject_count, reward_cents)
-        }
+          |> Map.put(:action, :insert)
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, fee_changeset: changeset)}
+        {:noreply, assign(socket, reward_changeset: changeset, reward_input: raw_reward)}
     end
   end
 
@@ -144,13 +161,6 @@ defmodule Systems.Assignment.BudgetForm do
 
   defp parse_int(_), do: 0
 
-  defp convert_subject_reward(%{"subject_reward" => value} = attrs) when is_binary(value) do
-    Map.put(attrs, "subject_reward", CurrencyHelpers.display_to_cents(value))
-  end
-
-  defp convert_subject_reward(attrs), do: attrs
-
-  defp cents_to_display(value), do: CurrencyHelpers.cents_to_display(value)
   defp format_cents(value), do: CurrencyHelpers.format_cents(value)
 
   defp confirm_enabled?(%{reward_locked?: true, subject_count: count}), do: count > 0
@@ -173,9 +183,9 @@ defmodule Systems.Assignment.BudgetForm do
       <.spacing value="L" />
 
       <%= if not @reward_locked? do %>
-        <.form id={"#{@id}_fee"} :let={fee_form} for={@fee_changeset} phx-change="save_fee" phx-target={@myself}>
+        <.form id={"#{@id}_reward"} :let={reward_form} for={@reward_changeset} phx-change="save_reward" phx-target={@myself}>
           <.text_input
-            form={fee_form}
+            form={reward_form}
             field={:aim_of_study}
             label_text={dgettext("eyra-assignment", "budget_form.aim.label")}
             maxlength="250"
@@ -185,15 +195,19 @@ defmodule Systems.Assignment.BudgetForm do
             <%= dgettext("eyra-assignment", "budget_form.aim.hint") %>
           </div>
           <.currency_input
-            form={fee_form}
+            form={reward_form}
             field={:subject_reward}
             label_text={dgettext("eyra-assignment", "budget_form.fee.label")}
-            value={cents_to_display(input_value(fee_form, :subject_reward))}
+            value={@reward_input}
             active_currency={@active_currency}
             currencies={[@active_currency]}
+            reserve_error_space={false}
             testid="budget-form-reward-input"
           />
-          <div class="-mt-3 mb-4 text-label font-label text-grey2">
+          <div class={[
+            "mb-4 text-label font-label text-grey2",
+            not Enum.empty?(reward_form[:subject_reward].errors) && "mt-2"
+          ]}>
             <%= dgettext("eyra-assignment", "budget_form.fee.hint") %>
           </div>
         </.form>

--- a/core/systems/assignment/budget_form.ex
+++ b/core/systems/assignment/budget_form.ex
@@ -69,45 +69,14 @@ defmodule Systems.Assignment.BudgetForm do
   def handle_event(
         "save_reward",
         %{"info_model" => %{"subject_reward" => raw_reward} = attrs},
-        %{assigns: %{assignment: assignment, info: info, subject_count: subject_count}} = socket
+        %{assigns: %{info: info}} = socket
       ) do
-    case CurrencyHelpers.display_to_cents(raw_reward) do
-      {:ok, cents} ->
-        attrs = Map.put(attrs, "subject_reward", cents)
-        changeset = Assignment.InfoModel.changeset(info, :auto_save, attrs)
-
-        case Core.Persister.save(changeset.data, changeset) do
-          {:ok, updated_info} ->
-            reward_cents = updated_info.subject_reward || 0
-
-            {
-              :noreply,
-              socket
-              |> assign(
-                assignment: %{assignment | info: updated_info},
-                info: updated_info,
-                reward_changeset: Assignment.InfoModel.changeset(updated_info, :create, %{}),
-                reward_cents: reward_cents,
-                reward_input: raw_reward
-              )
-              |> assign_totals(subject_count, reward_cents)
-            }
-
-          {:error, changeset} ->
-            {:noreply, assign(socket, reward_changeset: changeset, reward_input: raw_reward)}
-        end
-
-      :error ->
-        changeset =
-          info
-          |> Assignment.InfoModel.changeset(:create, %{})
-          |> Ecto.Changeset.add_error(
-            :subject_reward,
-            dgettext("eyra-assignment", "budget_form.fee.invalid")
-          )
-          |> Map.put(:action, :insert)
-
-        {:noreply, assign(socket, reward_changeset: changeset, reward_input: raw_reward)}
+    with {:ok, cents} <- CurrencyHelpers.display_to_cents(raw_reward),
+         {:ok, updated_info} <- persist_reward(info, attrs, cents) do
+      {:noreply, apply_saved_reward(socket, updated_info, raw_reward)}
+    else
+      {:error, changeset} -> {:noreply, apply_save_error(socket, changeset, raw_reward)}
+      :error -> {:noreply, apply_invalid_reward(socket, raw_reward)}
     end
   end
 
@@ -139,6 +108,47 @@ defmodule Systems.Assignment.BudgetForm do
   @impl true
   def handle_event("cancel", _, socket) do
     {:noreply, socket |> send_event(:parent, "budget_form_cancelled")}
+  end
+
+  defp persist_reward(info, attrs, cents) do
+    attrs = Map.put(attrs, "subject_reward", cents)
+    changeset = Assignment.InfoModel.changeset(info, :auto_save, attrs)
+    Core.Persister.save(changeset.data, changeset)
+  end
+
+  defp apply_saved_reward(
+         %{assigns: %{assignment: assignment, subject_count: subject_count}} = socket,
+         updated_info,
+         raw_reward
+       ) do
+    reward_cents = updated_info.subject_reward || 0
+
+    socket
+    |> assign(
+      assignment: %{assignment | info: updated_info},
+      info: updated_info,
+      reward_changeset: Assignment.InfoModel.changeset(updated_info, :create, %{}),
+      reward_cents: reward_cents,
+      reward_input: raw_reward
+    )
+    |> assign_totals(subject_count, reward_cents)
+  end
+
+  defp apply_save_error(socket, changeset, raw_reward) do
+    assign(socket, reward_changeset: changeset, reward_input: raw_reward)
+  end
+
+  defp apply_invalid_reward(%{assigns: %{info: info}} = socket, raw_reward) do
+    changeset =
+      info
+      |> Assignment.InfoModel.changeset(:create, %{})
+      |> Ecto.Changeset.add_error(
+        :subject_reward,
+        dgettext("eyra-assignment", "budget_form.fee.invalid")
+      )
+      |> Map.put(:action, :insert)
+
+    assign(socket, reward_changeset: changeset, reward_input: raw_reward)
   end
 
   defp assign_totals(socket, subject_count, reward_cents) do

--- a/core/systems/assignment/currency_helpers.ex
+++ b/core/systems/assignment/currency_helpers.ex
@@ -15,9 +15,12 @@ defmodule Systems.Assignment.CurrencyHelpers do
   def cents_to_display(0), do: ""
 
   def cents_to_display(cents) when is_integer(cents) do
-    cents
-    |> cents_to_decimal()
-    |> Decimal.to_string(:normal)
+    decimal = cents_to_decimal(cents)
+
+    case CoreWeb.Cldr.Number.to_string(decimal, locale: locale()) do
+      {:ok, formatted} -> formatted
+      _ -> Decimal.to_string(decimal, :normal)
+    end
   end
 
   def cents_to_display(value) when is_binary(value) do
@@ -27,16 +30,36 @@ defmodule Systems.Assignment.CurrencyHelpers do
     end
   end
 
-  def display_to_cents(value) when is_binary(value) do
-    case Decimal.parse(value) do
-      {decimal, _} ->
-        decimal
-        |> Decimal.mult(100)
-        |> Decimal.round(0)
-        |> Decimal.to_integer()
+  # Accepts a plain decimal amount with either `.`, `,`, or `٫` as decimal
+  # separator (auto-fix of the wrong locale separator). Rejects anything that
+  # looks like a thousands grouping — the field is never asked to include one.
+  @amount_regex ~r/^\d+([.,\x{066B}]\d+)?$/u
 
-      :error ->
-        0
+  def display_to_cents(""), do: {:ok, 0}
+
+  def display_to_cents(value) when is_binary(value) do
+    if Regex.match?(@amount_regex, value) do
+      value
+      |> String.replace(["٫", ","], ".")
+      |> parse_decimal_to_cents()
+    else
+      :error
+    end
+  end
+
+  defp parse_decimal_to_cents(string) do
+    case Decimal.parse(string) do
+      {decimal, ""} ->
+        cents =
+          decimal
+          |> Decimal.mult(100)
+          |> Decimal.round(0)
+          |> Decimal.to_integer()
+
+        {:ok, cents}
+
+      _ ->
+        :error
     end
   end
 

--- a/core/test/systems/assignment/budget_form_save_reward_test.exs
+++ b/core/test/systems/assignment/budget_form_save_reward_test.exs
@@ -1,0 +1,57 @@
+defmodule Systems.Assignment.BudgetFormSaveRewardTest do
+  @moduledoc """
+  White-box coverage of `BudgetForm`'s `save_reward` event handler.
+
+  Covers the error branch that Melle spotted: in the EN locale, typing
+  "1,000.50" (thousands-style grouping) previously got silently reinterpreted
+  by Cldr as `100050`. Now the parser rejects it and the handler must expose
+  a changeset error on `:subject_reward` while keeping the user's raw text
+  in the `reward_input` assign so the field doesn't clobber their input.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Systems.Assignment.BudgetForm
+  alias Systems.Assignment.InfoModel
+
+  defp build_socket do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        assignment: %{info: %InfoModel{}},
+        info: %InfoModel{},
+        subject_count: 0
+      }
+    }
+  end
+
+  defp save_reward(raw_reward) do
+    BudgetForm.handle_event(
+      "save_reward",
+      %{"info_model" => %{"subject_reward" => raw_reward}},
+      build_socket()
+    )
+  end
+
+  test "flags a thousands-style grouping with a changeset error" do
+    {:noreply, socket} = save_reward("1,000.50")
+
+    changeset = socket.assigns.reward_changeset
+    assert changeset.action == :insert
+    assert changeset.errors[:subject_reward]
+  end
+
+  test "keeps the user's raw input in reward_input on error" do
+    {:noreply, socket} = save_reward("1,000.50")
+
+    assert socket.assigns.reward_input == "1,000.50"
+  end
+
+  test "flags letters as an error" do
+    {:noreply, socket} = save_reward("abc")
+
+    changeset = socket.assigns.reward_changeset
+    assert changeset.action == :insert
+    assert changeset.errors[:subject_reward]
+  end
+end

--- a/core/test/systems/assignment/currency_helpers_test.exs
+++ b/core/test/systems/assignment/currency_helpers_test.exs
@@ -1,0 +1,83 @@
+defmodule Systems.Assignment.CurrencyHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias Systems.Assignment.CurrencyHelpers
+
+  describe "display_to_cents/1 — accepts either decimal separator" do
+    test "parses a comma as decimal separator" do
+      assert CurrencyHelpers.display_to_cents("1,50") == {:ok, 150}
+    end
+
+    test "parses a period as decimal separator" do
+      assert CurrencyHelpers.display_to_cents("1.50") == {:ok, 150}
+    end
+
+    test "parses the Arabic decimal separator (U+066B)" do
+      assert CurrencyHelpers.display_to_cents("1٫50") == {:ok, 150}
+    end
+
+    test "parses a whole-number value" do
+      assert CurrencyHelpers.display_to_cents("42") == {:ok, 4200}
+    end
+
+    test "rounds a value with three fractional digits" do
+      assert CurrencyHelpers.display_to_cents("1,345") == {:ok, 135}
+    end
+
+    test "treats an empty string as zero" do
+      assert CurrencyHelpers.display_to_cents("") == {:ok, 0}
+    end
+  end
+
+  describe "display_to_cents/1 — rejects invalid input" do
+    test "rejects letters" do
+      assert CurrencyHelpers.display_to_cents("not a number") == :error
+    end
+
+    test "rejects a value with multiple separators (thousands grouping)" do
+      assert CurrencyHelpers.display_to_cents("1,000.50") == :error
+    end
+
+    test "rejects a value with a trailing separator" do
+      assert CurrencyHelpers.display_to_cents("1,") == :error
+    end
+
+    test "rejects a value with a leading separator" do
+      assert CurrencyHelpers.display_to_cents(",50") == :error
+    end
+  end
+
+  describe "cents_to_display/1 in nl locale" do
+    setup do
+      Gettext.put_locale(CoreWeb.Gettext, "nl")
+      :ok
+    end
+
+    test "renders a fractional amount with a comma" do
+      assert CurrencyHelpers.cents_to_display(150) == "1,5"
+    end
+
+    test "renders a whole-euro amount without a decimal separator" do
+      assert CurrencyHelpers.cents_to_display(4200) == "42"
+    end
+
+    test "renders nil as an empty string" do
+      assert CurrencyHelpers.cents_to_display(nil) == ""
+    end
+
+    test "renders zero as an empty string" do
+      assert CurrencyHelpers.cents_to_display(0) == ""
+    end
+  end
+
+  describe "cents_to_display/1 in en locale" do
+    setup do
+      Gettext.put_locale(CoreWeb.Gettext, "en")
+      :ok
+    end
+
+    test "renders a fractional amount with a period" do
+      assert CurrencyHelpers.cents_to_display(150) == "1.5"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Participant fee input on the Add-participants modal was routed through Cldr, which in `en` interprets `,` as a thousands separator. Typing `1,34` silently became `134` cents → **€134 per participant (100× overcharge)**. Signed-in creators are pinned to `en` by `ResolveLocale`, so every creator setting a fee with a comma hit this.

### Parser (`CurrencyHelpers.display_to_cents`)
- Locale-agnostic on input: single `.`, `,`, or `٫` all treated as decimal separator. `1,34` and `1.34` both become 134 cents.
- Rejects thousands groupings (`1,000.50`) and malformed input — never silently reinterprets.
- Returns `{:ok, cents} | :error` so callers can act on invalid input.

### Budget form UX
- Preserves user's raw text on the input field on both success and error (no more rewrite of `1,34` to `0.34`).
- On `:error`, adds inline changeset error on `:subject_reward` with `budget_form.fee.invalid` (example amount `3,75` / `3.75`).
- Drops `reserve_error_space` on the fee field so the error takes real height and pushes the hint down instead of overlapping it. Small `mt-2` on the hint only when the field errors.
- Renames all participant-reward identifiers to `reward_*` (event `save_reward`, `reward_input`, `reward_changeset`, `reward_form`) to stop mixing `fee_*`/`reward_*` for one concept. Partner fee (platform commission) keeps `fee_*` — that's a distinct thing.
- EN subtotal copy: `%{reward} reward` → `%{reward} fee` (matches user-facing "Participant fee" label).

### Locale scope
Signed-in creators are pinned to English by `CoreWeb.Plug.ResolveLocale`, so the Add-participants modal always parses in `en`. The original NL comma-parsing scenario therefore doesn't actually hit under current creator sessions. The fix still ships as defence-in-depth: it stops Cldr's `en` thousands-separator parse from silently 100×'ing an amount, and future-proofs when locale rules change.

## Test plan
- [x] 15 `CurrencyHelpers` unit tests (both separators, Arabic `٫`, empty, rounding, thousands rejection)
- [x] 3 `BudgetForm.save_reward` unit tests (error changeset, raw input preservation, letters rejected)
- [x] Pre-commit hook: format / compile --force / test / credo / dialyzer pass
- [ ] Manual: open Add-participants modal, try `1,34` (should show `€1.34` in totals), `1,000.50` (inline error + hint pushed down), plain `5` (no error, `€5.00` in totals)

## Follow-up
- Hint as a first-class `Pixel.Form` field feature — https://3.basecamp.com/5734045/buckets/35926565/todos/10114778570 (spotted while wrestling with hint-vs-error layout in this fix; also raises the design question whether Add-participants needs hints at all)

Fixes: https://3.basecamp.com/5734045/buckets/35926565/todos/10075154668