### PR TITLE
refactor(assignment): drop hint labels + normalize field spacing in budget form

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -586,14 +586,6 @@ msgid "budget_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
-msgstr "Bitte einen Betrag eingeben, z. B. 3,75"
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 
@@ -639,10 +631,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.aim.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -752,3 +740,11 @@ msgstr "Diese Studie ist leider voll und nimmt keine neuen Teilnehmer mehr auf."
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
 msgstr "Diese Studie ist voll"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Bitte einen Betrag eingeben, z. B. 3,75"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
+msgstr "Eine kurze Beschreibung deiner Studie"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -585,14 +585,6 @@ msgid "budget_form.description"
 msgstr "Proceed to pay the fee and recruit Panl participants."
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr "Please note that the minimum fee is €8,00 per hour"
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
-msgstr "Please enter a plain amount, like 3.75"
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr "Participant fee"
 
@@ -639,10 +631,6 @@ msgstr "Proceed with payment"
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
 msgstr "No transactions yet."
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.aim.hint"
-msgstr "A short description of your study"
 
 #, elixir-autogen, elixir-format
 msgid "recruit.panel.annotation"
@@ -751,3 +739,11 @@ msgstr "Unfortunately, this study is full and is no longer accepting new partici
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
 msgstr "This study is full"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Please enter a plain amount, like 3.75"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
+msgstr "A short description of your study"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -586,14 +586,6 @@ msgid "budget_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
-msgstr "Introduce un importe, p. ej., 3,75"
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 
@@ -639,10 +631,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.aim.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -752,3 +740,11 @@ msgstr "Lamentablemente, este estudio está completo y ya no acepta nuevos parti
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
 msgstr "Este estudio está completo"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Introduce un importe, p. ej., 3,75"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
+msgstr "Una breve descripción de tu estudio"

--- a/core/priv/gettext/eyra-assignment.pot
+++ b/core/priv/gettext/eyra-assignment.pot
@@ -585,10 +585,6 @@ msgid "budget_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr ""
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 
@@ -634,10 +630,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.aim.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -746,4 +738,12 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
 msgstr ""

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -586,14 +586,6 @@ msgid "budget_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
-msgstr "Inserisci un importo, es. 3,75"
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 
@@ -639,10 +631,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.aim.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -752,3 +740,11 @@ msgstr "Purtroppo questo studio è al completo e non accetta più nuovi partecip
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
 msgstr "Questo studio è al completo"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Inserisci un importo, es. 3,75"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
+msgstr "Una breve descrizione del tuo studio"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -596,14 +596,6 @@ msgid "budget_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
-msgstr "Įveskite sumą, pvz., 3,75"
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 
@@ -649,10 +641,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.aim.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -762,3 +750,11 @@ msgstr "Deja, šis tyrimas yra pilnas ir nebepriima naujų dalyvių."
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
 msgstr "Šis tyrimas yra pilnas"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Įveskite sumą, pvz., 3,75"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
+msgstr "Trumpas jūsų tyrimo aprašymas"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -585,14 +585,6 @@ msgid "budget_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
-msgstr "Voer een bedrag in, bijv. 3,75"
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 
@@ -638,10 +630,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.aim.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -751,3 +739,11 @@ msgstr "Helaas zit deze studie vol en worden er geen nieuwe deelnemers meer aang
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
 msgstr "Deze studie zit vol"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Voer een bedrag in, bijv. 3,75"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
+msgstr "Een korte omschrijving van je studie"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -596,14 +596,6 @@ msgid "budget_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.hint"
-msgstr ""
-
-#, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
-msgstr "Introdu o sumă, de ex. 3,75"
-
-#, elixir-autogen, elixir-format
 msgid "budget_form.fee.label"
 msgstr ""
 
@@ -649,10 +641,6 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "payment.transactions.empty"
-msgstr ""
-
-#, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.aim.hint"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -762,3 +750,11 @@ msgstr "Din păcate, acest studiu este complet și nu mai acceptă participanți
 #, elixir-autogen, elixir-format
 msgid "assignment_full.title"
 msgstr "Acest studiu este complet"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.fee.invalid"
+msgstr "Introdu o sumă, de ex. 3,75"
+
+#, elixir-autogen, elixir-format
+msgid "budget_form.aim.placeholder"
+msgstr "O scurtă descriere a studiului tău"

--- a/core/systems/assignment/budget_form.ex
+++ b/core/systems/assignment/budget_form.ex
@@ -206,12 +206,12 @@ defmodule Systems.Assignment.BudgetForm do
             form={reward_form}
             field={:aim_of_study}
             label_text={dgettext("eyra-assignment", "budget_form.aim.label")}
+            placeholder={dgettext("eyra-assignment", "budget_form.aim.placeholder")}
             maxlength="250"
+            reserve_error_space={false}
             testid="budget-form-aim-input"
           />
-          <div class="-mt-3 mb-4 text-label font-label text-grey2">
-            <%= dgettext("eyra-assignment", "budget_form.aim.hint") %>
-          </div>
+          <.spacing value="S" />
           <.currency_input
             form={reward_form}
             field={:subject_reward}
@@ -222,13 +222,8 @@ defmodule Systems.Assignment.BudgetForm do
             reserve_error_space={false}
             testid="budget-form-reward-input"
           />
-          <div class={[
-            "mb-4 text-label font-label text-grey2",
-            not Enum.empty?(reward_form[:subject_reward].errors) && "mt-2"
-          ]}>
-            <%= dgettext("eyra-assignment", "budget_form.fee.hint") %>
-          </div>
         </.form>
+        <.spacing value="S" />
       <% end %>
 
       <.form id={"#{@id}_slots"} :let={form} for={@slots_changeset} as={:slots} phx-change="update_slots" phx-target={@myself}>
@@ -237,6 +232,7 @@ defmodule Systems.Assignment.BudgetForm do
           field={:subject_count}
           label_text={dgettext("eyra-assignment", "budget_form.slots.label")}
           debounce="300"
+          reserve_error_space={false}
           testid="budget-form-slots-input"
         />
       </.form>


### PR DESCRIPTION
## Summary
Design decision for the "Add participants" modal (originally issued as FX#10114778570 to promote hint to a Pixel.Form attr — no longer needed since we're removing all hints):

- Drop the "Please note that the minimum fee is €8,00 per hour" hint below the Participant fee field.
- Drop the "A short description of your study" hint below the Aim of study field. Its copy moves into the input as a native HTML placeholder.
- Normalize vertical rhythm: every field sets \`reserve_error_space={false}\` and the spacing between fields is provided explicitly with \`<.spacing value="S" />\`. Previously inputs alternated between reserving and not reserving their error-message row, and the hint divs papered over the resulting gaps — so a fee-side error would squash into the "Number of participants" label directly below it.

Placeholder translated across all 7 locales.

FX#10114778570 — https://3.basecamp.com/5734045/buckets/35926565/todos/10114778570

## Test plan
- [x] \`mix test.ci\` passes locally.
- [x] Manual: enter \`qwerty\` in the fee field to trigger the error — Number of participants label no longer collapses into it, spacing stays consistent.
- [x] Manual: aim field shows the placeholder text when empty.
- [ ] Iris to eyeball the modal on eyra-next-dev after auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)