### PR TITLE
fix(home): make participant Home page fit within mobile viewport

### DIFF
--- a/core/systems/home/participated_view.ex
+++ b/core/systems/home/participated_view.ex
@@ -1,7 +1,6 @@
 defmodule Systems.Home.ParticipatedView do
   use CoreWeb, :live_component
 
-  alias Frameworks.Pixel.Image
   alias Frameworks.Pixel.Text
   alias Systems.Assignment.CurrencyHelpers
 
@@ -16,7 +15,7 @@ defmodule Systems.Home.ParticipatedView do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="border-2 border-grey4 rounded p-6" data-testid="participated">
+    <div class="border-2 border-grey4 rounded p-4 md:p-6" data-testid="participated">
       <Text.title2 margin="">
         <%= @labels.title %>
         <span class="text-primary"> <%= Enum.count(@content_items) %></span>
@@ -39,36 +38,43 @@ defmodule Systems.Home.ParticipatedView do
     ~H"""
     <a
       href={@item.path}
-      class="flex flex-row items-center gap-4 py-4 first:pt-0 last:pb-0 hover:bg-grey6 -mx-2 px-2 rounded"
+      class="flex flex-row items-start gap-3 md:gap-4 py-4 first:pt-0 last:pb-0 hover:bg-grey6 -mx-2 px-2 rounded"
       data-testid="participated-row"
     >
       <div class="flex-1 min-w-0">
-        <div class="text-title5 font-title5 text-grey1 truncate">
+        <div class="text-title5 font-title5 text-grey1 break-words line-clamp-2">
           <%= @item.title %>
         </div>
         <%= if @item.subtitle do %>
-          <div class="text-bodysmall font-body text-grey2 truncate">
+          <div class="mt-2 text-bodysmall font-body text-grey2 break-words line-clamp-2">
             <%= @item.subtitle %>
           </div>
         <% end %>
-      </div>
-
-      <div class="flex flex-col items-end gap-1 shrink-0">
-        <div class="text-bodymedium font-body text-grey1">
-          <%= @labels.reward_label %>
-          <span class="text-title6 font-title6">
-            <%= CurrencyHelpers.format_cents(@item.reward_cents) %>
-          </span>
+        <div class="mt-1 lg:hidden flex flex-wrap items-center gap-x-2 gap-y-1">
+          <.status_pill status={@item.reward_status} labels={@labels} />
+          <.reward_label labels={@labels} reward_cents={@item.reward_cents} />
         </div>
-        <.status_pill status={@item.reward_status} labels={@labels} />
       </div>
 
-      <div class="w-24 h-16 rounded overflow-hidden bg-grey4 shrink-0">
-        <%= if @item.image_info do %>
-          <Image.blurhash id={"participated-#{:erlang.phash2(@item.path)}"} image={@item.image_info} />
-        <% end %>
+      <div class="hidden lg:flex flex-col items-end gap-1 shrink-0">
+        <.status_pill status={@item.reward_status} labels={@labels} />
+        <.reward_label labels={@labels} reward_cents={@item.reward_cents} />
       </div>
     </a>
+    """
+  end
+
+  attr(:labels, :map, required: true)
+  attr(:reward_cents, :integer, required: true)
+
+  defp reward_label(assigns) do
+    ~H"""
+    <span class="text-bodymedium font-body text-grey1 whitespace-nowrap">
+      <%= @labels.reward_label %>
+      <span class="text-title6 font-title6">
+        <%= CurrencyHelpers.format_cents(@reward_cents) %>
+      </span>
+    </span>
     """
   end
 
@@ -77,7 +83,7 @@ defmodule Systems.Home.ParticipatedView do
 
   defp status_pill(%{status: :awaiting} = assigns) do
     ~H"""
-    <span class="inline-flex items-center px-3 py-0.5 rounded-full text-white text-label font-label bg-warning">
+    <span class="inline-flex items-center px-3 py-1 rounded-full text-white text-label font-label bg-warning">
       <%= @labels.status.awaiting %>
     </span>
     """
@@ -85,7 +91,7 @@ defmodule Systems.Home.ParticipatedView do
 
   defp status_pill(%{status: :approved} = assigns) do
     ~H"""
-    <span class="inline-flex items-center px-3 py-0.5 rounded-full text-white text-label font-label bg-success">
+    <span class="inline-flex items-center px-3 py-1 rounded-full text-white text-label font-label bg-success">
       <%= @labels.status.approved %>
     </span>
     """
@@ -93,7 +99,7 @@ defmodule Systems.Home.ParticipatedView do
 
   defp status_pill(%{status: :rejected} = assigns) do
     ~H"""
-    <span class="inline-flex items-center px-3 py-0.5 rounded-full text-white text-label font-label bg-delete">
+    <span class="inline-flex items-center px-3 py-1 rounded-full text-white text-label font-label bg-delete">
       <%= @labels.status.rejected %>
     </span>
     """

--- a/core/systems/next_action/view.ex
+++ b/core/systems/next_action/view.ex
@@ -7,7 +7,7 @@ defmodule Systems.NextAction.View do
   attr(:cta_action, :map, required: true)
 
   attr(:title_css, :string,
-    default: "font-title7 text-title7 md:font-title5 md:text-title5 text-grey1"
+    default: "font-title6 text-title6 md:font-title5 md:text-title5 text-grey1"
   )
 
   attr(:subtitle_css, :string, default: "text-bodysmall md:text-bodymedium font-body text-grey1")
@@ -25,7 +25,7 @@ defmodule Systems.NextAction.View do
   attr(:style, :string, default: nil)
 
   attr(:title_css, :string,
-    default: "font-title7 text-title7 md:font-title5 md:text-title5 text-grey1"
+    default: "font-title6 text-title6 md:font-title5 md:text-title5 text-grey1"
   )
 
   attr(:subtitle_css, :string, default: "text-bodysmall md:text-bodymedium font-body text-grey1")
@@ -38,22 +38,17 @@ defmodule Systems.NextAction.View do
 
     ~H"""
     <Button.action {@cta_action}>
-      <div class={"p-4 md:p-6 flex items-center space-x-4 rounded-md #{@colors.bg}"}>
-        <div class="flex-grow">
-          <div class={"#{@title_css} mb-2"}>
+      <div class={"p-4 md:p-6 flex flex-col lg:flex-row lg:items-center gap-4 lg:gap-0 lg:space-x-4 rounded-md #{@colors.bg}"}>
+        <div class="flex-grow min-w-0">
+          <div class={"#{@title_css} mb-2 break-words"}>
             <%= @title %>
           </div>
-          <div class={@subtitle_css}>
+          <div class={"#{@subtitle_css} break-words"}>
             <%= @description %>
           </div>
         </div>
-        <div class={"hidden lg:block font-button text-button text-center p-3 rounded-md whitespace-nowrap #{@colors.button}"}>
+        <div class={"w-full lg:w-auto font-button text-button text-center p-3 rounded-md whitespace-nowrap #{@colors.button}"}>
           <%= @cta_label %>
-        </div>
-        <div class="inline-block lg:hidden self-start mt-2px md:mt-1">
-          <svg width="8" height="13" viewBox="0 0 8 13" class={"fill-current #{@colors.icon}"}>
-            <path d="M0.263916 11.34L4.84392 6.75L0.263916 2.16L1.67392 0.75L7.67392 6.75L1.67392 12.75L0.263916 11.34Z" />
-          </svg>
         </div>
       </div>
     </Button.action>


### PR DESCRIPTION
Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/10143957142

## Summary

Iris found the participant Home ran off screen on phones. Root cause: two components (NBA banner + History block) claimed intrinsic horizontal width the viewport couldn't absorb, which forced sibling cards (rewards summary + adverts) to overflow with them.

## NextAction highlight (NBA banner)

- Missing `min-w-0` on the text container let long descriptions push the row wider than the viewport. Added `min-w-0` + `break-words`.
- Layout stacks on mobile: title + description on top, full-width CTA button below (was: chevron icon on the side, everything on one row).
- Mobile title bumped from `title7` → `title6` so it reads as a title.

## Home ParticipatedView (Geschiedenis list)

- Dropped the row image — added no value at this size and looked pixelated on mobile.
- Reward + status pill drop into the text column below the subtitle on `<lg` viewports; they only claim a right column on `lg+`.
- Title + subtitle capped at 2 lines each (`line-clamp-2`) so a long title doesn't wall-of-text the row.
- Pill styling aligned with Rewards Summary pills (`py-1`); pill sits above the reward amount in both placements.
- Container padding `p-4 md:p-6` (was `p-6` everywhere).

## Test plan

- [x] `mix test.ci` green
- [ ] Manual on staging (eyra-next-dev.fly.dev) after merge, as participant at 375px viewport: Home page fits without horizontal scroll; NBA + History both render without pushing sibling cards off screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)