### PR TITLE
refactor: collapse hand-rolled owner lookups onto the auth API

### DIFF
--- a/core/lib/core/authorization.ex
+++ b/core/lib/core/authorization.ex
@@ -267,7 +267,8 @@ defmodule Core.Authorization do
 
     Ecto.Query.from(u in Systems.Account.User,
       where: u.id in subquery(principal_ids),
-      preload: ^preload
+      preload: ^preload,
+      order_by: u.id
     )
     |> Core.Repo.all()
   end
@@ -277,7 +278,8 @@ defmodule Core.Authorization do
 
     Ecto.Query.from(u in Systems.Account.User,
       where: u.id in subquery(principal_ids),
-      preload: ^preload
+      preload: ^preload,
+      order_by: u.id
     )
     |> Core.Repo.all()
   end
@@ -302,7 +304,8 @@ defmodule Core.Authorization do
 
     from(u in Systems.Account.User,
       where: u.id in subquery(principal_ids),
-      preload: ^preload
+      preload: ^preload,
+      order_by: u.id
     )
     |> Core.Repo.all()
   end
@@ -314,28 +317,6 @@ defmodule Core.Authorization do
   def user_has_role?(user_id, entity, role) do
     users_with_role(entity, role)
     |> Enum.any?(&(&1.id == user_id))
-  end
-
-  def first_user_with_role(entity, role, preload) do
-    user =
-      entity
-      |> users_with_role(role, preload)
-      |> List.first()
-
-    case user do
-      nil ->
-        Logger.error("No user found with role #{role} for #{entity}")
-        {:error}
-
-      user ->
-        {:ok, user}
-    end
-  end
-
-  def top_entity(%{auth_node_id: _auth_node_id} = entity) do
-    entity
-    |> get_parent_nodes()
-    |> List.last()
   end
 
   def link(auth_tree) do

--- a/core/systems/advert/_public.ex
+++ b/core/systems/advert/_public.ex
@@ -217,15 +217,9 @@ defmodule Systems.Advert.Public do
   defp list_excluded_assignment_ids(_), do: []
 
   def list_owners(%Advert.Model{} = advert, preload \\ []) do
-    owner_ids =
-      advert
-      |> auth_module().list_principals()
-      |> Enum.filter(fn %{roles: roles} -> MapSet.member?(roles, :owner) end)
-      |> Enum.map(fn %{id: id} -> id end)
-
-    from(u in User, where: u.id in ^owner_ids, preload: ^preload, order_by: u.id) |> Repo.all()
     # AUTH: needs to be marked save. Current user is normally not allowed to
     # access other users.
+    auth_module().users_with_role(advert, :owner, preload)
   end
 
   def assign_owners(advert, users) do

--- a/core/systems/assignment/_public.ex
+++ b/core/systems/assignment/_public.ex
@@ -477,9 +477,10 @@ defmodule Systems.Assignment.Public do
     end
   end
 
+  # Only entities that carry an auth node: a Workflow.ItemModel has none, so it
+  # has no tree to resolve an owner from.
   def owner!(%Assignment.Model{} = assignment), do: parent_owner!(assignment)
   def owner!(%Workflow.Model{} = workflow), do: parent_owner!(workflow)
-  def owner!(%Workflow.ItemModel{} = item), do: parent_owner!(item)
 
   def assign_tester_role(tool, user) do
     %{crew: crew} = get_by_tool(tool, [:crew])
@@ -489,17 +490,18 @@ defmodule Systems.Assignment.Public do
     end
   end
 
-  defp parent_owner!(entity) do
-    case parent_owner(entity) do
-      {:ok, user} -> user
-      _ -> nil
-    end
-  end
+  # Resolves the owner the way `can?/3` does: a role granted anywhere up the
+  # tree applies here. Asking only the top entity would miss an owner assigned
+  # on an intermediate node.
+  defp parent_owner!(%struct{auth_node_id: _auth_node_id, id: id} = entity) do
+    case auth_module().users_with_inherited_role(entity, :owner) do
+      [owner | _] ->
+        owner
 
-  defp parent_owner(%{auth_node_id: _auth_node_id} = entity) do
-    entity
-    |> auth_module().top_entity()
-    |> auth_module().first_user_with_role(:owner, [])
+      [] ->
+        Logger.error("No owner found for #{inspect(struct)} #{id}")
+        nil
+    end
   end
 
   def expiration_timestamp(%{info: info}) do

--- a/core/systems/project/_public.ex
+++ b/core/systems/project/_public.ex
@@ -11,7 +11,6 @@ defmodule Systems.Project.Public do
 
   alias Frameworks.Signal
 
-  alias Systems.Account.User
   alias Systems.Advert
   alias Systems.Assignment
   alias Systems.Graphite
@@ -351,13 +350,7 @@ defmodule Systems.Project.Public do
   end
 
   def list_owners(%Project.Model{} = project, preload \\ []) do
-    owner_ids =
-      project
-      |> auth_module().list_principals()
-      |> Enum.filter(fn %{roles: roles} -> MapSet.member?(roles, :owner) end)
-      |> Enum.map(fn %{id: id} -> id end)
-
-    from(u in User, where: u.id in ^owner_ids, preload: ^preload, order_by: u.id) |> Repo.all()
+    auth_module().users_with_role(project, :owner, preload)
   end
 end
 

--- a/core/test/systems/assignment/_public_test.exs
+++ b/core/test/systems/assignment/_public_test.exs
@@ -1000,6 +1000,77 @@ defmodule Systems.Assignment.PublicTest do
     end
   end
 
+  describe "owner!/1" do
+    test "finds an owner assigned on the top of the tree" do
+      %{id: user_id} = user = Factories.insert!(:creator)
+      top = Core.Authorization.create_node!()
+      assignment = assignment_under(Core.Authorization.create_node!(top))
+
+      :ok = assign_owner(user, top)
+
+      assert %{id: ^user_id} = Assignment.Public.owner!(assignment)
+    end
+
+    # The reason for using users_with_inherited_role/3 over a walk to the top
+    # entity: an owner assigned halfway up the tree is a real configuration and
+    # asking only the top node would miss it.
+    test "finds an owner assigned on an intermediate node" do
+      %{id: user_id} = user = Factories.insert!(:creator)
+      middle = Core.Authorization.create_node!(Core.Authorization.create_node!())
+      assignment = assignment_under(Core.Authorization.create_node!(middle))
+
+      :ok = assign_owner(user, middle)
+
+      assert %{id: ^user_id} = Assignment.Public.owner!(assignment)
+    end
+
+    test "finds an owner assigned directly on the assignment" do
+      %{id: user_id} = user = Factories.insert!(:creator)
+      node = Core.Authorization.create_node!(Core.Authorization.create_node!())
+      assignment = assignment_under(node)
+
+      :ok = assign_owner(user, node)
+
+      assert %{id: ^user_id} = Assignment.Public.owner!(assignment)
+    end
+
+    test "ignores a role that is not :owner" do
+      user = Factories.insert!(:creator)
+      top = Core.Authorization.create_node!()
+      assignment = assignment_under(Core.Authorization.create_node!(top))
+
+      :ok = Core.Authorization.assign_role(user, node_id(top), :participant)
+
+      assert Assignment.Public.owner!(assignment) == nil
+    end
+
+    test "does not pick up an owner from a sibling tree" do
+      user = Factories.insert!(:creator)
+      assignment = assignment_under(Core.Authorization.create_node!())
+
+      :ok = assign_owner(user, Core.Authorization.create_node!())
+
+      assert Assignment.Public.owner!(assignment) == nil
+    end
+
+    test "returns nil when the tree carries no owner" do
+      assignment = assignment_under(Core.Authorization.create_node!())
+
+      assert Assignment.Public.owner!(assignment) == nil
+    end
+  end
+
+  defp assignment_under(%Core.Authorization.Node{id: parent_id}) do
+    auth_node = Factories.insert!(:auth_node, %{parent_id: parent_id})
+    Factories.insert!(:assignment, %{auth_node: auth_node})
+  end
+
+  # assign_role/3 resolves its target through the AuthorizationNode protocol,
+  # which a raw Node struct does not implement — it takes the id.
+  defp assign_owner(user, node), do: Core.Authorization.assign_role(user, node_id(node), :owner)
+
+  defp node_id(%Core.Authorization.Node{id: id}), do: id
+
   defp funded_assignment(fund, subject_reward) do
     info =
       Factories.insert!(:assignment_info, %{


### PR DESCRIPTION
Basecamp issue:
- [10143571966](https://app.basecamp.com/5734045/buckets/35926565/todos/10143571966)