### PR TITLE
fix(account): show rate-limit message (not "expired") after exhausting OTP attempts

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Der Marktplatz ist momentan leer."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filter:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Marktplatz"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Dauer"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/de/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Vergütung"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "El mercado está vacío por el momento."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtro:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Mercado"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Duración"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Recompensa"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Il marketplace è attualmente vuoto."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtro:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Marketplace"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Durata"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Compenso"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Prekyvietė šiuo metu yra tuščia."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtras:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Prekyvietė"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Trukmė"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Atlygis"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-pool.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.empty.message"
-msgstr ""
+msgstr "Piața este momentan goală."
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.all"
@@ -53,7 +53,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.filter.label"
-msgstr ""
+msgstr "Filtru:"
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.search.placeholder"
@@ -61,7 +61,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "marketplace.title"
-msgstr ""
+msgstr "Piață"
 
 #, elixir-autogen, elixir-format
 msgid "content.title"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-promotion.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-promotion.po
@@ -45,7 +45,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "duration.title"
-msgstr ""
+msgstr "Durată"
 
 #, elixir-autogen, elixir-format
 msgid "expectations.public.label"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-submission.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-submission.po
@@ -33,7 +33,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 msgid "reward.title"
-msgstr ""
+msgstr "Recompensă"
 
 #, elixir-autogen, elixir-format
 msgid "byline"

--- a/core/systems/account/auth_code.ex
+++ b/core/systems/account/auth_code.ex
@@ -45,7 +45,6 @@ defmodule Systems.Account.AuthCodeModel do
     from(t in __MODULE__,
       where: t.email == ^email,
       where: t.inserted_at > ago(@validity_in_minutes, "minute"),
-      where: t.attempts < @max_attempts,
       order_by: [desc: t.id],
       limit: 1
     )

--- a/core/test/bundles/next/account/auth_code_verify_page_test.exs
+++ b/core/test/bundles/next/account/auth_code_verify_page_test.exs
@@ -1,0 +1,37 @@
+defmodule Next.Account.AuthCodeVerifyPageTest do
+  @moduledoc """
+  Wires up the rate-limit path end-to-end at the LiveView level: hitting
+  the attempts limit on the verify page must bounce back to
+  /user/auth/identify with the RATE-LIMIT flash, not the "code expired"
+  one. See Flux 10025618754.
+  """
+  use CoreWeb.ConnCase, async: false
+  use Core.FeatureFlags.Test
+  use Gettext, backend: CoreWeb.Gettext
+
+  import Phoenix.LiveViewTest
+
+  alias Core.Repo
+  alias Systems.Account.AuthCodeModel
+
+  describe "/user/auth/verify rate limit" do
+    test "redirects to /user/auth/identify with the rate-limit message after exhausting attempts",
+         %{conn: conn} do
+      set_feature_flag(:otp, true)
+
+      email = "rate-limited@example.com"
+      {_code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(%{auth_code | attempts: 5})
+
+      {:ok, view, _html} = live(conn, ~p"/user/auth/verify?email=#{email}")
+
+      result = render_submit(view, "verify", %{"code" => "999999"})
+      assert {:error, {:live_redirect, %{to: "/user/auth/identify"}}} = result
+
+      {:ok, _view, html} = follow_redirect(result, conn)
+
+      assert html =~ dgettext("eyra-account", "auth.code.max_attempts")
+      refute html =~ dgettext("eyra-account", "auth.code.expired")
+    end
+  end
+end

--- a/core/test/bundles/next/account/auth_code_verify_page_test.exs
+++ b/core/test/bundles/next/account/auth_code_verify_page_test.exs
@@ -33,5 +33,25 @@ defmodule Next.Account.AuthCodeVerifyPageTest do
       assert html =~ dgettext("eyra-account", "auth.code.max_attempts")
       refute html =~ dgettext("eyra-account", "auth.code.expired")
     end
+
+    test "with attempts: 4, a wrong code stays on the page with the invalid message",
+         %{conn: conn} do
+      # Pins the boundary the other way: the user still has one attempt on
+      # attempt #5, so a wrong code shows the inline error — no redirect,
+      # no rate-limit flash.
+      set_feature_flag(:otp, true)
+
+      email = "boundary@example.com"
+      {_code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(%{auth_code | attempts: 4})
+
+      {:ok, view, _html} = live(conn, ~p"/user/auth/verify?email=#{email}")
+
+      html = render_submit(view, "verify", %{"code" => "999999"})
+
+      assert html =~ dgettext("eyra-account", "auth.code.invalid")
+      refute html =~ dgettext("eyra-account", "auth.code.max_attempts")
+      refute html =~ dgettext("eyra-account", "auth.code.expired")
+    end
   end
 end

--- a/core/test/systems/account/auth_code_test.exs
+++ b/core/test/systems/account/auth_code_test.exs
@@ -94,13 +94,18 @@ defmodule Systems.Account.AuthCodeTest do
       assert result == nil
     end
 
-    test "returns nil when max attempts reached" do
+    test "still returns the row after max attempts so verify/2 can flag the rate-limit" do
+      # If active_query filtered rate-limited rows out, verify_otp would map
+      # them to :not_found — and the verify page would show "code expired"
+      # instead of the rate-limit message. Keep the row visible so verify/2
+      # gets a chance to return :max_attempts.
       {_code, auth_code} = AuthCodeModel.build("user@example.com", nil)
 
       Repo.insert!(%{auth_code | attempts: 5})
 
       result = AuthCodeModel.active_query("user@example.com") |> Repo.one()
-      assert result == nil
+      assert result != nil
+      assert result.attempts == 5
     end
 
     test "returns most recent code when multiple exist" do
@@ -235,12 +240,16 @@ defmodule Systems.Account.AuthCodeTest do
       assert Repo.one(AuthCodeModel.active_query(email)) == nil
     end
 
-    test "returns {:error, :max_attempts} after 5 wrong attempts" do
+    test "returns {:error, :max_attempts} after the attempts limit, not :not_found" do
+      # Regression: the auth_code_verify_page maps :not_found → "This code has
+      # expired" and :max_attempts → the correct rate-limit message. Once the
+      # attempts counter hits @max_attempts the user is rate-limited, not
+      # holding an expired code — verify_otp must surface that distinction.
       email = "user@example.com"
       {code, auth_code} = AuthCodeModel.build(email, nil)
       Repo.insert!(%{auth_code | attempts: 5})
 
-      assert {:error, :not_found} = Account.Public.verify_otp(email, code)
+      assert {:error, :max_attempts} = Account.Public.verify_otp(email, code)
     end
   end
 end

--- a/core/test/systems/account/auth_code_test.exs
+++ b/core/test/systems/account/auth_code_test.exs
@@ -251,5 +251,19 @@ defmodule Systems.Account.AuthCodeTest do
 
       assert {:error, :max_attempts} = Account.Public.verify_otp(email, code)
     end
+
+    test "with attempts: 4 (one below the limit), a wrong code still returns :invalid" do
+      # Pins the boundary: the rate-limit engages AT the limit, not before.
+      # The user still has their 5th attempt to get it right.
+      email = "boundary@example.com"
+      {code, auth_code} = AuthCodeModel.build(email, nil)
+      Repo.insert!(%{auth_code | attempts: 4})
+      wrong_code = if code == "000000", do: "000001", else: "000000"
+
+      assert {:error, :invalid} = Account.Public.verify_otp(email, wrong_code)
+
+      updated = Repo.one(AuthCodeModel.active_query(email))
+      assert updated.attempts == 5
+    end
   end
 end


### PR DESCRIPTION
Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/10025618754

## Problem

Iris: after typing 5 wrong OTP codes on `/user/auth/verify`, the page redirected with "This code has expired. Please request a new code" — misleading. The code isn't expired; the user hit the attempts limit.

## Root cause

`AuthCodeModel.active_query/1` filtered out any row with `attempts >= @max_attempts`, so `verify_otp/2` on the 6th attempt got `nil` → `{:error, :not_found}` → `auth_code_verify_page` mapped that to `"auth.code.expired"`.

The `AuthCodeModel.verify/2` clause that returns `:max_attempts` was effectively dead code — the row was hidden before `verify/2` could see it.

## Fix

Drop the `attempts < @max_attempts` filter from `active_query`. `verify/2` now gets the row and can return `:max_attempts`; the page already has the right flash mapping (`"auth.code.max_attempts"`).

One-line change:

```diff
- where: t.attempts < @max_attempts,
```

## Tests

- Rewrote the misleading model-layer test that codified the bug (`"returns :max_attempts after 5 wrong attempts"` whose assertion was actually `:not_found`).
- Inverted the `active_query` test that asserted `nil` for attempts-exhausted rows — the row must stay visible.
- Added a page-level test on `Next.Account.AuthCodeVerifyPage` that submits with an exhausted code, follows the redirect, and asserts the max_attempts flash is on the target page's html — and the "expired" one isn't.
- Added the other side of the boundary (attempts:4) on both layers: one wrong code still returns `:invalid`, stays on the page, no redirect. Guards against a future off-by-one.

## Test plan

- [x] `mix test test/systems/account test/bundles/next/account` — 246 tests, 0 failures.
- [ ] Manual on eyra-next-dev after merge: try 5 wrong codes on `/user/auth/verify`. Redirect to `/user/auth/identify` with the rate-limit message (not the "code expired" one). One wrong code from a fresh state stays on the page with the inline error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)