### PR TITLE
fix(assignment): highlight BudgetForm fields on focus

### DIFF
--- a/core/systems/assignment/budget_form.ex
+++ b/core/systems/assignment/budget_form.ex
@@ -191,7 +191,7 @@ defmodule Systems.Assignment.BudgetForm do
     assigns = assign(assigns, :confirm_enabled?, confirm_enabled?(assigns))
 
     ~H"""
-    <div>
+    <div id={"#{@id}_content"} phx-hook="LiveContent" data-show-errors={true}>
       <Text.title3>
         <%= dgettext("eyra-assignment", "budget_form.title") %>
       </Text.title3>


### PR DESCRIPTION
Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/10143882079

## Summary

The Add-participants modal (`Assignment.BudgetForm`) rendered its inputs without an enclosing `LiveContent` hook. `LiveField` dispatched `field-activated` / `field-deactivated` on focus, but they bubbled out of the modal (portalled to a `fixed z-50` layer, outside the page's `LiveContent` tree) and landed nowhere. Result: label + border never turned blue on focus.

Wrap the form's outer `<div>` in `phx-hook="LiveContent"` so the events have a listener — same pattern the other modal-hosted forms (storage endpoint forms, signup, reset-password) already use.

## Test plan

- [x] `mix test.ci` — green
- [ ] Manual on staging after auto-deploy: open an assignment's Add-participants modal → click into the participant fee, aim-of-study text, and number-of-participants inputs → label + border should turn blue on focus, back to grey on blur.

Follow-up: FX 10167806368 — replace the disabled Confirm button with an always-enabled variant + inline error messages under invalid fields (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)