### PR TITLE
i18n(pool): fill missing marketplace translations for de/it/es/lt/ro

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Der Marktplatz ist momentan leer."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filter:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Marktplatz"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Dauer"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Vergütung"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "El mercado está vacío por el momento."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtro:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Mercado"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Duración"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Recompensa"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Il marketplace è attualmente vuoto."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtro:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Marketplace"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Durata"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Compenso"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Prekyvietė šiuo metu yra tuščia."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtras:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Prekyvietė"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Trukmė"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Atlygis"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Piața este momentan goală."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtru:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Piață"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Durată"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Recompensă"
 
 #, elixir-autogen, elixir-format
 msgid "byline"


### PR DESCRIPTION
Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/10120767014

## Problem

Iris: the Panl marketplace rendered raw msgids (`marketplace.title`, `duration.title`, `reward.title`) instead of translated text in non-Dutch/English locales. Gettext falls back to msgid when msgstr is empty; the dot-notation keys used here make that fallback look like a bug to users.

## Fix

Fill 5 keys × 5 locales. Iris named 3; grepping the marketplace surface (`marketplace_page_builder.ex`, `marketplace_view.ex`, `{:marketplace, :card}` in `advert/view_model_builders.ex`) turned up 2 more that were empty in the same 5 locales, so filling them at the same time.

| key (domain) | de | it | es | lt | ro |
|---|---|---|---|---|---|
| `marketplace.title` (eyra-pool) | Marktplatz | Marketplace | Mercado | Prekyvietė | Piață |
| `marketplace.empty.message` (eyra-pool) | Der Marktplatz ist momentan leer. | Il marketplace è attualmente vuoto. | El mercado está vacío por el momento. | Prekyvietė šiuo metu yra tuščia. | Piața este momentan goală. |
| `marketplace.filter.label` (eyra-pool) | Filter: | Filtro: | Filtro: | Filtras: | Filtru: |
| `duration.title` (eyra-promotion) | Dauer | Durata | Duración | Trukmė | Durată |
| `reward.title` (eyra-submission) | Vergütung | Compenso | Recompensa | Atlygis | Recompensă |

15 file edits total.

## Not addressed

The systemic pattern. Dot-notation msgids elsewhere in the codebase will keep leaking as raw keys whenever a translation is missing. A future PR could either move to English-text msgids (Gettext canonical) or add a runtime fallback wrapper.

## Test plan

- [ ] After merge on eyra-next-dev, switch locale to de/it/es/lt/ro and open the Panl marketplace — the title, filter label, empty state, and each card's duration/reward labels should render in the selected language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)