### PR TITLE
refactor: normalize provider statuses and events at the payment boundary

### DIFF
--- a/core/systems/budget/transaction_reconciliation.ex
+++ b/core/systems/budget/transaction_reconciliation.ex
@@ -66,8 +66,8 @@ defmodule Systems.Budget.TransactionReconciliation do
          state
        ) do
     case Payment.Public.reconcile_get_transaction(state, uid) do
-      {{:ok, %{status: provider_status}}, state} ->
-        apply_status(state, transaction, provider_status)
+      {{:ok, %{status: provider_status, raw_status: raw_status}}, state} ->
+        apply_status(state, transaction, provider_status, raw_status)
 
       {:not_found, state} ->
         Logger.error(
@@ -85,27 +85,33 @@ defmodule Systems.Budget.TransactionReconciliation do
     end
   end
 
-  defp apply_status(state, %Budget.TransactionModel{status: :completed}, _provider_status),
-    do: State.tally(state, :verified)
+  defp apply_status(
+         state,
+         %Budget.TransactionModel{status: :completed},
+         _provider_status,
+         _raw_status
+       ),
+       do: State.tally(state, :verified)
 
   defp apply_status(
          state,
          %Budget.TransactionModel{id: id, transaction_id: uid, status: status} = transaction,
-         provider_status
+         provider_status,
+         raw_status
        ) do
     case resolve(transaction, provider_status) do
       {:ok, trivial} when trivial in [:still_pending, :verified] ->
         State.tally(state, trivial)
 
       {:ok, outcome} ->
-        record(state, outcome, id, uid, status, provider_status, %{})
+        record(state, outcome, id, uid, status, raw_status, %{})
 
       {:error, reason} ->
-        record(state, :errors, id, uid, status, provider_status, %{error: inspect(reason)})
+        record(state, :errors, id, uid, status, raw_status, %{error: inspect(reason)})
     end
   end
 
-  defp resolve(%{transaction_id: uid}, "completed") do
+  defp resolve(%{transaction_id: uid}, :completed) do
     case Budget.Public.complete_transaction(uid) do
       {:ok, _} -> {:ok, :resolved_completed}
       other -> {:error, other}
@@ -114,11 +120,9 @@ defmodule Systems.Budget.TransactionReconciliation do
     error -> {:error, error}
   end
 
-  defp resolve(%{status: :pending, transaction_id: uid}, "failed") do
+  defp resolve(%{status: :pending, transaction_id: uid}, :failed) do
     case Budget.Public.fail_transaction(uid) do
       {:ok, _} -> {:ok, :resolved_failed}
-      # Provider completed the transaction in the gap between our read and this
-      # write; the guard refused the stale "failed" — a benign no-op, not an error.
       {:error, :already_completed} -> {:ok, :verified}
       other -> {:error, other}
     end
@@ -126,7 +130,7 @@ defmodule Systems.Budget.TransactionReconciliation do
     error -> {:error, error}
   end
 
-  defp resolve(%{status: :failed}, "failed"), do: {:ok, :verified}
+  defp resolve(%{status: :failed}, :failed), do: {:ok, :verified}
   defp resolve(_transaction, _status), do: {:ok, :still_pending}
 
   defp record(state, outcome, id, uid, local_status, provider_status, details) do

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -1059,7 +1059,7 @@ defmodule Systems.Fund.Public do
   # A verified bank account (OPP Level 200) is sufficient for participant payouts;
   # merchant identity-KYC (Level 400) is never required. Ready iff the bank
   # account is approved, so a withdrawal never fires against an unapproved account.
-  defp payout_ready_for(%{status: "approved"}), do: :ok
+  defp payout_ready_for(%{status: :verified}), do: :ok
 
   defp payout_ready_for(%{verification_url: verification_url})
        when is_binary(verification_url) and verification_url != "",
@@ -1083,7 +1083,7 @@ defmodule Systems.Fund.Public do
     case Payment.Public.list_bank_accounts(merchant_uid) do
       {:ok, accounts} ->
         accounts
-        |> Enum.find(&(&1.status != "disapproved"))
+        |> Enum.find(&(&1.status != :rejected))
         |> bank_account_status()
 
       {:error, _} ->
@@ -1091,17 +1091,14 @@ defmodule Systems.Fund.Public do
     end
   end
 
-  # OPP's `status` is authoritative for the display state. A bank account that is
-  # under review ("pending") can still carry a `verification_url`, so status must
+  # The normalized `status` is authoritative for the display state. A bank account
+  # under review (`:pending`) can still carry a `verification_url`, so status must
   # be matched before any URL fallback — otherwise a pending account is mislabeled
-  # "not verified". "new" means the participant still has to complete verification
-  # (the "Toevoegen" iDEAL flow); anything else non-approved is being reviewed.
-  defp bank_account_status(%{status: "approved"}), do: :verified
-  defp bank_account_status(%{status: "new"}), do: :not_verified
-
-  defp bank_account_status(%{status: status}) when is_binary(status) and status != "",
-    do: :pending
-
+  # "not verified". `:new` means the participant still has to complete verification
+  # (the "Toevoegen" iDEAL flow); anything else non-verified is being reviewed.
+  defp bank_account_status(%{status: :verified}), do: :verified
+  defp bank_account_status(%{status: :new}), do: :not_verified
+  defp bank_account_status(%{status: status}) when is_atom(status), do: :pending
   defp bank_account_status(_bank_account), do: :not_verified
 
   @doc """
@@ -1134,7 +1131,7 @@ defmodule Systems.Fund.Public do
 
   # A verified bank account is all we need; we never hand off to OPP's hosted
   # merchant-overview screen. Approved → done; otherwise drive the iDEAL flow.
-  defp bank_handoff(_merchant, %{status: "approved"}), do: :verified
+  defp bank_handoff(_merchant, %{status: :verified}), do: :verified
 
   defp bank_handoff(_merchant, %{verification_url: verification_url})
        when is_binary(verification_url) and verification_url != "",

--- a/core/systems/payment/_public.ex
+++ b/core/systems/payment/_public.ex
@@ -181,7 +181,7 @@ defmodule Systems.Payment.Public do
   end
 
   defp usable_or_new_bank_account(merchant_uid, accounts) do
-    case Enum.find(accounts, &(&1.status != "disapproved")) do
+    case Enum.find(accounts, &(&1.status != :rejected)) do
       nil -> create_bank_account(merchant_uid, bank_account_attrs())
       usable -> {:ok, usable}
     end

--- a/core/systems/payment/controller.ex
+++ b/core/systems/payment/controller.ex
@@ -23,8 +23,11 @@ defmodule Systems.Payment.Controller do
   defp handle_webhook(conn, handler) do
     case handler.verify_and_parse(conn) do
       {:ok, event} ->
-        Logger.info("[Payment.Webhook] Received event=#{event.type} object=#{event.object_uid}")
-        process_event(event)
+        Logger.info(
+          "[Payment.Webhook] Received category=#{event.category} type=#{event.raw_type}"
+        )
+
+        route(event)
         json(conn, %{status: "ok"})
 
       {:error, error} ->
@@ -36,63 +39,21 @@ defmodule Systems.Payment.Controller do
     end
   end
 
-  defp process_event(%{type: type, object_uid: uid, object_type: object_type} = event) do
-    Logger.info("[Payment.Webhook] Processing event type=#{type} object_uid=#{uid}")
-    Logger.info("[Payment.Webhook] Full event: #{inspect(event)}")
+  # The adapter has already translated its wire format into a provider-agnostic
+  # category, so routing knows nothing about any provider's event strings.
+  defp route(%{category: :transaction, object_uid: uid}),
+    do: handle_transaction_status_change(uid)
 
-    route_event(object_type, type, uid, event)
-  end
+  defp route(%{category: :withdrawal, object_uid: uid}), do: handle_withdrawal_status_change(uid)
 
-  # Route on the authoritative `object_type`. OPP prefixes the event `type` with
-  # the owning resource (e.g. "merchant.withdrawal.status.changed"), so matching
-  # the type string alone misclassifies withdrawal/transaction events as KYC —
-  # their object_type is settled first, before the KYC type-prefix heuristic.
-  defp route_event("withdrawal", _type, uid, _event), do: handle_withdrawal_status_change(uid)
-  defp route_event("transaction", _type, uid, _event), do: handle_transaction_status_change(uid)
-
-  defp route_event(object_type, type, uid, event) do
-    if kyc_event?(type, object_type) do
-      handle_kyc_change(event)
-    else
-      handle_event(type, uid)
-    end
-  end
-
-  # OPP's exact bank-account/merchant event-type strings vary; match on either the
-  # object_type or a type prefix so a KYC status change is never missed.
-  defp kyc_event?(type, object_type) do
-    object_type in ["bank_account", "merchant"] or
-      String.starts_with?(type, "bank_account") or
-      String.starts_with?(type, "merchant")
-  end
-
-  # A bank-account event's owning merchant is the parent; a merchant event is itself.
-  defp handle_kyc_change(%{object_type: "merchant", object_uid: merchant_uid}),
+  defp route(%{category: :kyc, merchant_uid: merchant_uid}) when is_binary(merchant_uid),
     do: notify_kyc(merchant_uid)
 
-  defp handle_kyc_change(%{parent_type: "merchant", parent_uid: merchant_uid})
-       when is_binary(merchant_uid),
-       do: notify_kyc(merchant_uid)
-
-  # OPP's type-prefix carries the ownership when object_type isn't "merchant"
-  # itself — e.g. "merchant.something.changed" on an untyped envelope.
-  defp handle_kyc_change(%{type: "merchant" <> _, object_uid: merchant_uid}),
-    do: notify_kyc(merchant_uid)
-
-  # A bank_account event without parent info is unroutable — we can't resolve
-  # the owning merchant, so the participant's badge won't refresh reactively.
-  # Log at :error with the identifying fields so a real occurrence is visible
-  # in production (and can drive a follow-up fetch-by-uid resolver).
-  defp handle_kyc_change(event) do
-    Logger.error(
-      "[Payment.Webhook] KYC event missing merchant reference — badge will not refresh. " <>
-        "type=#{inspect(Map.get(event, :type))} " <>
-        "object_type=#{inspect(Map.get(event, :object_type))} " <>
-        "object_uid=#{inspect(Map.get(event, :object_uid))} " <>
-        "parent_type=#{inspect(Map.get(event, :parent_type))} " <>
-        "parent_uid=#{inspect(Map.get(event, :parent_uid))}"
-    )
-  end
+  # `:ignored`, or a `:kyc` the adapter couldn't tie to a merchant — nothing to
+  # act on but the raw type, which we log. The guard above keeps a merchant-less
+  # KYC event from ever reaching notify_kyc/1 with a nil uid.
+  defp route(%{raw_type: raw_type}),
+    do: Logger.info("[Payment.Webhook] Ignoring event type=#{raw_type}")
 
   defp notify_kyc(merchant_uid) do
     case Account.Public.get_user_by_merchant_uid(merchant_uid) do
@@ -108,16 +69,6 @@ defmodule Systems.Payment.Controller do
     end
   end
 
-  defp handle_event("transaction.status_changed", uid), do: handle_transaction_status_change(uid)
-  defp handle_event("transaction.status.changed", uid), do: handle_transaction_status_change(uid)
-
-  defp handle_event("withdrawal.status_changed", uid), do: handle_withdrawal_status_change(uid)
-  defp handle_event("withdrawal.status.changed", uid), do: handle_withdrawal_status_change(uid)
-
-  defp handle_event(type, _uid) do
-    Logger.info("[Payment.Webhook] Ignoring event type=#{type}")
-  end
-
   defp handle_transaction_status_change(uid) do
     case Systems.Payment.Public.get_transaction(uid) do
       {:ok, %{status: status}} ->
@@ -129,12 +80,12 @@ defmodule Systems.Payment.Controller do
     end
   end
 
-  defp apply_transaction_status("completed", uid) do
+  defp apply_transaction_status(:completed, uid) do
     result = Budget.Public.complete_transaction(uid)
     Logger.info("[Payment.Webhook] Complete result: #{inspect(result)}")
   end
 
-  defp apply_transaction_status("failed", uid) do
+  defp apply_transaction_status(:failed, uid) do
     result = Budget.Public.fail_transaction(uid)
     Logger.info("[Payment.Webhook] Fail result: #{inspect(result)}")
   end

--- a/core/systems/payment/controller.ex
+++ b/core/systems/payment/controller.ex
@@ -49,9 +49,11 @@ defmodule Systems.Payment.Controller do
   defp route(%{category: :kyc, merchant_uid: merchant_uid}) when is_binary(merchant_uid),
     do: notify_kyc(merchant_uid)
 
-  # `:ignored`, or a `:kyc` the adapter couldn't tie to a merchant — nothing to
-  # act on but the raw type, which we log. The guard above keeps a merchant-less
-  # KYC event from ever reaching notify_kyc/1 with a nil uid.
+  # A KYC event the adapter couldn't tie to a merchant. The guard above keeps it
+  # from reaching notify_kyc/1 with a nil uid; the adapter has already logged why
+  # the badge won't refresh, so we stay silent rather than emit a second line.
+  defp route(%{category: :kyc}), do: :ok
+
   defp route(%{raw_type: raw_type}),
     do: Logger.info("[Payment.Webhook] Ignoring event type=#{raw_type}")
 

--- a/core/systems/payment/provider.ex
+++ b/core/systems/payment/provider.ex
@@ -44,9 +44,26 @@ defmodule Systems.Payment.Provider do
 
   # Bank accounts
 
+  @typedoc """
+  Provider-agnostic bank-account (KYC) verification status. Each adapter maps its
+  own vocabulary onto these atoms so domain code never matches on provider status
+  strings:
+
+    * `:verified`  — approved; payouts may fire against it
+    * `:rejected`  — permanently refused; never reused for a payout
+    * `:new`       — created but the participant has not submitted details yet
+    * `:pending`   — submitted and under review
+
+  An unrecognised provider status maps to `:pending`: an unknown state must never
+  be treated as verified (which would authorize a payout) nor as rejected. The
+  provider's own word is kept alongside it as `raw_status` for the audit trail.
+  """
+  @type kyc_status :: :verified | :rejected | :new | :pending
+
   @type bank_account :: %{
           uid: String.t(),
-          status: String.t(),
+          status: kyc_status(),
+          raw_status: String.t(),
           verification_url: String.t() | nil
         }
 
@@ -69,9 +86,22 @@ defmodule Systems.Payment.Provider do
 
   # Transactions
 
+  @typedoc """
+  Provider-agnostic lifecycle status shared by transactions, withdrawals and
+  transfers. Each adapter maps its own vocabulary onto these three atoms, so
+  domain code never matches on a provider's status strings. An unrecognised
+  provider status maps to `:pending`: an unknown state must never finalize money
+  movement.
+
+  The provider's own word is kept alongside it as `raw_status`, so an audit trail
+  can record that OPP said "disapproved" rather than the collapsed `:failed`.
+  """
+  @type lifecycle_status :: :pending | :completed | :failed
+
   @type transaction :: %{
           uid: String.t(),
-          status: String.t(),
+          status: lifecycle_status(),
+          raw_status: String.t(),
           payment_url: String.t() | nil,
           amount: integer()
         }
@@ -100,20 +130,6 @@ defmodule Systems.Payment.Provider do
   @callback get_transaction(uid :: String.t()) :: {:ok, transaction()} | {:error, Error.t()}
 
   # Withdrawals
-
-  @typedoc """
-  Provider-agnostic lifecycle status. Each adapter maps its own vocabulary onto
-  these three atoms, so domain code never matches on a provider's status strings.
-  An unrecognised provider status maps to `:pending`: an unknown state must never
-  finalize money movement.
-
-  The provider's own word is kept alongside it as `raw_status`, so an audit trail
-  can record that OPP said "disapproved" rather than the collapsed `:failed`.
-
-  Transactions and transfers still carry raw provider strings — normalizing those
-  is the remaining scope of the "normalize provider statuses" tech-debt ticket.
-  """
-  @type lifecycle_status :: :pending | :completed | :failed
 
   @type withdrawal :: %{
           uid: String.t(),
@@ -163,7 +179,8 @@ defmodule Systems.Payment.Provider do
 
   @type transfer :: %{
           uid: String.t(),
-          status: String.t(),
+          status: lifecycle_status(),
+          raw_status: String.t(),
           amount: integer()
         }
 

--- a/core/systems/payment/provider/local.ex
+++ b/core/systems/payment/provider/local.ex
@@ -47,7 +47,7 @@ defmodule Systems.Payment.Provider.Local do
   # Bank accounts — always "approved" so the pay-out path doesn't stall in KYC.
 
   defp stub_bank_account(uid) do
-    %{uid: uid, status: "approved", verification_url: nil}
+    %{uid: uid, status: :verified, raw_status: "approved", verification_url: nil}
   end
 
   @impl true
@@ -87,7 +87,8 @@ defmodule Systems.Payment.Provider.Local do
     {:ok,
      %{
        uid: uid,
-       status: "created",
+       status: :pending,
+       raw_status: "created",
        payment_url: "#{CoreWeb.Endpoint.url()}/payment/local/#{uid}",
        amount: total_amount
      }}
@@ -96,7 +97,7 @@ defmodule Systems.Payment.Provider.Local do
   @impl true
   def get_transaction(uid) when is_binary(uid) do
     Logger.info("[Payment.Local] get_transaction uid=#{uid}")
-    {:ok, %{uid: uid, status: "created", payment_url: nil, amount: 0}}
+    {:ok, %{uid: uid, status: :pending, raw_status: "created", payment_url: nil, amount: 0}}
   end
 
   # Withdrawals
@@ -143,7 +144,7 @@ defmodule Systems.Payment.Provider.Local do
       "[Payment.Local] transfer_to_merchant from=#{from_owner_uid} to=#{to_owner_uid} amount=#{amount} uid=#{uid} idempotence_key=#{idempotence_key}"
     )
 
-    {:ok, %{uid: uid, status: "created", amount: amount}}
+    {:ok, %{uid: uid, status: :pending, raw_status: "created", amount: amount}}
   end
 
   defp generate_uid do

--- a/core/systems/payment/provider/opp.ex
+++ b/core/systems/payment/provider/opp.ex
@@ -266,12 +266,23 @@ defmodule Systems.Payment.Provider.OPP do
   # Parsers
 
   defp parse_bank_account(uid, data) do
+    raw_status = Map.get(data, "status", "new")
+
     %{
       uid: uid,
-      status: Map.get(data, "status", "new"),
+      status: normalize_kyc_status(raw_status),
+      raw_status: raw_status,
       verification_url: Map.get(data, "verification_url")
     }
   end
+
+  # Only OPP's terminal KYC words are recognised. Everything else — including a
+  # status OPP adds later — stays :pending, so an unknown state is never treated
+  # as verified (which would authorize a payout).
+  defp normalize_kyc_status("approved"), do: :verified
+  defp normalize_kyc_status("disapproved"), do: :rejected
+  defp normalize_kyc_status("new"), do: :new
+  defp normalize_kyc_status(_status), do: :pending
 
   defp parse_merchant(uid, data) do
     compliance = Map.get(data, "compliance", %{})
@@ -286,9 +297,12 @@ defmodule Systems.Payment.Provider.OPP do
   end
 
   defp parse_transaction(uid, data) do
+    raw_status = Map.get(data, "status", "unknown")
+
     %{
       uid: uid,
-      status: Map.get(data, "status", "unknown"),
+      status: normalize_lifecycle_status(raw_status),
+      raw_status: raw_status,
       payment_url: Map.get(data, "redirect_url"),
       amount: Map.get(data, "total_amount", 0)
     }
@@ -299,28 +313,33 @@ defmodule Systems.Payment.Provider.OPP do
 
     %{
       uid: uid,
-      status: normalize_withdrawal_status(raw_status),
+      status: normalize_lifecycle_status(raw_status),
       raw_status: raw_status,
       reference: Map.get(data, "reference"),
       amount: Map.get(data, "amount", 0)
     }
   end
 
-  # Only OPP's two terminal words are recognised. Everything else — including a
-  # status OPP adds later — stays :pending, so an unknown state can never
-  # finalize or fail a payout.
-  defp normalize_withdrawal_status("completed"), do: :completed
-  defp normalize_withdrawal_status("failed"), do: :failed
-  defp normalize_withdrawal_status("disapproved"), do: :failed
-  defp normalize_withdrawal_status(_status), do: :pending
-
   defp parse_transfer(uid, data) do
+    raw_status = Map.get(data, "status", "unknown")
+
     %{
       uid: uid,
-      status: Map.get(data, "status", "unknown"),
+      status: normalize_lifecycle_status(raw_status),
+      raw_status: raw_status,
       amount: Map.get(data, "amount", 0)
     }
   end
+
+  # Only OPP's terminal words are recognised. Everything else — including a status
+  # OPP adds later — stays :pending, so an unknown state can never finalize or
+  # fail money movement. Shared by transactions, withdrawals and transfers;
+  # "disapproved" is a withdrawal/KYC rejection and simply never occurs for the
+  # other two.
+  defp normalize_lifecycle_status("completed"), do: :completed
+  defp normalize_lifecycle_status("failed"), do: :failed
+  defp normalize_lifecycle_status("disapproved"), do: :failed
+  defp normalize_lifecycle_status(_status), do: :pending
 
   defp put_opts(body, opts) do
     Enum.reduce(opts, body, fn {key, value}, acc ->

--- a/core/systems/payment/provider/opp/webhook.ex
+++ b/core/systems/payment/provider/opp/webhook.ex
@@ -3,6 +3,12 @@ defmodule Systems.Payment.Provider.OPP.Webhook do
 
   @signature_regex ~r/(\w+)="([^"]*)"/
 
+  # OPP resource names used both to classify an event as KYC and to resolve its
+  # owning merchant — kept in one place so the wire vocabulary isn't duplicated.
+  @merchant_type "merchant"
+  @bank_account_type "bank_account"
+  @kyc_object_types [@merchant_type, @bank_account_type]
+
   require Logger
 
   alias Systems.Payment.Error
@@ -111,18 +117,8 @@ defmodule Systems.Payment.Provider.OPP.Webhook do
 
   defp parse_event(body) do
     case Jason.decode(body) do
-      {:ok, %{"uid" => uid, "type" => type, "object_uid" => object_uid} = data} ->
-        event = %{
-          uid: uid,
-          type: type,
-          object_uid: object_uid,
-          object_type: Map.get(data, "object_type", ""),
-          object_url: Map.get(data, "object_url", ""),
-          parent_uid: Map.get(data, "parent_uid"),
-          parent_type: Map.get(data, "parent_type")
-        }
-
-        {:ok, event}
+      {:ok, %{"uid" => _uid, "type" => type, "object_uid" => object_uid} = data} ->
+        {:ok, classify(type, object_uid, data)}
 
       {:ok, _} ->
         {:error, %Error{code: :invalid_event, message: "Missing required event fields"}}
@@ -130,6 +126,87 @@ defmodule Systems.Payment.Provider.OPP.Webhook do
       {:error, _} ->
         {:error, %Error{code: :invalid_json, message: "Invalid JSON body"}}
     end
+  end
+
+  # Translate OPP's wire vocabulary into the provider-agnostic event the domain
+  # routes on. OPP prefixes the event `type` with the owning resource (e.g.
+  # "merchant.withdrawal.status.changed"), so the authoritative `object_type` is
+  # settled first; only KYC events, then the bare `type` string, are consulted
+  # after.
+  defp classify(type, object_uid, data) do
+    object_type = Map.get(data, "object_type", "")
+
+    cond do
+      object_type == "withdrawal" -> event(:withdrawal, object_uid, type)
+      object_type == "transaction" -> event(:transaction, object_uid, type)
+      kyc?(type, object_type) -> classify_kyc(type, object_uid, data)
+      status_changed(type) == :transaction -> event(:transaction, object_uid, type)
+      status_changed(type) == :withdrawal -> event(:withdrawal, object_uid, type)
+      true -> event(:ignored, object_uid, type)
+    end
+  end
+
+  # `merchant_uid` is only set for :kyc events; every other category leaves it nil.
+  defp event(category, object_uid, raw_type, merchant_uid \\ nil) do
+    %{category: category, object_uid: object_uid, merchant_uid: merchant_uid, raw_type: raw_type}
+  end
+
+  # OPP sends both dotted and underscore variants of the status-change type.
+  defp status_changed("transaction.status.changed"), do: :transaction
+  defp status_changed("transaction.status_changed"), do: :transaction
+  defp status_changed("withdrawal.status.changed"), do: :withdrawal
+  defp status_changed("withdrawal.status_changed"), do: :withdrawal
+  defp status_changed(_type), do: nil
+
+  # OPP's exact bank-account/merchant event-type strings vary; match on either the
+  # object_type or a type prefix so a KYC status change is never missed.
+  defp kyc?(type, object_type) do
+    object_type in @kyc_object_types or
+      String.starts_with?(type, @bank_account_type) or
+      String.starts_with?(type, @merchant_type)
+  end
+
+  # Resolve the owning merchant so the domain can refresh the participant's badge.
+  # When it can't be resolved the event is unroutable — log the OPP-specific
+  # identifiers here (they never reach the controller) and drop it to `:ignored`.
+  defp classify_kyc(type, object_uid, data) do
+    case resolve_merchant_uid(type, object_uid, data) do
+      merchant_uid when is_binary(merchant_uid) ->
+        event(:kyc, object_uid, type, merchant_uid)
+
+      nil ->
+        log_unresolvable_kyc(type, object_uid, data)
+        event(:ignored, object_uid, type)
+    end
+  end
+
+  # A merchant event is itself the merchant; a bank-account event's owning merchant
+  # is its parent; OPP's type-prefix carries ownership when object_type isn't set.
+  defp resolve_merchant_uid(type, object_uid, data) do
+    cond do
+      Map.get(data, "object_type") == @merchant_type ->
+        object_uid
+
+      Map.get(data, "parent_type") == @merchant_type and is_binary(Map.get(data, "parent_uid")) ->
+        Map.get(data, "parent_uid")
+
+      String.starts_with?(type, @merchant_type) ->
+        object_uid
+
+      true ->
+        nil
+    end
+  end
+
+  defp log_unresolvable_kyc(type, object_uid, data) do
+    Logger.error(
+      "[OPP.Webhook] KYC event missing merchant reference — badge will not refresh. " <>
+        "type=#{inspect(type)} " <>
+        "object_type=#{inspect(Map.get(data, "object_type"))} " <>
+        "object_uid=#{inspect(object_uid)} " <>
+        "parent_type=#{inspect(Map.get(data, "parent_type"))} " <>
+        "parent_uid=#{inspect(Map.get(data, "parent_uid"))}"
+    )
   end
 
   defp notification_secret do

--- a/core/systems/payment/provider/opp/webhook.ex
+++ b/core/systems/payment/provider/opp/webhook.ex
@@ -168,15 +168,18 @@ defmodule Systems.Payment.Provider.OPP.Webhook do
 
   # Resolve the owning merchant so the domain can refresh the participant's badge.
   # When it can't be resolved the event is unroutable — log the OPP-specific
-  # identifiers here (they never reach the controller) and drop it to `:ignored`.
+  # identifiers here (they never reach the controller); the event stays `:kyc`
+  # with a nil merchant, which the controller no-ops on.
   defp classify_kyc(type, object_uid, data) do
     case resolve_merchant_uid(type, object_uid, data) do
       merchant_uid when is_binary(merchant_uid) ->
         event(:kyc, object_uid, type, merchant_uid)
 
       nil ->
+        # Stays a :kyc event with no merchant. The controller no-ops on it, so the
+        # only log is this one detailed :error — not also a generic "ignoring" line.
         log_unresolvable_kyc(type, object_uid, data)
-        event(:ignored, object_uid, type)
+        event(:kyc, object_uid, type)
     end
   end
 

--- a/core/systems/payment/webhook.ex
+++ b/core/systems/payment/webhook.ex
@@ -1,14 +1,28 @@
 defmodule Systems.Payment.Webhook do
   alias Systems.Payment.Error
 
+  @typedoc """
+  Provider-agnostic event category. The adapter's `verify_and_parse/1` classifies
+  its own wire vocabulary into one of these, so `Payment.Controller` routes without
+  knowing any provider's event-type or object-type strings:
+
+    * `:transaction` / `:withdrawal` — a lifecycle status change; act on `object_uid`
+    * `:kyc` — a merchant/bank-account verification change; refresh `merchant_uid`
+    * `:ignored` — an event the domain does not act on
+  """
+  @type category :: :transaction | :withdrawal | :kyc | :ignored
+
+  @typedoc """
+  Provider-agnostic webhook event. Adapters resolve the identifiers the domain
+  needs (the owning `merchant_uid` for `:kyc`) so no provider wire-format detail
+  reaches the controller. `raw_type` is the provider's own event-type string,
+  retained for logging only.
+  """
   @type event :: %{
-          uid: String.t(),
-          type: String.t(),
-          object_uid: String.t(),
-          object_type: String.t(),
-          object_url: String.t(),
-          parent_uid: String.t() | nil,
-          parent_type: String.t() | nil
+          category: category(),
+          object_uid: String.t() | nil,
+          merchant_uid: String.t() | nil,
+          raw_type: String.t()
         }
 
   @callback verify_and_parse(Plug.Conn.t()) :: {:ok, event()} | {:error, Error.t()}

--- a/core/test/systems/account/payouts_reactive_test.exs
+++ b/core/test/systems/account/payouts_reactive_test.exs
@@ -34,7 +34,8 @@ defmodule Systems.Account.PayoutsReactiveTest do
        [
          %{
            uid: "ba",
-           status: Agent.get(bank, & &1),
+           status: normalize_kyc(Agent.get(bank, & &1)),
+           raw_status: Agent.get(bank, & &1),
            verification_url: "https://opp.test/ba/verify"
          }
        ]}
@@ -42,6 +43,13 @@ defmodule Systems.Account.PayoutsReactiveTest do
 
     %{user: user, bank: bank}
   end
+
+  # Mirrors the provider's KYC normalization so the mock returns the same shape
+  # a real adapter would (normalized atom + preserved raw word).
+  defp normalize_kyc("approved"), do: :verified
+  defp normalize_kyc("disapproved"), do: :rejected
+  defp normalize_kyc("new"), do: :new
+  defp normalize_kyc(_), do: :pending
 
   test "bank badge flips pending -> verified when the KYC webhook fires", %{
     conn: conn,

--- a/core/test/systems/account/payouts_view_builder_test.exs
+++ b/core/test/systems/account/payouts_view_builder_test.exs
@@ -28,7 +28,7 @@ defmodule Systems.Account.PayoutsViewBuilderTest do
       user = Factories.insert!(:member, %{creator: false, merchant_uid: "m_v"})
 
       expect(ProviderMock, :list_bank_accounts, fn "m_v" ->
-        {:ok, [%{uid: "ba", status: "approved", verification_url: nil}]}
+        {:ok, [%{uid: "ba", status: :verified, raw_status: "approved", verification_url: nil}]}
       end)
 
       vm = Account.PayoutsViewBuilder.view_model(user, %{})
@@ -43,7 +43,15 @@ defmodule Systems.Account.PayoutsViewBuilderTest do
 
       # A pending account can still carry a verification_url; status must win.
       expect(ProviderMock, :list_bank_accounts, fn "m_p" ->
-        {:ok, [%{uid: "ba", status: "pending", verification_url: "https://opp.test/ba/verify"}]}
+        {:ok,
+         [
+           %{
+             uid: "ba",
+             status: :pending,
+             raw_status: "pending",
+             verification_url: "https://opp.test/ba/verify"
+           }
+         ]}
       end)
 
       vm = Account.PayoutsViewBuilder.view_model(user, %{})
@@ -58,7 +66,15 @@ defmodule Systems.Account.PayoutsViewBuilderTest do
       user = Factories.insert!(:member, %{creator: false, merchant_uid: "m_nv"})
 
       expect(ProviderMock, :list_bank_accounts, fn "m_nv" ->
-        {:ok, [%{uid: "ba", status: "new", verification_url: "https://opp.test/ba/verify"}]}
+        {:ok,
+         [
+           %{
+             uid: "ba",
+             status: :new,
+             raw_status: "new",
+             verification_url: "https://opp.test/ba/verify"
+           }
+         ]}
       end)
 
       vm = Account.PayoutsViewBuilder.view_model(user, %{})
@@ -72,7 +88,7 @@ defmodule Systems.Account.PayoutsViewBuilderTest do
       # No get_merchant expectation: the badge is derived from the bank account
       # only, so a lingering merchant overview_url (Level 400) is irrelevant.
       expect(ProviderMock, :list_bank_accounts, fn "m_b" ->
-        {:ok, [%{uid: "ba", status: "approved", verification_url: nil}]}
+        {:ok, [%{uid: "ba", status: :verified, raw_status: "approved", verification_url: nil}]}
       end)
 
       vm = Account.PayoutsViewBuilder.view_model(user, %{})
@@ -100,7 +116,15 @@ defmodule Systems.Account.PayoutsViewBuilderTest do
       end)
 
       expect(ProviderMock, :list_bank_accounts, fn "m_b" ->
-        {:ok, [%{uid: "ba", status: "new", verification_url: "https://opp.test/ba/verify"}]}
+        {:ok,
+         [
+           %{
+             uid: "ba",
+             status: :new,
+             raw_status: "new",
+             verification_url: "https://opp.test/ba/verify"
+           }
+         ]}
       end)
 
       assert {:bank, "https://opp.test/ba/verify"} = Fund.Public.start_bank_verification(user)
@@ -121,7 +145,7 @@ defmodule Systems.Account.PayoutsViewBuilderTest do
       end)
 
       expect(ProviderMock, :list_bank_accounts, fn "m_b" ->
-        {:ok, [%{uid: "ba", status: "approved", verification_url: nil}]}
+        {:ok, [%{uid: "ba", status: :verified, raw_status: "approved", verification_url: nil}]}
       end)
 
       assert :verified = Fund.Public.start_bank_verification(user)

--- a/core/test/systems/budget/reconcile_transactions_test.exs
+++ b/core/test/systems/budget/reconcile_transactions_test.exs
@@ -81,11 +81,24 @@ defmodule Systems.Budget.ReconcileTransactionsTest do
     Ecto.Changeset.put_change(changeset, :currency_ledger_id, ensure_currency_ledger(:EUR).id)
   end
 
-  defp stub_opp_status(uid, status) do
+  # Simulates the provider contract: a raw provider word in, a normalized
+  # lifecycle atom plus the preserved raw_status out.
+  defp stub_opp_status(uid, raw_status) do
     expect(ProviderMock, :get_transaction, fn ^uid ->
-      {:ok, %{uid: uid, status: status, payment_url: nil, amount: 0}}
+      {:ok,
+       %{
+         uid: uid,
+         status: normalize_lifecycle(raw_status),
+         raw_status: raw_status,
+         payment_url: nil,
+         amount: 0
+       }}
     end)
   end
+
+  defp normalize_lifecycle("completed"), do: :completed
+  defp normalize_lifecycle("failed"), do: :failed
+  defp normalize_lifecycle(_), do: :pending
 
   test "completes a pending transaction that OPP has completed" do
     transaction = setup_transaction(:pending)
@@ -148,7 +161,7 @@ defmodule Systems.Budget.ReconcileTransactionsTest do
       from(t in Budget.TransactionModel, where: t.transaction_id == ^uid)
       |> Repo.update_all(set: [status: :completed])
 
-      {:ok, %{uid: uid, status: "failed", payment_url: nil, amount: 0}}
+      {:ok, %{uid: uid, status: :failed, raw_status: "failed", payment_url: nil, amount: 0}}
     end)
 
     assert %{scanned: 1, verified: 1, errors: 0, resolved_failed: 0} = reconcile()

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -920,7 +920,7 @@ defmodule Systems.Fund.PublicTest do
     # locking (list_bank_accounts only — the bank account gates the payout).
     defp stub_payout_ready(merchant_uid) do
       expect(ProviderMock, :list_bank_accounts, fn ^merchant_uid ->
-        {:ok, [%{uid: "ba_ok", status: "approved", verification_url: nil}]}
+        {:ok, [%{uid: "ba_ok", status: :verified, raw_status: "approved", verification_url: nil}]}
       end)
     end
 
@@ -1071,7 +1071,7 @@ defmodule Systems.Fund.PublicTest do
         |> Ecto.Changeset.change(%{status: :pending_payout})
         |> Core.Repo.update!()
 
-        {:ok, [%{uid: "ba_ok", status: "approved", verification_url: nil}]}
+        {:ok, [%{uid: "ba_ok", status: :verified, raw_status: "approved", verification_url: nil}]}
       end)
 
       # No transfer_to_merchant / create_withdrawal expectations: the compare-and-swap
@@ -1577,7 +1577,8 @@ defmodule Systems.Fund.PublicTest do
     # idempotent in tests that don't care about that step.
     defp stub_existing_bank_account(merchant_uid) do
       expect(ProviderMock, :list_bank_accounts, fn ^merchant_uid ->
-        {:ok, [%{uid: "ba_existing", status: "approved", verification_url: nil}]}
+        {:ok,
+         [%{uid: "ba_existing", status: :verified, raw_status: "approved", verification_url: nil}]}
       end)
     end
 
@@ -1689,7 +1690,13 @@ defmodule Systems.Fund.PublicTest do
         assert is_binary(attrs.notify_url)
         assert is_binary(attrs.return_url)
 
-        {:ok, %{uid: "ba_new", status: "new", verification_url: "https://opp.test/ba/verify"}}
+        {:ok,
+         %{
+           uid: "ba_new",
+           status: :new,
+           raw_status: "new",
+           verification_url: "https://opp.test/ba/verify"
+         }}
       end)
 
       # Freshly created bank account is not yet approved -> drive the iDEAL flow.
@@ -1722,7 +1729,7 @@ defmodule Systems.Fund.PublicTest do
 
       # Bank account is not approved and carries no verification_url.
       expect(ProviderMock, :list_bank_accounts, fn "m_prep_1" ->
-        {:ok, [%{uid: "ba", status: "new", verification_url: nil}]}
+        {:ok, [%{uid: "ba", status: :new, raw_status: "new", verification_url: nil}]}
       end)
 
       assert {:error, :kyc_unavailable} = Fund.Public.prepare_payout(user, "euro")
@@ -1745,7 +1752,14 @@ defmodule Systems.Fund.PublicTest do
 
       expect(ProviderMock, :list_bank_accounts, fn "m_prep_1" ->
         {:ok,
-         [%{uid: "ba_pending", status: "new", verification_url: "https://opp.test/ba/verify"}]}
+         [
+           %{
+             uid: "ba_pending",
+             status: :new,
+             raw_status: "new",
+             verification_url: "https://opp.test/ba/verify"
+           }
+         ]}
       end)
 
       assert {:error, {:kyc_required, :bank, "https://opp.test/ba/verify"}} =
@@ -1770,7 +1784,7 @@ defmodule Systems.Fund.PublicTest do
       # Bank not approved and no verification_url; the merchant overview_url is
       # irrelevant now that a verified bank account is all we require.
       expect(ProviderMock, :list_bank_accounts, fn "m_prep_1" ->
-        {:ok, [%{uid: "ba_pending", status: "new", verification_url: nil}]}
+        {:ok, [%{uid: "ba_pending", status: :new, raw_status: "new", verification_url: nil}]}
       end)
 
       assert {:error, :kyc_unavailable} = Fund.Public.prepare_payout(user, "euro")

--- a/core/test/systems/home/rewards_summary_view_handlers_test.exs
+++ b/core/test/systems/home/rewards_summary_view_handlers_test.exs
@@ -92,7 +92,7 @@ defmodule Systems.Home.RewardsSummaryViewHandlersTest do
     end)
 
     stub(ProviderMock, :list_bank_accounts, fn ^merchant_uid ->
-      {:ok, [%{uid: "ba_ok", status: "approved", verification_url: nil}]}
+      {:ok, [%{uid: "ba_ok", status: :verified, raw_status: "approved", verification_url: nil}]}
     end)
   end
 
@@ -124,7 +124,7 @@ defmodule Systems.Home.RewardsSummaryViewHandlersTest do
       end)
 
       stub(ProviderMock, :list_bank_accounts, fn _ ->
-        {:ok, [%{uid: "ba", status: "approved", verification_url: nil}]}
+        {:ok, [%{uid: "ba", status: :verified, raw_status: "approved", verification_url: nil}]}
       end)
 
       {:noreply, socket} = RewardsSummaryView.handle_event("request_payout", %{}, socket(user))
@@ -149,7 +149,15 @@ defmodule Systems.Home.RewardsSummaryViewHandlersTest do
       end)
 
       stub(ProviderMock, :list_bank_accounts, fn _ ->
-        {:ok, [%{uid: "ba", status: "new", verification_url: "https://opp.test/ba/verify"}]}
+        {:ok,
+         [
+           %{
+             uid: "ba",
+             status: :new,
+             raw_status: "new",
+             verification_url: "https://opp.test/ba/verify"
+           }
+         ]}
       end)
 
       {:noreply, socket} = RewardsSummaryView.handle_event("request_payout", %{}, socket(user))
@@ -173,7 +181,7 @@ defmodule Systems.Home.RewardsSummaryViewHandlersTest do
       end)
 
       stub(ProviderMock, :list_bank_accounts, fn _ ->
-        {:ok, [%{uid: "ba", status: "new", verification_url: nil}]}
+        {:ok, [%{uid: "ba", status: :new, raw_status: "new", verification_url: nil}]}
       end)
 
       {:noreply, socket} = RewardsSummaryView.handle_event("request_payout", %{}, socket(user))

--- a/core/test/systems/payment/_public_test.exs
+++ b/core/test/systems/payment/_public_test.exs
@@ -179,7 +179,13 @@ defmodule Systems.Payment.PublicTest do
 
   describe "ensure_bank_account_for/1" do
     test "returns the existing bank account when one already exists (no create call)" do
-      existing = %{uid: "ba_existing", status: "approved", verification_url: nil}
+      existing = %{
+        uid: "ba_existing",
+        status: :verified,
+        raw_status: "approved",
+        verification_url: nil
+      }
+
       expect(ProviderMock, :list_bank_accounts, fn "m_x" -> {:ok, [existing]} end)
       # No :create_bank_account expectation -> Mox fails if invoked.
 
@@ -196,10 +202,16 @@ defmodule Systems.Payment.PublicTest do
         assert is_binary(attrs.return_url)
         assert attrs.is_default == true
 
-        {:ok, %{uid: "ba_new", status: "new", verification_url: "https://opp.test/ba/verify"}}
+        {:ok,
+         %{
+           uid: "ba_new",
+           status: :new,
+           raw_status: "new",
+           verification_url: "https://opp.test/ba/verify"
+         }}
       end)
 
-      assert {:ok, %{uid: "ba_new", status: "new"}} =
+      assert {:ok, %{uid: "ba_new", status: :new}} =
                Payment.Public.ensure_bank_account_for("m_y")
     end
 
@@ -214,8 +226,8 @@ defmodule Systems.Payment.PublicTest do
 
     test "reuses a usable (non-disapproved) account even when a disapproved one exists" do
       accounts = [
-        %{uid: "ba_bad", status: "disapproved", verification_url: nil},
-        %{uid: "ba_good", status: "new", verification_url: "https://opp.test/v"}
+        %{uid: "ba_bad", status: :rejected, raw_status: "disapproved", verification_url: nil},
+        %{uid: "ba_good", status: :new, raw_status: "new", verification_url: "https://opp.test/v"}
       ]
 
       expect(ProviderMock, :list_bank_accounts, fn "m_mix" -> {:ok, accounts} end)
@@ -227,10 +239,17 @@ defmodule Systems.Payment.PublicTest do
     test "creates a fresh account when the only existing one is disapproved" do
       ProviderMock
       |> expect(:list_bank_accounts, fn "m_dis" ->
-        {:ok, [%{uid: "ba_bad", status: "disapproved", verification_url: nil}]}
+        {:ok,
+         [%{uid: "ba_bad", status: :rejected, raw_status: "disapproved", verification_url: nil}]}
       end)
       |> expect(:create_bank_account, fn "m_dis", _attrs ->
-        {:ok, %{uid: "ba_fresh", status: "new", verification_url: "https://opp.test/v2"}}
+        {:ok,
+         %{
+           uid: "ba_fresh",
+           status: :new,
+           raw_status: "new",
+           verification_url: "https://opp.test/v2"
+         }}
       end)
 
       assert {:ok, %{uid: "ba_fresh"}} = Payment.Public.ensure_bank_account_for("m_dis")

--- a/core/test/systems/payment/local_test.exs
+++ b/core/test/systems/payment/local_test.exs
@@ -20,7 +20,7 @@ defmodule Systems.Payment.Provider.LocalTest do
 
   describe "create_bank_account/2" do
     test "returns an approved bank account" do
-      assert {:ok, %{status: "approved"} = ba} = Local.create_bank_account("m_1", %{})
+      assert {:ok, %{status: :verified} = ba} = Local.create_bank_account("m_1", %{})
       assert is_binary(ba.uid)
     end
 
@@ -35,7 +35,7 @@ defmodule Systems.Payment.Provider.LocalTest do
 
   describe "list_bank_accounts/1" do
     test "returns a non-empty list with an approved account" do
-      assert {:ok, [%{status: "approved"} | _]} = Local.list_bank_accounts("m_1")
+      assert {:ok, [%{status: :verified} | _]} = Local.list_bank_accounts("m_1")
     end
 
     test "crashes on a non-binary merchant_uid (guard)" do

--- a/core/test/systems/payment/opp_test.exs
+++ b/core/test/systems/payment/opp_test.exs
@@ -41,7 +41,12 @@ defmodule Systems.Payment.Provider.OPPTest do
       end)
 
       assert {:ok,
-              %{uid: "ba_1", status: "new", verification_url: "https://opp.test/verify/ba_1"}} =
+              %{
+                uid: "ba_1",
+                status: :new,
+                raw_status: "new",
+                verification_url: "https://opp.test/verify/ba_1"
+              }} =
                OPP.create_bank_account("m_1", %{notify_url: "x", return_url: "y"})
     end
 
@@ -51,7 +56,7 @@ defmodule Systems.Payment.Provider.OPPTest do
         Plug.Conn.resp(conn, 200, ~s<{"uid": "ba_2"}>)
       end)
 
-      assert {:ok, %{uid: "ba_2", status: "new", verification_url: nil}} =
+      assert {:ok, %{uid: "ba_2", status: :new, raw_status: "new", verification_url: nil}} =
                OPP.create_bank_account("m_1", %{})
     end
 
@@ -77,8 +82,8 @@ defmodule Systems.Payment.Provider.OPPTest do
 
       assert {:ok,
               [
-                %{uid: "ba_a", status: "approved"},
-                %{uid: "ba_b", status: "disapproved"}
+                %{uid: "ba_a", status: :verified, raw_status: "approved"},
+                %{uid: "ba_b", status: :rejected, raw_status: "disapproved"}
               ]} = OPP.list_bank_accounts("m_1")
     end
 
@@ -329,7 +334,7 @@ defmodule Systems.Payment.Provider.OPPTest do
         Plug.Conn.resp(conn, 200, ~s<{"uid": "chg_1", "status": "created", "amount": 1000}>)
       end)
 
-      assert {:ok, %{uid: "chg_1", status: "created", amount: 1000}} =
+      assert {:ok, %{uid: "chg_1", status: :pending, raw_status: "created", amount: 1000}} =
                OPP.transfer_to_merchant(
                  "mer_platform",
                  "mer_participant",

--- a/core/test/systems/payment/opp_webhook_test.exs
+++ b/core/test/systems/payment/opp_webhook_test.exs
@@ -149,6 +149,22 @@ defmodule Systems.Payment.Provider.OPP.WebhookTest do
       assert event.category == :ignored
       assert event.raw_type == "some.other.event"
     end
+
+    test "a KYC event with no resolvable merchant stays :kyc with a nil merchant_uid" do
+      body =
+        Jason.encode!(%{
+          "uid" => "notif_orphan",
+          "type" => "bank_account.status.changed",
+          "object_uid" => "ba_orphan",
+          "object_type" => "bank_account"
+        })
+
+      conn = build_signed_conn(body)
+
+      assert {:ok, event} = Webhook.verify_and_parse(conn)
+      assert event.category == :kyc
+      assert event.merchant_uid == nil
+    end
   end
 
   describe "verify_and_parse/1 signature verification" do

--- a/core/test/systems/payment/opp_webhook_test.exs
+++ b/core/test/systems/payment/opp_webhook_test.exs
@@ -58,26 +58,25 @@ defmodule Systems.Payment.Provider.OPP.WebhookTest do
     })
   end
 
-  describe "verify_and_parse/1 valid requests" do
-    test "accepts webhook with correct signature" do
+  describe "verify_and_parse/1 classifies OPP events into the agnostic shape" do
+    test "a merchant event becomes a :kyc event owned by the merchant itself" do
       body = valid_event_body()
       conn = build_signed_conn(body)
 
       assert {:ok, event} = Webhook.verify_and_parse(conn)
-      assert event.uid == "notif_123"
-      assert event.type == "merchant.status_changed"
-      assert event.object_uid == "merchant_456"
-      assert event.object_type == "merchant"
+      assert event.category == :kyc
+      assert event.merchant_uid == "merchant_456"
+      assert event.raw_type == "merchant.status_changed"
     end
 
-    test "parses optional parent fields" do
+    test "a bank_account event resolves its owning merchant from the parent fields" do
       body =
         Jason.encode!(%{
           "uid" => "notif_1",
-          "type" => "transaction.completed",
-          "object_uid" => "tx_1",
-          "object_type" => "transaction",
-          "object_url" => "https://api.example.com/v1/transactions/tx_1",
+          "type" => "bank_account.status.changed",
+          "object_uid" => "ba_1",
+          "object_type" => "bank_account",
+          "object_url" => "https://api.example.com/v1/bank_accounts/ba_1",
           "parent_uid" => "merchant_1",
           "parent_type" => "merchant"
         })
@@ -85,8 +84,70 @@ defmodule Systems.Payment.Provider.OPP.WebhookTest do
       conn = build_signed_conn(body)
 
       assert {:ok, event} = Webhook.verify_and_parse(conn)
-      assert event.parent_uid == "merchant_1"
-      assert event.parent_type == "merchant"
+      assert event.category == :kyc
+      assert event.merchant_uid == "merchant_1"
+    end
+
+    test "a merchant-prefixed withdrawal event becomes a :withdrawal, not :kyc" do
+      body =
+        Jason.encode!(%{
+          "uid" => "notif_2",
+          "type" => "merchant.withdrawal.status.changed",
+          "object_uid" => "w_1",
+          "object_type" => "withdrawal",
+          "object_url" => "https://api.example.com/v1/withdrawals/w_1"
+        })
+
+      conn = build_signed_conn(body)
+
+      assert {:ok, event} = Webhook.verify_and_parse(conn)
+      assert event.category == :withdrawal
+      assert event.object_uid == "w_1"
+    end
+
+    test "falls back to the bare type string when object_type is absent (transaction)" do
+      body =
+        Jason.encode!(%{
+          "uid" => "notif_3",
+          "type" => "transaction.status.changed",
+          "object_uid" => "tx_9"
+        })
+
+      conn = build_signed_conn(body)
+
+      assert {:ok, event} = Webhook.verify_and_parse(conn)
+      assert event.category == :transaction
+      assert event.object_uid == "tx_9"
+    end
+
+    test "falls back on the underscore type variant when object_type is absent (withdrawal)" do
+      body =
+        Jason.encode!(%{
+          "uid" => "notif_4",
+          "type" => "withdrawal.status_changed",
+          "object_uid" => "w_9"
+        })
+
+      conn = build_signed_conn(body)
+
+      assert {:ok, event} = Webhook.verify_and_parse(conn)
+      assert event.category == :withdrawal
+      assert event.object_uid == "w_9"
+    end
+
+    test "an unrecognised event is classified :ignored" do
+      body =
+        Jason.encode!(%{
+          "uid" => "notif_5",
+          "type" => "some.other.event",
+          "object_uid" => "x_9"
+        })
+
+      conn = build_signed_conn(body)
+
+      assert {:ok, event} = Webhook.verify_and_parse(conn)
+      assert event.category == :ignored
+      assert event.raw_type == "some.other.event"
     end
   end
 

--- a/core/test/systems/payment/reconciliation_worker_test.exs
+++ b/core/test/systems/payment/reconciliation_worker_test.exs
@@ -115,7 +115,14 @@ defmodule Systems.Payment.ReconciliationWorkerTest do
     end)
 
     expect(ProviderMock, :get_transaction, fn "tx_payin" ->
-      {:ok, %{uid: "tx_payin", status: "completed", payment_url: nil, amount: 0}}
+      {:ok,
+       %{
+         uid: "tx_payin",
+         status: :completed,
+         raw_status: "completed",
+         payment_url: nil,
+         amount: 0
+       }}
     end)
 
     assert :ok = ReconciliationWorker.perform(%Oban.Job{args: %{}})
@@ -133,7 +140,14 @@ defmodule Systems.Payment.ReconciliationWorkerTest do
     end)
 
     expect(ProviderMock, :get_transaction, fn "tx_payin" ->
-      {:ok, %{uid: "tx_payin", status: "completed", payment_url: nil, amount: 0}}
+      {:ok,
+       %{
+         uid: "tx_payin",
+         status: :completed,
+         raw_status: "completed",
+         payment_url: nil,
+         amount: 0
+       }}
     end)
 
     assert :ok = ReconciliationWorker.perform(%Oban.Job{args: %{}})


### PR DESCRIPTION
Keeps OPP's wire vocabulary inside its own adapter so a second provider maps its strings once.

- Transaction + transfer statuses normalize to the shared `:pending | :completed | :failed` atom (withdrawals were already done), keeping the provider's word as `raw_status` for the audit trail.
- Bank-account KYC status normalizes to `:verified | :rejected | :new | :pending`; unknown → `:pending` so an unknown state never authorizes a payout. Merchant status left raw (no consumers).
- OPP.Webhook classifies events into a provider-agnostic `category` and resolves the owning `merchant_uid`; the controller routes purely on category and never sees a provider string.

Addresses the "normalize provider statuses" (9995556065) and "normalize provider events" (10000440219) tech-debt tickets.