### PR TITLE
refactor(assignment): move payout mutations off PayoutModal to auth-gated parent

### DIFF
--- a/core/systems/assignment/participants_view.ex
+++ b/core/systems/assignment/participants_view.ex
@@ -117,6 +117,61 @@ defmodule Systems.Assignment.ParticipantsView do
     }
   end
 
+  # Auth-gated mutation. Reaching this handler means the request went through
+  # a routed page whose live_view guarantees the researcher can only see their
+  # own assignment. PayoutModal has no such guarantee, so it bubbles the click
+  # to us via `send_event(:parent, "pay_out_all")` instead of running the
+  # mutation itself. Result flows back to the modal via `send_event(:payout_modal,
+  # "post_pay_out_all", …)`, which the modal handles to clear its decline UI
+  # / set the error banner and re-fetch its view model.
+  @impl true
+  def handle_event(
+        "pay_out_all",
+        _,
+        %{assigns: %{assignment: assignment}} = socket
+      ) do
+    result = Assignment.Public.bulk_approve_pending_payouts(assignment)
+
+    if match?({:error, _}, result) do
+      Logger.warning("[ParticipantsView] bulk approve failed: #{inspect(result)}")
+    end
+
+    {
+      :noreply,
+      socket
+      |> send_event(:payout_modal, "post_pay_out_all", %{result: result})
+      |> assign_pending_approvals()
+    }
+  end
+
+  # Auth-gated mutation. task_id + reason come up in the payload from
+  # PayoutModal's shim `send_event(:parent, "submit_decline", %{...})`; the
+  # modal's expand_decline / update_reason UI state is what supplied them.
+  @impl true
+  def handle_event(
+        "submit_decline",
+        %{task_id: task_id, reason: reason},
+        %{assigns: %{assignment: assignment}} = socket
+      )
+      when is_integer(task_id) do
+    result =
+      Assignment.Public.reject_task_by_id(assignment, task_id, %{
+        category: :other,
+        message: reason
+      })
+
+    if match?({:error, _}, result) do
+      Logger.warning("[ParticipantsView] reject_task #{task_id} failed: #{inspect(result)}")
+    end
+
+    {
+      :noreply,
+      socket
+      |> send_event(:payout_modal, "post_submit_decline", %{result: result})
+      |> assign_pending_approvals()
+    }
+  end
+
   defp assign_pending_approvals(%{assigns: %{assignment: assignment}} = socket) do
     assign(socket, pending_approvals: Assignment.Public.list_pending_payouts(assignment))
   end

--- a/core/systems/assignment/payout_modal.ex
+++ b/core/systems/assignment/payout_modal.ex
@@ -5,7 +5,20 @@ defmodule Systems.Assignment.PayoutModal do
 
   All data access, transformation and i18n live in
   `Systems.Assignment.PayoutModalBuilder`; this component only renders the
-  view model and handles events (delegating mutations to `Assignment.Public`).
+  view model and owns local UI state (active tab, decline expansion,
+  search query, error banner).
+
+  Mutations (`pay_out_all`, `submit_decline`) do NOT run here — the button
+  click and form submit fire the local shim clauses, which only bubble
+  the event to the parent via `send_event(:parent, ...)`. The auth-gated
+  parent (`Systems.Assignment.ParticipantsView`) owns the actual mutation.
+  Composing this modal under any other parent gives the parent the choice
+  whether to implement those events — with no such handler, no mutation.
+
+  The parent signals the outcome back via `send_event(socket, :payout_modal,
+  ...)`, which this component receives as `"post_pay_out_all"` /
+  `"post_submit_decline"` events and uses to update the local error banner
+  and refresh the view model.
 
   Two tabs: `:waiting` (default) lists rewards in `:pending_approval` with
   per-row Decline expansion + bulk "Pay out all"; `:overview` shows historical
@@ -20,7 +33,6 @@ defmodule Systems.Assignment.PayoutModal do
   alias Frameworks.Pixel.SearchBar
   alias Frameworks.Pixel.Text
 
-  alias Systems.Assignment
   alias Systems.Assignment.CurrencyHelpers
   alias Systems.Assignment.PayoutModalBuilder, as: Builder
 
@@ -66,24 +78,6 @@ defmodule Systems.Assignment.PayoutModal do
   end
 
   @impl true
-  def handle_event("pay_out_all", _, %{assigns: %{vm: %{assignment: assignment}}} = socket) do
-    error =
-      case Assignment.Public.bulk_approve_pending_payouts(assignment) do
-        {:ok, _count} ->
-          nil
-
-        {:error, reason} ->
-          Logger.warning("[PayoutModal] bulk approve failed: #{inspect(reason)}")
-          :pay_out_all
-      end
-
-    {:noreply,
-     socket
-     |> assign(declining_task_id: nil, decline_reason: "", error: error)
-     |> assign_vm()}
-  end
-
-  @impl true
   def handle_event("expand_decline", %{"task-id" => task_id}, socket) do
     {:noreply,
      socket
@@ -102,35 +96,65 @@ defmodule Systems.Assignment.PayoutModal do
     {:noreply, assign(socket, decline_reason: reason)}
   end
 
+  # Shim: mutation is not performed here. The auth-gated parent
+  # (ParticipantsView) owns the actual bulk-approve handler. This clause
+  # just bubbles the event up so the parent can decide (auth by
+  # construction — an unauthenticated parent that hasn't wired the handler
+  # simply does nothing).
+  @impl true
+  def handle_event("pay_out_all", _, socket) do
+    {:noreply, send_event(socket, :parent, "pay_out_all")}
+  end
+
+  # Shim: same rationale as pay_out_all. Task id + reason come from local
+  # UI state (updated by expand_decline / update_reason) and are passed up
+  # to the parent, which is the only place the reject actually runs.
   @impl true
   def handle_event(
         "submit_decline",
         _,
-        %{
-          assigns: %{
-            vm: %{assignment: assignment},
-            declining_task_id: task_id,
-            decline_reason: reason
-          }
-        } = socket
+        %{assigns: %{declining_task_id: task_id, decline_reason: reason}} = socket
       )
       when is_integer(task_id) do
-    {declining_task_id, error} =
-      case Assignment.Public.reject_task_by_id(assignment, task_id, %{
-             category: :other,
-             message: reason
-           }) do
-        {:ok, _} ->
-          {nil, nil}
+    {:noreply, send_event(socket, :parent, "submit_decline", %{task_id: task_id, reason: reason})}
+  end
 
-        error ->
-          Logger.warning("[PayoutModal] reject_task #{task_id} failed: #{inspect(error)}")
-          {task_id, :decline}
-      end
-
+  # Result signal from the auth-gated parent after a bulk approve. Success
+  # clears the decline UI and the error banner; failure keeps the modal state
+  # and surfaces the error. Either way the view model re-fetches to reflect
+  # whatever the mutation did (or didn't) change.
+  @impl true
+  def handle_event("post_pay_out_all", %{result: {:ok, _count}}, socket) do
     {:noreply,
      socket
-     |> assign(declining_task_id: declining_task_id, decline_reason: "", error: error)
+     |> assign(declining_task_id: nil, decline_reason: "", error: nil)
+     |> assign_vm()}
+  end
+
+  @impl true
+  def handle_event("post_pay_out_all", %{result: {:error, _reason}}, socket) do
+    {:noreply,
+     socket
+     |> assign(declining_task_id: nil, decline_reason: "", error: :pay_out_all)
+     |> assign_vm()}
+  end
+
+  # Result signal for a per-row decline. On success clear the decline UI; on
+  # failure keep the decline expanded so the user can retry after seeing the
+  # error banner.
+  @impl true
+  def handle_event("post_submit_decline", %{result: {:ok, _}}, socket) do
+    {:noreply,
+     socket
+     |> assign(declining_task_id: nil, decline_reason: "", error: nil)
+     |> assign_vm()}
+  end
+
+  @impl true
+  def handle_event("post_submit_decline", %{result: {:error, _reason}}, socket) do
+    {:noreply,
+     socket
+     |> assign(decline_reason: "", error: :decline)
      |> assign_vm()}
   end
 

--- a/core/test/systems/assignment/payout_mutations_ownership_test.exs
+++ b/core/test/systems/assignment/payout_mutations_ownership_test.exs
@@ -1,0 +1,156 @@
+defmodule Systems.Assignment.PayoutMutationsOwnershipTest do
+  @moduledoc """
+  Regression: FX#9919395084.
+
+  Payout-related mutations (bulk approve, decline) must live on the
+  auth-gated parent `ParticipantsView`, not on the child `PayoutModal`.
+  Today the modal is only composed from ParticipantsView so mutations are
+  gated in practice, but by construction the modal owns no auth check —
+  composing it elsewhere would expose the mutations.
+
+  These tests pin the handler location:
+  - the parent's handlers actually mutate,
+  - the child's don't (it may still render buttons, but a direct
+    handle_event/3 invocation on the modal must not perform the mutation).
+  """
+  use Core.DataCase, async: false
+
+  alias Core.Factories
+  alias Systems.Assignment
+  alias Systems.Assignment.ParticipantsView
+  alias Systems.Assignment.PayoutModal
+  alias Systems.Crew
+  alias Systems.Fund
+
+  defp setup_pending_approval do
+    assignment = Assignment.Factories.create_questionnaire_assignment()
+
+    currency = Fund.Factories.create_currency("eur_p4", :legal, "€", 2)
+    fund = Fund.Factories.create_fund("fund_p4_#{assignment.id}", currency)
+
+    {:ok, _} =
+      assignment
+      |> Assignment.Model.changeset(fund)
+      |> Core.Repo.update()
+
+    assignment = Core.Repo.preload(assignment, [:crew, :workflow], force: true)
+
+    participant = Factories.insert!(:member, %{creator: false})
+
+    [workflow_item | _] =
+      assignment.workflow |> Core.Repo.preload(:items) |> Map.fetch!(:items)
+
+    member = Crew.Factories.create_member(assignment.crew, participant)
+    identifier = ["item=#{workflow_item.id}", "member=#{member.id}"]
+    task = Crew.Factories.create_task(assignment.crew, member, identifier, status: :completed)
+
+    # Create the reward through Fund.Public so the accompanying deposit exists
+    # — reject_task rolls back the deposit as part of an atomic multi, so
+    # without one the whole reject fails and the task stays :completed.
+    idempotence_key = "assignment=#{assignment.id},user=#{participant.id}"
+
+    {:ok, %{reward: reward}} =
+      Fund.Public.create_reward(
+        Core.Repo.preload(fund, [:available, :pending, :currency]),
+        1000,
+        participant,
+        idempotence_key
+      )
+
+    reward =
+      reward
+      |> Ecto.Changeset.change(%{status: :pending_approval})
+      |> Core.Repo.update!()
+
+    assignment =
+      Assignment.Public.get!(assignment.id, Assignment.Model.preload_graph(:down))
+
+    %{assignment: assignment, task: task, reward: reward}
+  end
+
+  defp parent_socket(assignment) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        assignment: assignment,
+        fabric: Fabric.Factories.create_fabric()
+      }
+    }
+  end
+
+  # Modal shim's `send_event(:parent, ...)` walks fabric.parent; supply a
+  # valid ref (test process) so the shim doesn't raise before we can assert
+  # its no-mutation behavior.
+  defp modal_fabric do
+    parent_ref = %Fabric.LiveView.RefModel{pid: self()}
+    self_ref = %Fabric.LiveView.RefModel{pid: self()}
+    %Fabric.Model{parent: parent_ref, self: self_ref, children: nil}
+  end
+
+  defp modal_socket(assignment) do
+    %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        assignment_id: assignment.id,
+        vm: %{assignment: assignment},
+        active_tab: :waiting,
+        declining_task_id: nil,
+        decline_reason: "",
+        search_query: "",
+        error: nil,
+        fabric: modal_fabric()
+      }
+    }
+  end
+
+  describe "ParticipantsView owns the mutations" do
+    test "pay_out_all approves the pending reward" do
+      %{assignment: assignment, reward: reward} = setup_pending_approval()
+
+      {:noreply, _socket} =
+        ParticipantsView.handle_event("pay_out_all", %{}, parent_socket(assignment))
+
+      assert Core.Repo.reload(reward).status == :approved
+    end
+
+    test "submit_decline rejects the identified task" do
+      %{assignment: assignment, task: task} = setup_pending_approval()
+
+      {:noreply, _socket} =
+        ParticipantsView.handle_event(
+          "submit_decline",
+          %{task_id: task.id, reason: "n/a"},
+          parent_socket(assignment)
+        )
+
+      assert %{status: :rejected} = Crew.Public.get_task!(task.id)
+    end
+  end
+
+  describe "PayoutModal does not own the mutations" do
+    test "handle_event(\"pay_out_all\", ...) does not mutate" do
+      %{assignment: assignment, reward: reward} = setup_pending_approval()
+
+      {:noreply, _socket} =
+        PayoutModal.handle_event("pay_out_all", %{}, modal_socket(assignment))
+
+      assert Core.Repo.reload(reward).status == :pending_approval
+    end
+
+    test "handle_event(\"submit_decline\", ...) does not mutate" do
+      %{assignment: assignment, task: task} = setup_pending_approval()
+
+      socket = %{
+        modal_socket(assignment)
+        | assigns:
+            modal_socket(assignment).assigns
+            |> Map.put(:declining_task_id, task.id)
+            |> Map.put(:decline_reason, "n/a")
+      }
+
+      {:noreply, _socket} = PayoutModal.handle_event("submit_decline", %{}, socket)
+
+      assert %{status: :completed} = Crew.Public.get_task!(task.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- PayoutModal used to run \`bulk_approve_pending_payouts\` and \`reject_task_by_id\` directly. Today it's only composed from ParticipantsView (auth-gated), so no exploit — but by construction the modal owns no auth check.
- Fix: PayoutModal keeps a thin shim for each mutation event that only bubbles to \`:parent\` via \`send_event\`. The mutation lives on ParticipantsView, where routing already guarantees the researcher only reaches their own assignment.
- The parent signals the outcome back via \`send_event(:payout_modal, "post_pay_out_all"|"post_submit_decline", …)\`; the modal handles those to clear its decline UI / set the error banner and re-fetch its view model.
- Composing PayoutModal under any other parent gives that parent the choice whether to wire the mutation events — with no such handler, no mutation runs.

FX#9919395084 — https://3.basecamp.com/5734045/buckets/35926565/todos/9919395084

## Test plan
- [x] New unit tests in \`payout_mutations_ownership_test.exs\`:
  - \`ParticipantsView.handle_event("pay_out_all", …)\` moves rewards from \`:pending_approval\` → \`:approved\` (fails on develop — no such handler).
  - \`ParticipantsView.handle_event("submit_decline", …)\` moves task \`:completed\` → \`:rejected\` (fails on develop — no such handler).
  - \`PayoutModal.handle_event("pay_out_all", …)\` does NOT mutate (fails on develop — the modal used to mutate).
  - \`PayoutModal.handle_event("submit_decline", …)\` does NOT mutate (same).
- [x] All existing assignment tests pass (\`mix test test/systems/assignment\`).
- [ ] Manual on eyra-next-dev: PayoutModal "Pay out all" and per-row Decline still work end-to-end from ParticipantsView.

## Non-goals
- Doesn't refactor ParticipantsView into an embedded LiveView — separate scope. The mutation-location fix is orthogonal to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)