### PR TITLE
fix(pixel): suppress Firefox default focus outline on <trix-editor>

### DIFF
--- a/core/assets/css/app.css
+++ b/core/assets/css/app.css
@@ -110,6 +110,17 @@ trix-toolbar .trix-button--icon:disabled::before {
   border: 0 !important;
 }
 
+/* Firefox on macOS draws a default :focus-visible outline INSIDE
+ * <trix-editor> even though the wrapping .field-input div already carries
+ * `focus:outline-none` — the rich-text editor is a separate focusable
+ * element, so Tailwind's rule on the outer div doesn't reach it. Chrome
+ * and Safari suppress this by default; Firefox doesn't. See Flux 8467829033.
+ */
+trix-editor:focus,
+trix-editor:focus-visible {
+  outline: none;
+}
+
 .trix-button--icon-attach,
 .trix-button--icon-decrease-nesting-level,
 .trix-button--icon-increase-nesting-level {


### PR DESCRIPTION
Flux: https://3.basecamp.com/5734045/buckets/35926565/todos/8467829033

## Problem

Clicking a WYSIWYG text field in the workflow builder (and any other page hosting `<trix-editor>`) shows an inner blue line on Firefox/macOS. Chrome and Safari don't render it.

## Root cause

The wrapping `.field-input` div carries `focus:outline-none` (Tailwind), but the rich-text editor is a separate focusable `<trix-editor>` element that Tailwind's `focus:` doesn't reach. Firefox's default `:focus-visible` rule for `<trix-editor>` is `outline: auto; outline-offset: 2px` — that's the artefact. Chrome and Safari suppress it.

## Fix

One CSS rule in `assets/css/app.css`:

```css
trix-editor:focus,
trix-editor:focus-visible {
  outline: none;
}
```

Focus is still indicated by the outer `.field-input`'s active-border swap driven by the `LiveField`/`LiveContent` hooks, so the editor stays visibly focused — just without Firefox's inner ring.

## Test plan

- [x] Manual on Firefox/macOS: focus a WYSIWYG field in the workflow builder → no inner blue line. Reporter confirmed.
- [ ] Manual on Chrome + Safari: focus behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)