### PR TITLE
fix(pool): make marketplace mobile-friendly + fix breadcrumb + always show 'See all'

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
@@ -44,10 +44,6 @@ msgid "landing.description.visitor"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr ""
 
@@ -61,10 +57,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -134,3 +126,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
 msgstr "Pool beitreten"
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
+msgstr "Alle anzeigen"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-pool.po
@@ -43,10 +43,6 @@ msgid "landing.description.visitor"
 msgstr "🚫 You are not a member of this pool."
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr "Overview"
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr "The marketplace is currently empty."
 
@@ -61,10 +57,6 @@ msgstr "Filter:"
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
 msgstr "Search"
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
-msgstr "Show more"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
@@ -133,3 +125,7 @@ msgstr "You already joined %{pool_name}"
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
 msgstr "Join pool"
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
+msgstr "See all"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
@@ -44,10 +44,6 @@ msgid "landing.description.visitor"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr ""
 
@@ -61,10 +57,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -134,3 +126,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
 msgstr "Unirse al pool"
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
+msgstr "Ver todo"

--- a/core/priv/gettext/eyra-pool.pot
+++ b/core/priv/gettext/eyra-pool.pot
@@ -43,10 +43,6 @@ msgid "landing.description.visitor"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr ""
 
@@ -60,10 +56,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -132,4 +124,8 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
 msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
@@ -44,10 +44,6 @@ msgid "landing.description.visitor"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr ""
 
@@ -61,10 +57,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -134,3 +126,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
 msgstr "Unisciti al pool"
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
+msgstr "Vedi tutto"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
@@ -44,10 +44,6 @@ msgid "landing.description.visitor"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr ""
 
@@ -61,10 +57,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -134,3 +126,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
 msgstr "Prisijunk prie fondo"
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
+msgstr "Rodyti visus"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-pool.po
@@ -43,10 +43,6 @@ msgid "landing.description.visitor"
 msgstr "Je bent nog geen lid van deze pool."
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr "Overzicht"
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr "De marktplaats is momenteel leeg."
 
@@ -61,10 +57,6 @@ msgstr "Filter:"
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
 msgstr "Zoeken"
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
-msgstr "Toon meer"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
@@ -133,3 +125,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
 msgstr "Word lid van pool"
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
+msgstr "Bekijk alles"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
@@ -44,10 +44,6 @@ msgid "landing.description.visitor"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "marketplace.breadcrumb.overview"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
 msgstr ""
 
@@ -61,10 +57,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "marketplace.show_more"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -134,3 +126,7 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "onboarding.hero.title"
 msgstr "Alătură-te grupului"
+
+#, elixir-autogen, elixir-format
+msgid "marketplace.see_all"
+msgstr "Vezi toate"

--- a/core/systems/home/adverts_view.ex
+++ b/core/systems/home/adverts_view.ex
@@ -68,12 +68,12 @@ defmodule Systems.Home.AdvertsView do
           <Advert.CardView.dynamic card={card} target={@myself}/>
         <% end %>
       </Grid.dynamic>
-      <%= if @more_path && @count > Enum.count(@cards) do %>
+      <%= if @more_path && @count > 0 do %>
         <.spacing value="M" />
         <div class="flex flex-row justify-end">
           <.link navigate={@more_path}>
             <div class="flex flex-row items-center gap-2 text-button font-button text-primary">
-              <%= dgettext("eyra-pool", "marketplace.show_more") %>
+              <%= dgettext("eyra-pool", "marketplace.see_all") %>
               <img src={~p"/images/icons/forward.svg"} alt="" />
             </div>
           </.link>

--- a/core/systems/pool/marketplace_page.ex
+++ b/core/systems/pool/marketplace_page.ex
@@ -43,7 +43,7 @@ defmodule Systems.Pool.MarketplacePage do
       <:hero>
         <Hero.dynamic {@vm.hero} />
       </:hero>
-      <div class="bg-grey6 min-h-full">
+      <div class="min-h-full">
         <div class="py-4 border-b border-grey4">
           <Area.content>
             <.live_component module={Breadcrumbs} id={:marketplace_breadcrumbs} elements={@vm.breadcrumbs} />

--- a/core/systems/pool/marketplace_page_builder.ex
+++ b/core/systems/pool/marketplace_page_builder.ex
@@ -19,7 +19,7 @@ defmodule Systems.Pool.MarketplacePageBuilder do
         }
       },
       breadcrumbs: [
-        %{label: dgettext("eyra-pool", "marketplace.breadcrumb.overview"), path: ~p"/"},
+        %{label: dgettext("eyra-home", "member.title"), path: ~p"/"},
         %{
           label: dgettext("eyra-pool", "marketplace.title"),
           path: ~p"/pool/#{pool.id}/marketplace"

--- a/core/systems/pool/marketplace_view.ex
+++ b/core/systems/pool/marketplace_view.ex
@@ -93,11 +93,13 @@ defmodule Systems.Pool.MarketplaceView do
       <%= if Enum.empty?(@items) do %>
         <Text.body><%= dgettext("eyra-pool", "marketplace.empty.message") %></Text.body>
       <% else %>
-        <div class="flex flex-row items-center gap-3">
-          <div class="font-label text-label"><%= dgettext("eyra-pool", "marketplace.filter.label") %></div>
-          <.child name={:marketplace_year_selector} fabric={@fabric} />
-          <div class="flex-grow" />
-          <div class="flex-shrink-0">
+        <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+          <div class="flex flex-row flex-wrap items-center gap-3">
+            <div class="font-label text-label"><%= dgettext("eyra-pool", "marketplace.filter.label") %></div>
+            <.child name={:marketplace_year_selector} fabric={@fabric} />
+          </div>
+          <div class="hidden sm:block sm:flex-grow" />
+          <div class="w-full sm:w-auto sm:flex-shrink-0">
             <.child name={:marketplace_search_bar} fabric={@fabric} />
           </div>
         </div>

--- a/core/test/systems/pool/marketplace_page_builder_test.exs
+++ b/core/test/systems/pool/marketplace_page_builder_test.exs
@@ -43,13 +43,13 @@ defmodule Systems.Pool.MarketplacePageBuilderTest do
     do: %{current_user: user, uri_path: "/pool/#{pool.id}/marketplace"}
 
   describe "view_model/2" do
-    test "returns Overview > Marketplace breadcrumbs" do
+    test "returns Activities > Marketplace breadcrumbs" do
       pool = test_pool()
       user = pool_member(pool)
       vm = Pool.MarketplacePageBuilder.view_model(pool, build_assigns(user, pool))
 
       assert [
-               %{label: "Overview", path: "/"},
+               %{label: "Activities", path: "/"},
                %{label: "Marketplace", path: path}
              ] = vm.breadcrumbs
 


### PR DESCRIPTION
## Summary
Participant-facing tweaks to the marketplace surface (\`/pool/:id/marketplace\` + the home marketplace card):

- **Filter row** stacked its search bar with \`flex-shrink-0\`, forcing horizontal overflow on phones. Now stacks vertically on mobile (search bar takes the full row) and stays a single row on \`sm+\`.
- **Body background** dropped from \`bg-grey6\` back to the default — matches the rest of the app.
- **Breadcrumb** read "Overzicht > Marketplace" while the home hero it links to is titled "Activiteiten". Reuse \`eyra-home:member.title\` so the label stays in sync.
- **"See all" link on the home marketplace card** was hidden whenever adverts fit the home card limit (≤ 3), leaving no obvious way to reach the full marketplace with a small pool. Now shown any time there is ≥ 1 advert. Key renamed \`marketplace.show_more\` → \`marketplace.see_all\` and reworded to "See all" (translated to all 7 languages).

FX#9932545801 — https://3.basecamp.com/5734045/buckets/35926565/todos/9932545801

## Test plan
- [x] \`mix test.ci\` passes locally.
- [x] Manual on local dev at \`http://localhost:4000/pool/5/marketplace\` — mobile viewport no longer overflows; background is white; breadcrumb reads "Activiteiten > Marketplace".
- [x] Home marketplace card shows "Bekijk alles" for any advert count.
- [ ] Iris to reproduce the original UC-OPP-03 mobile test on eyra-next-dev after auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)