### PR TITLE
feat: enforce approved rewards have a payment at the database

### DIFF
--- a/core/lib/core/factories.ex
+++ b/core/lib/core/factories.ex
@@ -986,9 +986,6 @@ defmodule Core.Factories do
     {deposit, attributes} = Map.pop(attributes, :deposit, nil)
     {payment, attributes} = Map.pop(attributes, :payment, nil)
 
-    # An :approved reward always has a payment (approved_requires_payment CHECK),
-    # so persist one and set payment_id unless the caller supplied a payment or
-    # payment_id. Applies to :approved only — other statuses are unaffected.
     attributes =
       if payment == nil and attributes[:status] == :approved and
            not Map.has_key?(attributes, :payment_id) do

--- a/core/lib/core/factories.ex
+++ b/core/lib/core/factories.ex
@@ -986,6 +986,23 @@ defmodule Core.Factories do
     {deposit, attributes} = Map.pop(attributes, :deposit, nil)
     {payment, attributes} = Map.pop(attributes, :payment, nil)
 
+    # An :approved reward always has a payment (approved_requires_payment CHECK),
+    # so persist one and set payment_id unless the caller supplied a payment or
+    # payment_id. Applies to :approved only — other statuses are unaffected.
+    attributes =
+      if payment == nil and attributes[:status] == :approved and
+           not Map.has_key?(attributes, :payment_id) do
+        entry =
+          insert!(:book_entry, %{
+            idempotence_key: "reward-payment-#{System.unique_integer([:positive])}",
+            journal_message: "reward payment"
+          })
+
+        Map.put(attributes, :payment_id, entry.id)
+      else
+        attributes
+      end
+
     %Fund.RewardModel{
       fund: fund,
       user: user,

--- a/core/priv/repo/migrations/20260723081508_add_approved_requires_payment_check_to_fund_rewards.exs
+++ b/core/priv/repo/migrations/20260723081508_add_approved_requires_payment_check_to_fund_rewards.exs
@@ -1,0 +1,31 @@
+defmodule Core.Repo.Migrations.AddApprovedRequiresPaymentCheckToFundRewards do
+  use Ecto.Migration
+
+  # Enforce, at the database, the invariant that an :approved reward always has a
+  # payment. It is currently guaranteed only by the approval Multi in app code;
+  # this CHECK stops any future non-Multi path (raw insert, bulk update, manual
+  # SQL) from leaving an approved reward without a payment_id.
+  #
+  # Added NOT VALID first — a brief ACCESS EXCLUSIVE lock, no table scan — then
+  # VALIDATE separately, which only takes a SHARE UPDATE EXCLUSIVE lock and lets
+  # reward writes continue while it scans. Non-transactional so the two statements
+  # commit independently; a single transaction would hold the ADD's exclusive lock
+  # across the whole VALIDATE scan, defeating the point.
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    execute("""
+    ALTER TABLE fund_rewards
+      ADD CONSTRAINT approved_requires_payment
+      CHECK (status <> 'approved' OR payment_id IS NOT NULL)
+      NOT VALID
+    """)
+
+    execute("ALTER TABLE fund_rewards VALIDATE CONSTRAINT approved_requires_payment")
+  end
+
+  def down do
+    execute("ALTER TABLE fund_rewards DROP CONSTRAINT approved_requires_payment")
+  end
+end

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -410,10 +410,6 @@ defmodule Systems.Fund.Public do
     |> Repo.commit()
   end
 
-  # Create the payment entry BEFORE the status flip, so `cas_approve_step` can set
-  # status and payment_id in a single atomic update — the row is never transiently
-  # :approved with a nil payment_id (which the approved_requires_payment CHECK
-  # would reject). Reuse an already-linked payment if one somehow exists.
   defp approve_payment_step(multi, %Fund.RewardModel{payment: %Bookkeeping.EntryModel{} = payment}) do
     Multi.run(multi, :payment, fn _, _ -> {:ok, payment} end)
   end
@@ -424,9 +420,6 @@ defmodule Systems.Fund.Public do
     end)
   end
 
-  # Flip to :approved and set payment_id in one CAS update, using the entry the
-  # payment step created. The status precondition still serializes concurrent
-  # approvals: a losing writer updates 0 rows and rolls its payment back with the tx.
   defp cas_approve_step(multi, %Fund.RewardModel{} = reward, from_statuses, extra_set) do
     Multi.run(multi, :reward, fn repo, %{payment: %Bookkeeping.EntryModel{id: payment_id}} ->
       cas_update(

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -396,8 +396,8 @@ defmodule Systems.Fund.Public do
 
   defp do_approve_reward(%Fund.RewardModel{} = reward) do
     Multi.new()
-    |> cas_status_step(:reward, reward, [:reserved, :pending_approval], status: :approved)
     |> approve_payment_step(reward)
+    |> cas_approve_step(reward, [:reserved, :pending_approval], [])
     |> Repo.commit()
   end
 
@@ -405,46 +405,59 @@ defmodule Systems.Fund.Public do
   # from there (the `deposit: nil` branch of create_payment_transaction).
   defp do_override_rejected(%Fund.RewardModel{} = reward) do
     Multi.new()
-    |> cas_status_step(:reward, reward, [:rejected],
-      status: :approved,
-      rejection_reason: nil,
-      rejected_at: nil
-    )
     |> approve_payment_step(reward)
+    |> cas_approve_step(reward, [:rejected], rejection_reason: nil, rejected_at: nil)
     |> Repo.commit()
   end
 
-  # A reward must never be :approved with a nil payment_id.
-  defp approve_payment_step(multi, %Fund.RewardModel{payment: %Bookkeeping.EntryModel{}} = reward) do
-    Multi.run(multi, :payment, fn _, _ -> {:ok, reward} end)
+  # Create the payment entry BEFORE the status flip, so `cas_approve_step` can set
+  # status and payment_id in a single atomic update — the row is never transiently
+  # :approved with a nil payment_id (which the approved_requires_payment CHECK
+  # would reject). Reuse an already-linked payment if one somehow exists.
+  defp approve_payment_step(multi, %Fund.RewardModel{payment: %Bookkeeping.EntryModel{} = payment}) do
+    Multi.run(multi, :payment, fn _, _ -> {:ok, payment} end)
   end
 
   defp approve_payment_step(multi, %Fund.RewardModel{} = reward) do
     Multi.run(multi, :payment, fn _, _ ->
-      with {:ok, %{entry: payment}} <- create_payment_transaction(reward) do
-        link_payment_transaction(reward, payment)
-      end
+      with {:ok, %{entry: payment}} <- create_payment_transaction(reward), do: {:ok, payment}
     end)
+  end
+
+  # Flip to :approved and set payment_id in one CAS update, using the entry the
+  # payment step created. The status precondition still serializes concurrent
+  # approvals: a losing writer updates 0 rows and rolls its payment back with the tx.
+  defp cas_approve_step(multi, %Fund.RewardModel{} = reward, from_statuses, extra_set) do
+    Multi.run(multi, :reward, fn repo, %{payment: %Bookkeeping.EntryModel{id: payment_id}} ->
+      cas_update(
+        repo,
+        reward,
+        from_statuses,
+        [status: :approved, payment_id: payment_id] ++ extra_set
+      )
+    end)
+  end
+
+  defp cas_status_step(multi, name, %Fund.RewardModel{} = reward, from_statuses, set)
+       when is_list(from_statuses) and is_list(set) do
+    Multi.run(multi, name, fn repo, _ -> cas_update(repo, reward, from_statuses, set) end)
   end
 
   # Compare-and-swap: the status precondition serializes concurrent transitions
   # so a losing writer hits 0 rows and rolls back instead of double-applying.
-  defp cas_status_step(multi, name, %Fund.RewardModel{id: id}, from_statuses, set)
-       when is_list(from_statuses) and is_list(set) do
+  defp cas_update(repo, %Fund.RewardModel{id: id}, from_statuses, set) do
     set = Keyword.put_new(set, :updated_at, now())
 
-    Multi.run(multi, name, fn repo, _ ->
-      query =
-        from(r in Fund.RewardModel,
-          where: r.id == ^id and r.status in ^from_statuses,
-          select: r
-        )
+    query =
+      from(r in Fund.RewardModel,
+        where: r.id == ^id and r.status in ^from_statuses,
+        select: r
+      )
 
-      case repo.update_all(query, set: set) do
-        {1, [reward]} -> {:ok, reward}
-        {0, _} -> {:error, :stale_reward}
-      end
-    end)
+    case repo.update_all(query, set: set) do
+      {1, [reward]} -> {:ok, reward}
+      {0, _} -> {:error, :stale_reward}
+    end
   end
 
   defp now, do: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)

--- a/core/test/systems/fund/_public_test.exs
+++ b/core/test/systems/fund/_public_test.exs
@@ -577,7 +577,7 @@ defmodule Systems.Fund.PublicTest do
     end
 
     test "transitions :reserved → :approved and creates wallet payment", %{key: key} do
-      assert {:ok, %{reward: %{status: :approved}, payment: %{payment_id: payment_id}}} =
+      assert {:ok, %{reward: %{status: :approved, payment_id: payment_id}}} =
                Fund.Public.approve_reward(key)
 
       refute is_nil(payment_id)

--- a/core/test/systems/fund/reward_model_test.exs
+++ b/core/test/systems/fund/reward_model_test.exs
@@ -46,10 +46,6 @@ defmodule Systems.Fund.RewardModelTest do
     end
   end
 
-  # Guards the invariant at the database (approved_requires_payment CHECK), so a
-  # non-Multi path — a raw struct insert like Factories.insert! here — can't leave
-  # an approved reward without a payment. The app-level Multi is the primary path;
-  # this is the backstop.
   describe "approved_requires_payment constraint" do
     test "the database rejects an :approved reward with no payment" do
       assert_raise Ecto.ConstraintError, ~r/approved_requires_payment/, fn ->

--- a/core/test/systems/fund/reward_model_test.exs
+++ b/core/test/systems/fund/reward_model_test.exs
@@ -1,6 +1,8 @@
 defmodule Systems.Fund.RewardModelTest do
   use Core.DataCase
 
+  alias Core.Factories
+  alias Core.Repo
   alias Systems.Fund
 
   describe "status field" do
@@ -42,5 +44,37 @@ defmodule Systems.Fund.RewardModelTest do
       refute changeset.valid?
       assert "is invalid" in errors_on(changeset).status
     end
+  end
+
+  # Guards the invariant at the database (approved_requires_payment CHECK), so a
+  # non-Multi path — a raw struct insert like Factories.insert! here — can't leave
+  # an approved reward without a payment. The app-level Multi is the primary path;
+  # this is the backstop.
+  describe "approved_requires_payment constraint" do
+    test "the database rejects an :approved reward with no payment" do
+      assert_raise Ecto.ConstraintError, ~r/approved_requires_payment/, fn ->
+        Repo.insert!(reward(status: :approved, payment_id: nil))
+      end
+    end
+
+    test "an :approved reward with a payment is allowed" do
+      payment =
+        Factories.insert!(:book_entry, %{
+          idempotence_key: "pay-#{System.unique_integer([:positive])}",
+          journal_message: "reward payment"
+        })
+
+      assert %Fund.RewardModel{status: :approved} =
+               Repo.insert!(reward(status: :approved, payment_id: payment.id))
+    end
+
+    test "a non-approved reward with no payment is allowed" do
+      assert %Fund.RewardModel{status: :reserved} = Repo.insert!(reward(status: :reserved))
+    end
+  end
+
+  defp reward(attrs) do
+    defaults = %{idempotence_key: "rwd-#{System.unique_integer([:positive])}", amount: 100}
+    Factories.build(:reward, Map.merge(defaults, Map.new(attrs)))
   end
 end


### PR DESCRIPTION
Add a CHECK constraint on fund_rewards (status <> 'approved' OR payment_id IS NOT NULL) so the invariant can't be broken by a future non-Multi path. Currently it is only guaranteed by the approval Multi in app code.

The constraint is evaluated per-statement and Postgres cannot defer CHECKs, so the approval Multi had to stop transiently leaving a reward :approved with a null payment_id: create the payment bookkeeping entry first, then a single compare-and-swap sets status and payment_id together. The CAS still serializes concurrent approvals — a losing writer updates 0 rows and rolls its payment back with the transaction.

The migration adds the constraint NOT VALID then VALIDATEs it separately, so the deploy never holds an exclusive lock across the validation scan.

Addresses the "approved rewards must have payment_id" tech-debt ticket (nonblocker from PR #1503 review).