### PR TITLE
refactor(assignment): sync Add participants modal with Figma design

### DIFF
--- a/core/frameworks/pixel/components/modal_view.ex
+++ b/core/frameworks/pixel/components/modal_view.ex
@@ -427,10 +427,10 @@ defmodule Frameworks.Pixel.ModalView do
 
   def compact(assigns) do
     ~H"""
-      <div class="modal-dialog w-[700px] px-4 sm:px-10">
-        <div class="relative w-full max-h-[90vh] bg-white pt-6 pb-9 px-9 rounded shadow-floating flex flex-col">
+      <div class="modal-dialog w-[720px] px-4 sm:px-10">
+        <div class="relative w-full max-h-[90vh] bg-white p-6 rounded shadow-floating flex flex-col">
           <%!-- Floating close button --%>
-          <div class="absolute z-30 top-6 right-9">
+          <div class="absolute z-30 top-6 right-6">
             <Button.dynamic {close_icon_button(@modal)} />
           </div>
           <%!-- BODY --%>

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -641,13 +641,13 @@ msgstr ""
 msgid "recruit.panel.title"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.partner_fee.label"
-msgstr ""
+msgstr "Servicegebühr (%{percentage}%)"
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr ""
+msgstr "%{count} x Teilnehmergebühr von %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "budget_form.total.label"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -642,11 +642,11 @@ msgstr "Recruit participants"
 
 #, elixir-autogen, elixir-format
 msgid "budget_form.partner_fee.label"
-msgstr "Service fee"
+msgstr "Service fee (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr "Subtotal (%{count} × %{reward} fee)"
+msgstr "%{count} x participant fee of %{reward}"
 
 #, elixir-autogen, elixir-format
 msgid "budget_form.total.label"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -641,13 +641,13 @@ msgstr ""
 msgid "recruit.panel.title"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.partner_fee.label"
-msgstr ""
+msgstr "Tarifa de servicio (%{percentage}%)"
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr ""
+msgstr "%{count} x tarifa por participante de %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "budget_form.total.label"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -641,13 +641,13 @@ msgstr ""
 msgid "recruit.panel.title"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.partner_fee.label"
-msgstr ""
+msgstr "Costo di servizio (%{percentage}%)"
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr ""
+msgstr "%{count} x tariffa per partecipante di %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "budget_form.total.label"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -651,13 +651,13 @@ msgstr ""
 msgid "recruit.panel.title"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.partner_fee.label"
-msgstr ""
+msgstr "Aptarnavimo mokestis (%{percentage}%)"
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr ""
+msgstr "%{count} x dalyvio mokestis po %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "budget_form.total.label"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -640,13 +640,13 @@ msgstr ""
 msgid "recruit.panel.title"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.partner_fee.label"
-msgstr ""
+msgstr "Servicekosten (%{percentage}%)"
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr ""
+msgstr "%{count} x participant fee van %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "budget_form.total.label"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -651,13 +651,13 @@ msgstr ""
 msgid "recruit.panel.title"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.partner_fee.label"
-msgstr ""
+msgstr "Taxă de serviciu (%{percentage}%)"
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "budget_form.subtotal.label"
-msgstr ""
+msgstr "%{count} x taxă per participant de %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "budget_form.total.label"

--- a/core/systems/assignment/budget_form.ex
+++ b/core/systems/assignment/budget_form.ex
@@ -192,13 +192,13 @@ defmodule Systems.Assignment.BudgetForm do
 
     ~H"""
     <div>
-      <Text.title2>
+      <Text.title3>
         <%= dgettext("eyra-assignment", "budget_form.title") %>
-      </Text.title2>
+      </Text.title3>
       <Text.body>
         <%= dgettext("eyra-assignment", "budget_form.description") %>
       </Text.body>
-      <.spacing value="L" />
+      <.spacing value="M" />
 
       <%= if not @reward_locked? do %>
         <.form id={"#{@id}_reward"} :let={reward_form} for={@reward_changeset} phx-change="save_reward" phx-target={@myself}>
@@ -245,7 +245,7 @@ defmodule Systems.Assignment.BudgetForm do
         </div>
       </div>
       <div class="flex flex-col gap-1">
-        <div class="flex flex-row justify-between text-bodymedium font-body text-grey2">
+        <div class="flex flex-row justify-between text-bodymedium font-body text-grey1">
           <div>
             <%= dgettext("eyra-assignment", "budget_form.subtotal.label",
               count: display_count(@subject_count),
@@ -254,16 +254,16 @@ defmodule Systems.Assignment.BudgetForm do
           </div>
           <div><%= format_cents(@base_cents) %></div>
         </div>
-        <%= if @fee_cents > 0 do %>
-          <div class="flex flex-row justify-between text-bodymedium font-body text-grey2">
-            <div>
-              <%= dgettext("eyra-assignment", "budget_form.partner_fee.label") %>
-            </div>
-            <div><%= format_cents(@fee_cents) %></div>
+        <div class="flex flex-row justify-between text-bodymedium font-body text-grey1">
+          <div>
+            <%= dgettext("eyra-assignment", "budget_form.partner_fee.label",
+              percentage: @partner_fee_percentage
+            ) %>
           </div>
-        <% end %>
+          <div><%= format_cents(@fee_cents) %></div>
+        </div>
         <div class="border-t border-grey4 my-2"></div>
-        <div class="flex flex-row justify-between text-bodylarge font-body text-grey1 font-bold">
+        <div class="flex flex-row justify-between text-title6 font-title6 text-grey1">
           <div><%= dgettext("eyra-assignment", "budget_form.total.label") %></div>
           <div><%= format_cents(@total_cents) %></div>
         </div>


### PR DESCRIPTION
## Summary
Two adjustments from Neo's Figma approval on the Add participants modal:

**Cost breakdown**
- Service fee row now always renders (previously hidden when 0 cents) and its label includes the configured percentage — e.g. \"Service fee (20%)\". Percentage comes from \`Systems.Payment.Public.partner_fee_percentage/0\`, defaulting to 0.
- Subtotal row copy simplified to \"%{count} x participant fee of %{reward}\".
- Both rows are \`text-grey1\` / \`bodymedium\`; total row promoted to \`title6\` to align with the Costs section header.

**Modal chrome**
- Title dropped from \`title2\` to \`title3\`.
- Description-to-form spacing tightened from \`L\` to \`M\`.
- Compact modal padding normalized to a uniform \`p-6\` (was \`pt-6 pb-9 px-9\`) with the close button re-anchored \`right-6\` to match Neo's 24px border padding.

Percentage placeholder + subtotal copy translated across all 7 locales.

FX#10119525734 — https://3.basecamp.com/5734045/buckets/35926565/todos/10119525734

## Test plan
- [x] \`mix test.ci\` passes locally.
- [x] Manual: opened Add participants modal on local dev — layout matches the approved Figma (see thread on FX#10119525734).
- [x] With \`OPP_PARTNER_FEE_PERCENTAGE=20\` in dev, service fee row shows \"Service fee (20%)\" and non-zero cents. Without the env var it shows \"Service fee (0%)\" with €0.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)