### PR TITLE
refactor: rename :live_view / :live_component to _fabric variants

### DIFF
--- a/core/bundles/next/lib/account/auth_code_verify_page.ex
+++ b/core/bundles/next/lib/account/auth_code_verify_page.ex
@@ -1,5 +1,5 @@
 defmodule Next.Account.AuthCodeVerifyPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/bundles/next/lib/account/auth_page.ex
+++ b/core/bundles/next/lib/account/auth_page.ex
@@ -1,5 +1,5 @@
 defmodule Next.Account.AuthPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/bundles/next/lib/account/auth_signup_page.ex
+++ b/core/bundles/next/lib/account/auth_signup_page.ex
@@ -1,5 +1,5 @@
 defmodule Next.Account.AuthSignupPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/bundles/next/lib/account/creator_signin_view.ex
+++ b/core/bundles/next/lib/account/creator_signin_view.ex
@@ -1,5 +1,5 @@
 defmodule Next.Account.CreatorSigninView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Line
   import Systems.Account.UserForm

--- a/core/bundles/next/lib/account/participant_signin_view.ex
+++ b/core/bundles/next/lib/account/participant_signin_view.ex
@@ -1,5 +1,5 @@
 defmodule Next.Account.ParticipantSigninView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Line
   import Systems.Account.UserForm

--- a/core/bundles/next/lib/account/signin_page.ex
+++ b/core/bundles/next/lib/account/signin_page.ex
@@ -1,5 +1,5 @@
 defmodule Next.Account.SigninPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/bundles/self/lib/account/signin_page.ex
+++ b/core/bundles/self/lib/account/signin_page.ex
@@ -1,5 +1,5 @@
 defmodule Self.Account.SigninPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/frameworks/pixel/components/breadcrumbs.ex
+++ b/core/frameworks/pixel/components/breadcrumbs.ex
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.Breadcrumbs do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{elements: elements}, %{assigns: %{}} = socket) do

--- a/core/frameworks/pixel/components/confirmation_modal.ex
+++ b/core/frameworks/pixel/components/confirmation_modal.ex
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.ConfirmationModal do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{assigns: assigns}, socket) do

--- a/core/frameworks/pixel/components/dropdown_selector.ex
+++ b/core/frameworks/pixel/components/dropdown_selector.ex
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.DropdownSelector do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.FormHelpers, only: [get_border_color: 1]
 

--- a/core/frameworks/pixel/components/image_catalog_picker.ex
+++ b/core/frameworks/pixel/components/image_catalog_picker.ex
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.ImageCatalogPicker do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import CoreWeb.UI.Dialog
   import CoreWeb.LiveDefaults

--- a/core/frameworks/pixel/components/notification_view.ex
+++ b/core/frameworks/pixel/components/notification_view.ex
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.NotificationView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Text
 

--- a/core/frameworks/pixel/components/radio_group.ex
+++ b/core/frameworks/pixel/components/radio_group.ex
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.RadioGroup do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{items: items}, socket) do

--- a/core/frameworks/pixel/components/search_bar.ex
+++ b/core/frameworks/pixel/components/search_bar.ex
@@ -1,6 +1,6 @@
 defmodule Frameworks.Pixel.SearchBar do
   @moduledoc false
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(

--- a/core/frameworks/pixel/components/selector.ex
+++ b/core/frameworks/pixel/components/selector.ex
@@ -1,6 +1,6 @@
 defmodule Frameworks.Pixel.Selector do
   @moduledoc false
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import CoreWeb.LiveDefaults
   alias Phoenix.LiveView.JS

--- a/core/frameworks/pixel/components/switch.ex
+++ b/core/frameworks/pixel/components/switch.ex
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.Switch do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel
 

--- a/core/frameworks/pixel/components/toolbar.ex
+++ b/core/frameworks/pixel/components/toolbar.ex
@@ -3,7 +3,7 @@ defmodule Frameworks.Pixel.Toolbar do
   Toolbar LiveComponent that centralizes button event handling and forwards events
   to the parent via LiveNest events.
   """
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Line
   alias Frameworks.Pixel.Button

--- a/core/frameworks/pixel/components/user_list_item.ex
+++ b/core/frameworks/pixel/components/user_list_item.ex
@@ -2,7 +2,7 @@ defmodule Frameworks.Pixel.UserListItem do
   @moduledoc """
     User list item
   """
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Button
   alias Frameworks.Pixel.Text

--- a/core/lib/core_web.ex
+++ b/core/lib/core_web.ex
@@ -85,7 +85,7 @@ defmodule CoreWeb do
     end
   end
 
-  def live_component do
+  def live_component_fabric do
     quote do
       use Fabric.LiveComponent
       use LiveNest, :live_component
@@ -99,7 +99,7 @@ defmodule CoreWeb do
 
   # DEPRECATED: Use routed_live_view for LiveNest-based views.
   # This version includes Fabric.ModalPresenter which is only needed for Fabric sub-components.
-  def live_view do
+  def live_view_fabric do
     quote do
       use Phoenix.LiveView, layout: {unquote(CoreWeb.Layouts), :live}
       use LiveNest, :routed_live_view

--- a/core/lib/core_web/live/component_test_live.ex
+++ b/core/lib/core_web/live/component_test_live.ex
@@ -1,5 +1,5 @@
 defmodule CoreWeb.ComponentTestLive do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   @impl true
   def mount(_params, session, socket) do

--- a/core/lib/core_web/live/fake_qualtrics.ex
+++ b/core/lib/core_web/live/fake_qualtrics.ex
@@ -2,7 +2,7 @@ defmodule CoreWeb.FakeQualtrics do
   @moduledoc """
   The home screen.
   """
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
   alias Frameworks.Pixel.Text
   alias Frameworks.Pixel.Button
 

--- a/core/lib/core_web/live_form.ex
+++ b/core/lib/core_web/live_form.ex
@@ -11,7 +11,7 @@ defmodule CoreWeb.LiveForm do
 
   This is equivalent to:
 
-      use CoreWeb, :live_component
+      use CoreWeb, :live_component_fabric
       use CoreWeb.Live.FlashHelpers
       use CoreWeb.Live.FormHelpers
 
@@ -20,7 +20,7 @@ defmodule CoreWeb.LiveForm do
 
   defmacro __using__(_) do
     quote do
-      use CoreWeb, :live_component
+      use CoreWeb, :live_component_fabric
       use CoreWeb.Live.FlashHelpers
 
       import Frameworks.Pixel.Form

--- a/core/lib/core_web/ui/dialog/plain.ex
+++ b/core/lib/core_web/ui/dialog/plain.ex
@@ -1,5 +1,5 @@
 defmodule CoreWeb.UI.Dialog.Plain do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   use Gettext, backend: CoreWeb.Gettext
 
   import CoreWeb.UI.Dialog

--- a/core/systems/account/await_confirmation.ex
+++ b/core/systems/account/await_confirmation.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Account.AwaitConfirmation do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.User, __MODULE__})

--- a/core/systems/account/confirm_token.ex
+++ b/core/systems/account/confirm_token.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Account.ConfirmToken do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/systems/account/phone_form.ex
+++ b/core/systems/account/phone_form.ex
@@ -10,7 +10,7 @@ defmodule Systems.Account.PhoneForm do
   form, so the participant fills in their number and continues straight to their
   bank. Cancelling is handled by the modal chrome's close control.
   """
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   require Logger
 

--- a/core/systems/account/reset_password.ex
+++ b/core/systems/account/reset_password.ex
@@ -2,7 +2,7 @@ defmodule Systems.Account.ResetPassword do
   @moduledoc """
   The home screen.
   """
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/systems/account/reset_password_token.ex
+++ b/core/systems/account/reset_password_token.ex
@@ -2,7 +2,7 @@ defmodule Systems.Account.ResetPasswordToken do
   @moduledoc """
   The password reset token.
   """
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/systems/account/signup_page.ex
+++ b/core/systems/account/signup_page.ex
@@ -2,7 +2,7 @@ defmodule Systems.Account.SignupPage do
   @moduledoc """
   The home screen.
   """
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/systems/admin/login_page.ex
+++ b/core/systems/admin/login_page.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Admin.LoginPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.User, __MODULE__})

--- a/core/systems/admin/typography_page.ex
+++ b/core/systems/admin/typography_page.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Admin.TypographyPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.User, __MODULE__})

--- a/core/systems/advert/list_view.ex
+++ b/core/systems/advert/list_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Advert.ListView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Empty
   import Frameworks.Pixel.Content

--- a/core/systems/advert/monitor_view.ex
+++ b/core/systems/advert/monitor_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Advert.MonitorView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Widget
 

--- a/core/systems/advert/settings_view.ex
+++ b/core/systems/advert/settings_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Advert.SettingsView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   require Systems.Advert.Themes
 
   alias Frameworks.Pixel.AlertBanner

--- a/core/systems/alliance/task_view.ex
+++ b/core/systems/alliance/task_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Alliance.TaskView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Utility.LiveCommand
   import Frameworks.Pixel.Navigation, only: [button_bar: 1]

--- a/core/systems/assignment/affiliate_view.ex
+++ b/core/systems/assignment/affiliate_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.AffiliateView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.Affiliate
 

--- a/core/systems/assignment/connection_view.ex
+++ b/core/systems/assignment/connection_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.ConnectionView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Panel
 

--- a/core/systems/assignment/connection_view_storage.ex
+++ b/core/systems/assignment/connection_view_storage.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.ConnectionViewStorage do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.Assignment
 

--- a/core/systems/assignment/connector_popup_storage.ex
+++ b/core/systems/assignment/connector_popup_storage.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.ConnectorPopupStorage do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import CoreWeb.UI.Dialog
 

--- a/core/systems/assignment/connector_view.ex
+++ b/core/systems/assignment/connector_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.ConnectorView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.{
     Assignment

--- a/core/systems/assignment/content_page_form.ex
+++ b/core/systems/assignment/content_page_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.ContentPageForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel
   alias Systems.Assignment

--- a/core/systems/assignment/declined_view.ex
+++ b/core/systems/assignment/declined_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.DeclinedView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   use Gettext, backend: CoreWeb.Gettext
 

--- a/core/systems/assignment/gdpr_form.ex
+++ b/core/systems/assignment/gdpr_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.GdprForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel
   alias Systems.Assignment

--- a/core/systems/assignment/landing_page.ex
+++ b/core/systems/assignment/landing_page.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.LandingPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
   use CoreWeb.Layouts.Stripped.Composer
 
   alias Systems.Assignment

--- a/core/systems/assignment/monitor_view.ex
+++ b/core/systems/assignment/monitor_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.MonitorView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Widget
 

--- a/core/systems/assignment/participants_view.ex
+++ b/core/systems/assignment/participants_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.ParticipantsView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   use Gettext, backend: CoreWeb.Gettext
   use Systems.Assignment.PaidSlotsLogic

--- a/core/systems/assignment/payout_modal.ex
+++ b/core/systems/assignment/payout_modal.ex
@@ -24,7 +24,7 @@ defmodule Systems.Assignment.PayoutModal do
   per-row Decline expansion + bulk "Pay out all"; `:overview` shows historical
   approvals + rejections (UI lands in commit C).
   """
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   require Logger
 

--- a/core/systems/assignment/settings_view.ex
+++ b/core/systems/assignment/settings_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.SettingsView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.Affiliate
   alias Systems.Assignment

--- a/core/systems/assignment/storage_view.ex
+++ b/core/systems/assignment/storage_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Assignment.StorageView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.RadioGroup
   alias Systems.Project

--- a/core/systems/citizen/overview.ex
+++ b/core/systems/citizen/overview.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Citizen.Overview do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.SearchBar
   alias Frameworks.Pixel.Text

--- a/core/systems/citizen/pool/form.ex
+++ b/core/systems/citizen/pool/form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Citizen.Pool.Form do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   require Logger
 

--- a/core/systems/citizen/pool/overview_plugin.ex
+++ b/core/systems/citizen/pool/overview_plugin.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Citizen.Pool.OverviewPlugin do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   use Gettext, backend: CoreWeb.Gettext
 

--- a/core/systems/consent/signature_view.ex
+++ b/core/systems/consent/signature_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Consent.SignatureView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{title: title, signature: signature}, %{assigns: %{}} = socket) do

--- a/core/systems/content/composer.ex
+++ b/core/systems/content/composer.ex
@@ -9,7 +9,7 @@ defmodule Systems.Content.Composer do
 
   def __using_live_website__ do
     quote do
-      use CoreWeb, :live_view
+      use CoreWeb, :live_view_fabric
 
       use CoreWeb.Layouts.Website.Composer
       use CoreWeb.LiveDefaults
@@ -21,7 +21,7 @@ defmodule Systems.Content.Composer do
 
   def __using_live_workspace__ do
     quote do
-      use CoreWeb, :live_view
+      use CoreWeb, :live_view_fabric
 
       use CoreWeb.Layouts.Workspace.Composer
       use CoreWeb.LiveDefaults

--- a/core/systems/content/context_menu.ex
+++ b/core/systems/content/context_menu.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Content.ContextMenu do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{items: items}, %{assigns: %{}} = socket) do

--- a/core/systems/content/file_copy_view.ex
+++ b/core/systems/content/file_copy_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Content.FileCopyView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Panel
   alias Frameworks.Pixel.Annotation

--- a/core/systems/content/page_view.ex
+++ b/core/systems/content/page_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Content.PageView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.Content
 

--- a/core/systems/crew/reject_view.ex
+++ b/core/systems/crew/reject_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Crew.RejectView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   require Logger
 

--- a/core/systems/desktop/view.ex
+++ b/core/systems/desktop/view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Desktop.View do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Content
   alias Frameworks.Pixel.Text

--- a/core/systems/document/pdf_nav_view.ex
+++ b/core/systems/document/pdf_nav_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Document.PDFNavView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   import Frameworks.Pixel.Line
 
   alias Systems.Document

--- a/core/systems/document/pdf_view.ex
+++ b/core/systems/document/pdf_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Document.PDFView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{key: key, url: url} = params, socket) do

--- a/core/systems/email/dialog.ex
+++ b/core/systems/email/dialog.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Email.Dialog do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Text
 

--- a/core/systems/email/form.ex
+++ b/core/systems/email/form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Email.Form do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias CoreWeb.UI.Timestamp
   import Frameworks.Pixel.Tag

--- a/core/systems/feldspar/app_page.ex
+++ b/core/systems/feldspar/app_page.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Feldspar.AppPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Uri, __MODULE__})

--- a/core/systems/feldspar/app_view.ex
+++ b/core/systems/feldspar/app_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Feldspar.AppView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{key: key, url: url, locale: locale} = params, socket) do

--- a/core/systems/fund/bank_account_form.ex
+++ b/core/systems/fund/bank_account_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Fund.BankAccountForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Ecto.Changeset
 

--- a/core/systems/fund/deposit_form.ex
+++ b/core/systems/fund/deposit_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Fund.DepositForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Ecto.Changeset
 

--- a/core/systems/fund/form.ex
+++ b/core/systems/fund/form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Fund.Form do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   require Logger
 

--- a/core/systems/graphite/leaderboard_page.ex
+++ b/core/systems/graphite/leaderboard_page.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Graphite.LeaderboardPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
   use CoreWeb.Layouts.Stripped.Composer
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})

--- a/core/systems/graphite/leaderboard_scores_view.ex
+++ b/core/systems/graphite/leaderboard_scores_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Graphite.LeaderboardScoresView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.{
     Graphite

--- a/core/systems/graphite/leaderboard_settings_view.ex
+++ b/core/systems/graphite/leaderboard_settings_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Graphite.LeaderboardSettingsView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.{
     Graphite

--- a/core/systems/graphite/leaderboard_submissions_view.ex
+++ b/core/systems/graphite/leaderboard_submissions_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Graphite.LeaderboardSubmissionsView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.Graphite
 

--- a/core/systems/graphite/leaderboard_table_view.ex
+++ b/core/systems/graphite/leaderboard_table_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Graphite.LeaderboardTableView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Selector
   alias Frameworks.Pixel.Align

--- a/core/systems/graphite/submission_form.ex
+++ b/core/systems/graphite/submission_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Graphite.SubmissionForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Form
 

--- a/core/systems/graphite/submission_overview.ex
+++ b/core/systems/graphite/submission_overview.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Graphite.SubmissionOverview do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.{
     Graphite

--- a/core/systems/home/adverts_view.ex
+++ b/core/systems/home/adverts_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Home.AdvertsView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Grid
   alias Frameworks.Pixel.Logo

--- a/core/systems/home/guest_view.ex
+++ b/core/systems/home/guest_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Home.GuestView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   import Systems.Home.HTML
 
   @impl true

--- a/core/systems/home/logged_in_view.ex
+++ b/core/systems/home/logged_in_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Home.LoggedInView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(%{blocks: blocks}, socket) do

--- a/core/systems/home/next_best_action_view.ex
+++ b/core/systems/home/next_best_action_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Home.NextBestActionView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.NextAction
 

--- a/core/systems/home/participated_view.ex
+++ b/core/systems/home/participated_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Home.ParticipatedView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Image
   alias Frameworks.Pixel.Text

--- a/core/systems/home/rewards_summary_view.ex
+++ b/core/systems/home/rewards_summary_view.ex
@@ -18,7 +18,7 @@ defmodule Systems.Home.RewardsSummaryView do
   All i18n is resolved by `Systems.Home.PageBuilder`; this view only renders
   the supplied `labels`.
   """
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel
   alias Frameworks.Pixel.Button

--- a/core/systems/instruction/download_form.ex
+++ b/core/systems/instruction/download_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Instruction.DownloadForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   use CoreWeb.FileUploader, accept: ~w(.zip)
 
   use Gettext, backend: CoreWeb.Gettext

--- a/core/systems/instruction/general_form.ex
+++ b/core/systems/instruction/general_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Instruction.GeneralForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   use Gettext, backend: CoreWeb.Gettext
 

--- a/core/systems/lab/check_in_view.ex
+++ b/core/systems/lab/check_in_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Lab.CheckInView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   use Gettext, backend: CoreWeb.Gettext
   require Logger
 

--- a/core/systems/lab/day_entry_view.ex
+++ b/core/systems/lab/day_entry_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Lab.DayEntryView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Line
   alias Frameworks.Pixel.Selector

--- a/core/systems/lab/day_view.ex
+++ b/core/systems/lab/day_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Lab.DayView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   require Logger
 

--- a/core/systems/lab/public_page.ex
+++ b/core/systems/lab/public_page.ex
@@ -2,7 +2,7 @@ defmodule Systems.Lab.PublicPage do
   @moduledoc """
   The public lab screen.
   """
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   alias Systems.Lab
 

--- a/core/systems/lab/task_view.ex
+++ b/core/systems/lab/task_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Lab.TaskView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Navigation, only: [button_bar: 1]
   alias Frameworks.Utility.LiveCommand

--- a/core/systems/manual/builder/chapter_list_view.ex
+++ b/core/systems/manual/builder/chapter_list_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Manual.Builder.ChapterListView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Systems.Manual.Builder.Html, only: [chapter_list: 1]
 

--- a/core/systems/manual/builder/page_list_view.ex
+++ b/core/systems/manual/builder/page_list_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Manual.Builder.PageListView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Systems.Manual.Builder.Html, only: [page_list_item: 1]
 

--- a/core/systems/manual/builder/view.ex
+++ b/core/systems/manual/builder/view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Manual.Builder.View do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.Manual
 

--- a/core/systems/manual/chapter_list_view.ex
+++ b/core/systems/manual/chapter_list_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Manual.ChapterListView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Systems.Manual.Html
 

--- a/core/systems/manual/chapter_view.ex
+++ b/core/systems/manual/chapter_view.ex
@@ -3,7 +3,7 @@ defmodule Systems.Manual.ChapterView do
     Chapter View divided into Desktop and Mobile views.
   """
 
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   use Gettext, backend: CoreWeb.Gettext
 
   import Systems.Manual.Html, only: [chapter_desktop: 1, chapter_mobile: 1]

--- a/core/systems/manual/tool_form.ex
+++ b/core/systems/manual/tool_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Manual.Builder.ToolForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Annotation
   alias Systems.Manual

--- a/core/systems/notification/overview_page.ex
+++ b/core/systems/notification/overview_page.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Notification.OverviewPage do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
   alias Systems.Notification
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})

--- a/core/systems/pool/marketplace_view.ex
+++ b/core/systems/pool/marketplace_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Pool.MarketplaceView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Grid
   alias Frameworks.Pixel.SearchBar

--- a/core/systems/project/create_item_view.ex
+++ b/core/systems/project/create_item_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Project.CreateItemView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import CoreWeb.UI.Dialog
 

--- a/core/systems/project/item_monitor_view.ex
+++ b/core/systems/project/item_monitor_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Project.ItemMonitorView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def render(assigns) do

--- a/core/systems/project/node_page_empty_data_view.ex
+++ b/core/systems/project/node_page_empty_data_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Project.NodePageEmptyDataView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Systems.Project
 

--- a/core/systems/project/node_page_grid_view.ex
+++ b/core/systems/project/node_page_grid_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Project.NodePageGridView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Empty
   alias Frameworks.Pixel.Grid

--- a/core/systems/storage/empty_confirmation_view.ex
+++ b/core/systems/storage/empty_confirmation_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Storage.EmptyConfirmationView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Form
 

--- a/core/systems/storage/endpoint_data_view.ex
+++ b/core/systems/storage/endpoint_data_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Storage.EndpointDataView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Spinner
   alias Frameworks.Pixel.SearchBar

--- a/core/systems/storage/endpoint_files_view.ex
+++ b/core/systems/storage/endpoint_files_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Storage.EndpointFilesView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias CoreWeb.UI.Timestamp
   alias Systems.Storage

--- a/core/systems/storage/endpoint_monitor_view.ex
+++ b/core/systems/storage/endpoint_monitor_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Storage.EndpointMonitorView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Widget
 

--- a/core/systems/storage/endpoint_settings_view.ex
+++ b/core/systems/storage/endpoint_settings_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Storage.EndpointSettingsView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Concept
   alias Systems.Storage

--- a/core/systems/student/overview.ex
+++ b/core/systems/student/overview.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Student.Overview do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.SearchBar
   alias Frameworks.Pixel.Text

--- a/core/systems/student/pool/dashboard_view.ex
+++ b/core/systems/student/pool/dashboard_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Student.Pool.DashboardView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Pixel.Widget
 

--- a/core/systems/student/pool/overview_plugin.ex
+++ b/core/systems/student/pool/overview_plugin.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Student.Pool.OverviewPlugin do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   use Gettext, backend: CoreWeb.Gettext
 

--- a/core/systems/support/helpdesk_form.ex
+++ b/core/systems/support/helpdesk_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Support.HelpdeskForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   import Frameworks.Pixel.Form
 

--- a/core/systems/support/overview_tab.ex
+++ b/core/systems/support/overview_tab.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Support.OverviewTab do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Core.ImageHelpers
   import Frameworks.Pixel.Content

--- a/core/systems/test/page.ex
+++ b/core/systems/test/page.ex
@@ -2,7 +2,7 @@ defmodule Systems.Test.Page do
   @moduledoc """
   The page for testing the view model observations
   """
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   on_mount({CoreWeb.Live.Hook.Base, __MODULE__})
   on_mount({CoreWeb.Live.Hook.Model, __MODULE__})

--- a/core/systems/workflow/builder_view.ex
+++ b/core/systems/workflow/builder_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Workflow.BuilderView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   require Logger
 

--- a/core/systems/workflow/item_cell.ex
+++ b/core/systems/workflow/item_cell.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Workflow.ItemCell do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   alias Frameworks.Concept
   alias Systems.Workflow

--- a/core/systems/workflow/work_list_view.ex
+++ b/core/systems/workflow/work_list_view.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Workflow.WorkListView do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
   use Gettext, backend: CoreWeb.Gettext
 
   import Systems.Workflow.HTML, only: [work_list_item: 1]

--- a/core/systems/zircon/screening/tool_form.ex
+++ b/core/systems/zircon/screening/tool_form.ex
@@ -1,5 +1,5 @@
 defmodule Systems.Zircon.Screening.ToolForm do
-  use CoreWeb, :live_component
+  use CoreWeb, :live_component_fabric
 
   @impl true
   def update(_params, socket) do

--- a/core/test/frameworks/pixel/selector_test.exs
+++ b/core/test/frameworks/pixel/selector_test.exs
@@ -1,5 +1,5 @@
 defmodule Frameworks.Pixel.SelectorTest.View do
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   alias Frameworks.Pixel.Selector
 

--- a/core/test/systems/assignment/payout_modal_test.exs
+++ b/core/test/systems/assignment/payout_modal_test.exs
@@ -7,7 +7,7 @@ defmodule Systems.Assignment.PayoutModalTest.Host do
   test asked for, which is exactly the contract the real parent has with the
   modal: the modal bubbles up, the parent mutates, the parent signals back.
   """
-  use CoreWeb, :live_view
+  use CoreWeb, :live_view_fabric
 
   alias Systems.Assignment
 


### PR DESCRIPTION
## Summary

Prep step for the Fabric retirement epic ([Basecamp](https://3.basecamp.com/5734045/buckets/35926565/todos/10167834144)). Mechanical rename of the two `CoreWeb` macros still layering `use Fabric.LiveView` / `use Fabric.LiveComponent` on top of LiveNest, plus every consumer's `use` line.

- `def live_view` → `def live_view_fabric` (23 consumers renamed)
- `def live_component` → `def live_component_fabric` (93 consumers renamed)

Zero behaviour change — same macro bodies, just renamed atoms. The pure-LiveNest `:routed_live_view`, `:embedded_live_view`, `:modal_live_view` macros are untouched.

## Why now

After the rename lands, subsequent PRs can define new pure-LiveNest `:live_component` (and later `:live_view`) macros that migrations opt into. "Who still needs migrating off Fabric" becomes `grep _fabric`, and the closing PR of the epic just deletes the `_fabric` macro definitions.

Tracked in Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/10167999061

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix test.ci` passes (2526 tests)
- [x] Pre-commit hook: compile / format / test / credo / dialyzer all green
- [ ] CI green on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)