### PR TITLE
fix(pixel): FabricBridge shim must preserve :id assign for migrated components

### DIFF
--- a/core/frameworks/pixel/fabric_bridge.ex
+++ b/core/frameworks/pixel/fabric_bridge.ex
@@ -44,13 +44,19 @@ defmodule Frameworks.Pixel.FabricBridge do
 
       # Capture the :fabric assign when a Fabric parent renders this
       # component via compose_child, so emit_to_parent/2 can route parent
-      # events correctly. Mirrors the capture Fabric.LiveComponent used to
-      # do implicitly. Removed together with the surrounding module once no
-      # Fabric parents remain.
+      # events correctly. Mirrors what Fabric.LiveComponent's __using__ used
+      # to do implicitly — including assigning :id, which several Pixel
+      # renders reference as `@id`. Removed together with the surrounding
+      # module once no Fabric parents remain.
       @impl true
-      def update(%{fabric: fabric} = params, socket) do
+      def update(%{id: id, fabric: fabric} = params, socket) do
         params = Map.drop(params, [:fabric])
-        socket = Phoenix.Component.assign(socket, :fabric, fabric)
+
+        socket =
+          socket
+          |> Phoenix.Component.assign(:id, id)
+          |> Phoenix.Component.assign(:fabric, fabric)
+
         update(params, socket)
       end
     end


### PR DESCRIPTION
Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/10185982969

## Problem

Reported by Iris: opening any project item that hosts a Fabric-composed page (Panl or data-donation assignment content pages) crashed with `KeyError: :id` inside `Frameworks.Pixel.RadioGroup.render/1`. Breadcrumb rendered, content area stayed empty. The Settings tab's opt-in Switch composes a RadioGroup — hence the trigger.

## Root cause

PR #1704 migrated 10 Pixel live_components off `Fabric.LiveComponent` onto a pure-LiveNest `:live_component` + the `FabricBridge` shim.

`Fabric.LiveComponent`'s `__using__` used to inject an `update/2` clause that assigned both `:fabric` AND `:id` from params:

```elixir
def update(%{id: id, fabric: fabric} = params, socket) do
  params = Map.drop(params, [:fabric])
  socket = assign(socket, id: id, fabric: fabric)
  update(params, socket)
end
```

My shim only assigned `:fabric`, so the id was silently dropped and any render doing `id={"#{@id}_form"}` blew up on the second-and-later renders.

## Fix

Match on both `:id` and `:fabric` in the shim's injected `update/2` and assign both — mirrors `Fabric.LiveComponent`'s original behaviour. Same tight window until the whole shim goes away with the last Fabric parent.

## Test plan

- [x] `mix compile --warnings-as-errors` clean.
- [x] Manual: opened a Data Donation project item locally — page now renders correctly instead of `KeyError`.
- [ ] After merge, Iris to reproduce the original scenario on eyra-next-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)