### PR TITLE
chore(dev-loop): trim pre-commit + cache CI build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches-ignore:
       - master
 
+# Cancel superseded runs on the same ref so a new push stops the old job.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-24.04
@@ -35,15 +40,38 @@ jobs:
           otp-version: "27.3.4"
           elixir-version: "1.17.0-otp-27"
 
-      - name: Setup the Elixir project
-        run: make deps
+      # Cache Mix deps + build artifacts. Key is scoped to OTP/Elixir + mix.lock;
+      # restore-keys let us reuse a stale-lock build as a warm start.
+      - name: Cache mix deps + build
+        uses: actions/cache@v6.1.0
+        with:
+          path: |
+            core/deps
+            core/_build
+            banking_proxy/deps
+            banking_proxy/_build
+          key: mix-${{ runner.os }}-otp-${{ steps.setup-elixir.outputs.otp-version }}-elixir-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('core/mix.lock', 'banking_proxy/mix.lock') }}
+          restore-keys: |
+            mix-${{ runner.os }}-otp-${{ steps.setup-elixir.outputs.otp-version }}-elixir-${{ steps.setup-elixir.outputs.elixir-version }}-
 
-      # Setup caching (mostly for Dialyzer)
-      - uses: actions/cache@v6.1.0
-        id: cache
+      - name: Cache Dialyzer PLTs
+        uses: actions/cache@v6.1.0
         with:
           path: core/priv/plts
-          key: "mix-${{ runner.os }}-${{ steps.setup-elixir.outputs.otp-version }}-Elixir-${{ steps.setup-elixir.outputs.elixir-version }}"
+          key: plts-${{ runner.os }}-otp-${{ steps.setup-elixir.outputs.otp-version }}-elixir-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('core/mix.lock') }}
+          restore-keys: |
+            plts-${{ runner.os }}-otp-${{ steps.setup-elixir.outputs.otp-version }}-elixir-${{ steps.setup-elixir.outputs.elixir-version }}-
+
+      - name: Cache npm node_modules
+        uses: actions/cache@v6.1.0
+        with:
+          path: core/assets/node_modules
+          key: npm-${{ runner.os }}-${{ hashFiles('core/assets/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
+
+      - name: Setup the Elixir project
+        run: make deps
 
       - name: Format
         run: make format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+#
+# Two stages are wired up:
+#   pre-commit — fast checks (< 30s): format, credo, incremental compile
+#   pre-push   — heavy checks (test suite + dialyzer)
+#
+# One-time setup after cloning:
+#   pre-commit install --hook-type pre-commit --hook-type pre-push
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -30,13 +37,6 @@ repos:
         pass_filenames: false
         files: \.ex$
 
-      - id: mix-test
-        name: "elixir: mix test"
-        entry: make test
-        language: system
-        pass_filenames: false
-        files: \.exs?$
-
       - id: mix-credo
         name: "elixir: mix credo"
         entry: make credo
@@ -44,10 +44,18 @@ repos:
         pass_filenames: false
         files: \.exs*$
 
+      - id: mix-test
+        name: "elixir: mix test (pre-push)"
+        entry: make test
+        language: system
+        pass_filenames: false
+        files: \.exs?$
+        stages: [pre-push]
+
       - id: mix-dialyzer
-        name: "elixir: mix dialyzer"
+        name: "elixir: mix dialyzer (pre-push)"
         entry: make dialyzer
         language: system
         pass_filenames: false
         files: \.exs?$
-
+        stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,21 @@ MIX_PROJECTS=core banking_proxy
 all: test format compile credo deps
 
 .PHONY: setup
-setup: install_assets
+setup: install_assets install_hooks
 
 .PHONY: install_assets
 install_assets:
 	@echo "Installing assets"
 	@cd ./core/assets && npm install
+
+.PHONY: install_hooks
+install_hooks:
+	@if command -v pre-commit >/dev/null 2>&1; then \
+		echo "Installing git hooks (pre-commit + pre-push)"; \
+		pre-commit install --hook-type pre-commit --hook-type pre-push; \
+	else \
+		echo "pre-commit not found — skipping git hook install. See https://pre-commit.com/#install"; \
+	fi
 
 .PHONY: prepare
 prepare: test format compile credo

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ credo/%: FORCE
 .PHONY: compile
 compile: ${MIX_PROJECTS:%=%/_build}
 %/_build: FORCE
-	cd $* && mix compile --force --warnings-as-errors
+	cd $* && mix compile --warnings-as-errors
 
 .PHONY: deps
 deps: ${MIX_PROJECTS:%=%/deps}


### PR DESCRIPTION
Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/10181055112

## Problem

Pre-commit ran the full `mix test.ci` (~10-15 min) plus `mix dialyzer` (~1-3 min) on every commit; CI cached only PLTs so cold-starts rebuilt everything (~15 min). Devs skipped hooks; superseded pushes still burned CI minutes.

## Pre-commit changes

- Move `mix test` and `mix dialyzer` to `stages: [pre-push]`. Format, compile, and credo stay on pre-commit.
- `make setup` now installs both hook types automatically (`pre-commit install --hook-type pre-commit --hook-type pre-push`); falls back gracefully when `pre-commit` isn't on PATH. Devs re-run `make setup` once after this PR merges.
- Drop `--force` from `make compile` so pre-commit (and CI) use the incremental build cache — was forcing a full rebuild every time.

## CI changes (`test.yml`)

- Cache `core/deps`, `core/_build`, `banking_proxy/deps`, `banking_proxy/_build` keyed on OTP + Elixir + `mix.lock`. `restore-keys` falls back to a stale-lock build so a warm start is possible even after a deps bump.
- Cache `core/assets/node_modules` on `package-lock.json`.
- Keep the PLT cache (renamed key for consistency with the mix cache).
- Add `concurrency: cancel-in-progress: true` so a new push on the same ref cancels the old run.

## Expected impact

- Pre-commit: ~10-15 min → ~30s (only format + compile + credo run).
- CI cached run: ~15 min → ~2-4 min.
- Superseded pushes stop burning minutes.

## Deferred to follow-ups

- Split CI into parallel jobs (test / credo / dialyzer / assets sharing the cache).
- Rethink the auto-format-and-commit step (fail-on-unformatted is more standard).

## Test plan

- [x] `mix format` / `mix compile` still work locally.
- [ ] After merge, first CI run seeds the caches. Second CI run on a follow-up branch should show a cache hit and finish materially faster.
- [ ] After merge, devs re-run `make setup` (or the raw `pre-commit install --hook-type pre-commit --hook-type pre-push`) to activate the pre-push stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
