### PR TITLE
i18n(assignment): restore pay_in_request_form gettext keys across all locales

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -566,35 +566,35 @@ msgid "panl.cta.home.button"
 msgstr "Zur Startseite"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.label"
+msgid "pay_in_request_form.aim.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.cancel.button"
+msgid "pay_in_request_form.cancel.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.confirm.button"
+msgid "pay_in_request_form.confirm.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.costs.label"
+msgid "pay_in_request_form.costs.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.description"
+msgid "pay_in_request_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.label"
+msgid "pay_in_request_form.fee.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.slots.label"
+msgid "pay_in_request_form.slots.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.title"
+msgid "pay_in_request_form.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -642,15 +642,15 @@ msgid "recruit.panel.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.partner_fee.label"
+msgid "pay_in_request_form.partner_fee.label"
 msgstr "Servicegebühr (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.subtotal.label"
+msgid "pay_in_request_form.subtotal.label"
 msgstr "%{count} x Teilnehmergebühr von %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.total.label"
+msgid "pay_in_request_form.total.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -718,11 +718,11 @@ msgid "assignment_full.title"
 msgstr "Diese Studie ist voll"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
+msgid "pay_in_request_form.fee.invalid"
 msgstr "Bitte einen Betrag eingeben, z. B. 3,75"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.placeholder"
+msgid "pay_in_request_form.aim.placeholder"
 msgstr "Eine kurze Beschreibung deiner Studie"
 
 #, elixir-autogen, elixir-format

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -565,35 +565,35 @@ msgid "panl.cta.home.button"
 msgstr "Go to home"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.label"
+msgid "pay_in_request_form.aim.label"
 msgstr "Aim of the study"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.cancel.button"
+msgid "pay_in_request_form.cancel.button"
 msgstr "Cancel"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.confirm.button"
+msgid "pay_in_request_form.confirm.button"
 msgstr "Confirm"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.costs.label"
+msgid "pay_in_request_form.costs.label"
 msgstr "Costs"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.description"
+msgid "pay_in_request_form.description"
 msgstr "Proceed to pay the fee and recruit Panl participants."
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.label"
+msgid "pay_in_request_form.fee.label"
 msgstr "Participant fee"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.slots.label"
+msgid "pay_in_request_form.slots.label"
 msgstr "Number of participants"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.title"
+msgid "pay_in_request_form.title"
 msgstr "Add participants"
 
 #, elixir-autogen, elixir-format
@@ -641,15 +641,15 @@ msgid "recruit.panel.title"
 msgstr "Recruit participants"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.partner_fee.label"
+msgid "pay_in_request_form.partner_fee.label"
 msgstr "Service fee (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.subtotal.label"
+msgid "pay_in_request_form.subtotal.label"
 msgstr "%{count} x participant fee of %{reward}"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.total.label"
+msgid "pay_in_request_form.total.label"
 msgstr "Total"
 
 #, elixir-autogen, elixir-format
@@ -747,11 +747,11 @@ msgid "assignment_full.title"
 msgstr "This study is full"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
+msgid "pay_in_request_form.fee.invalid"
 msgstr "Please enter a plain amount, like 3.75"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.placeholder"
+msgid "pay_in_request_form.aim.placeholder"
 msgstr "A short description of your study"
 
 #, elixir-autogen, elixir-format

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -566,35 +566,35 @@ msgid "panl.cta.home.button"
 msgstr "Ir al inicio"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.label"
+msgid "pay_in_request_form.aim.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.cancel.button"
+msgid "pay_in_request_form.cancel.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.confirm.button"
+msgid "pay_in_request_form.confirm.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.costs.label"
+msgid "pay_in_request_form.costs.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.description"
+msgid "pay_in_request_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.label"
+msgid "pay_in_request_form.fee.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.slots.label"
+msgid "pay_in_request_form.slots.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.title"
+msgid "pay_in_request_form.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -642,15 +642,15 @@ msgid "recruit.panel.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.partner_fee.label"
+msgid "pay_in_request_form.partner_fee.label"
 msgstr "Tarifa de servicio (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.subtotal.label"
+msgid "pay_in_request_form.subtotal.label"
 msgstr "%{count} x tarifa por participante de %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.total.label"
+msgid "pay_in_request_form.total.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -718,11 +718,11 @@ msgid "assignment_full.title"
 msgstr "Este estudio está completo"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
+msgid "pay_in_request_form.fee.invalid"
 msgstr "Introduce un importe, p. ej., 3,75"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.placeholder"
+msgid "pay_in_request_form.aim.placeholder"
 msgstr "Una breve descripción de tu estudio"
 
 #, elixir-autogen, elixir-format

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -566,35 +566,35 @@ msgid "panl.cta.home.button"
 msgstr "Vai alla homepage"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.label"
+msgid "pay_in_request_form.aim.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.cancel.button"
+msgid "pay_in_request_form.cancel.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.confirm.button"
+msgid "pay_in_request_form.confirm.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.costs.label"
+msgid "pay_in_request_form.costs.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.description"
+msgid "pay_in_request_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.label"
+msgid "pay_in_request_form.fee.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.slots.label"
+msgid "pay_in_request_form.slots.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.title"
+msgid "pay_in_request_form.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -642,15 +642,15 @@ msgid "recruit.panel.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.partner_fee.label"
+msgid "pay_in_request_form.partner_fee.label"
 msgstr "Costo di servizio (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.subtotal.label"
+msgid "pay_in_request_form.subtotal.label"
 msgstr "%{count} x tariffa per partecipante di %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.total.label"
+msgid "pay_in_request_form.total.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -718,11 +718,11 @@ msgid "assignment_full.title"
 msgstr "Questo studio è al completo"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
+msgid "pay_in_request_form.fee.invalid"
 msgstr "Inserisci un importo, es. 3,75"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.placeholder"
+msgid "pay_in_request_form.aim.placeholder"
 msgstr "Una breve descrizione del tuo studio"
 
 #, elixir-autogen, elixir-format

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -576,35 +576,35 @@ msgid "panl.cta.home.button"
 msgstr "Į pradžios puslapį"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.label"
+msgid "pay_in_request_form.aim.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.cancel.button"
+msgid "pay_in_request_form.cancel.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.confirm.button"
+msgid "pay_in_request_form.confirm.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.costs.label"
+msgid "pay_in_request_form.costs.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.description"
+msgid "pay_in_request_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.label"
+msgid "pay_in_request_form.fee.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.slots.label"
+msgid "pay_in_request_form.slots.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.title"
+msgid "pay_in_request_form.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -652,15 +652,15 @@ msgid "recruit.panel.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.partner_fee.label"
+msgid "pay_in_request_form.partner_fee.label"
 msgstr "Aptarnavimo mokestis (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.subtotal.label"
+msgid "pay_in_request_form.subtotal.label"
 msgstr "%{count} x dalyvio mokestis po %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.total.label"
+msgid "pay_in_request_form.total.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -728,11 +728,11 @@ msgid "assignment_full.title"
 msgstr "Šis tyrimas yra pilnas"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
+msgid "pay_in_request_form.fee.invalid"
 msgstr "Įveskite sumą, pvz., 3,75"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.placeholder"
+msgid "pay_in_request_form.aim.placeholder"
 msgstr "Trumpas jūsų tyrimo aprašymas"
 
 #, elixir-autogen, elixir-format

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -565,35 +565,35 @@ msgid "panl.cta.home.button"
 msgstr "Naar startpagina"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.label"
+msgid "pay_in_request_form.aim.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.cancel.button"
+msgid "pay_in_request_form.cancel.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.confirm.button"
+msgid "pay_in_request_form.confirm.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.costs.label"
+msgid "pay_in_request_form.costs.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.description"
+msgid "pay_in_request_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.label"
+msgid "pay_in_request_form.fee.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.slots.label"
+msgid "pay_in_request_form.slots.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.title"
+msgid "pay_in_request_form.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -641,15 +641,15 @@ msgid "recruit.panel.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.partner_fee.label"
+msgid "pay_in_request_form.partner_fee.label"
 msgstr "Servicekosten (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.subtotal.label"
+msgid "pay_in_request_form.subtotal.label"
 msgstr "%{count} x participant fee van %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.total.label"
+msgid "pay_in_request_form.total.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -717,11 +717,11 @@ msgid "assignment_full.title"
 msgstr "Deze studie zit vol"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
+msgid "pay_in_request_form.fee.invalid"
 msgstr "Voer een bedrag in, bijv. 3,75"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.placeholder"
+msgid "pay_in_request_form.aim.placeholder"
 msgstr "Een korte omschrijving van je studie"
 
 #, elixir-autogen, elixir-format

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -576,35 +576,35 @@ msgid "panl.cta.home.button"
 msgstr "Către pagina principală"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.label"
+msgid "pay_in_request_form.aim.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.cancel.button"
+msgid "pay_in_request_form.cancel.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.confirm.button"
+msgid "pay_in_request_form.confirm.button"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.costs.label"
+msgid "pay_in_request_form.costs.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.description"
+msgid "pay_in_request_form.description"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.label"
+msgid "pay_in_request_form.fee.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.slots.label"
+msgid "pay_in_request_form.slots.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.title"
+msgid "pay_in_request_form.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -652,15 +652,15 @@ msgid "recruit.panel.title"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.partner_fee.label"
+msgid "pay_in_request_form.partner_fee.label"
 msgstr "Taxă de serviciu (%{percentage}%)"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.subtotal.label"
+msgid "pay_in_request_form.subtotal.label"
 msgstr "%{count} x taxă per participant de %{reward}"
 
 #, elixir-autogen, elixir-format, fuzzy
-msgid "budget_form.total.label"
+msgid "pay_in_request_form.total.label"
 msgstr ""
 
 #, elixir-autogen, elixir-format
@@ -728,11 +728,11 @@ msgid "assignment_full.title"
 msgstr "Acest studiu este complet"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.fee.invalid"
+msgid "pay_in_request_form.fee.invalid"
 msgstr "Introdu o sumă, de ex. 3,75"
 
 #, elixir-autogen, elixir-format
-msgid "budget_form.aim.placeholder"
+msgid "pay_in_request_form.aim.placeholder"
 msgstr "O scurtă descriere a studiului tău"
 
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
## Summary
The Pay-in request modal was rendering raw gettext keys (`pay_in_request_form.title`, etc.) instead of translated text. Root cause was a merge/rebase artifact: PR #1703 renamed the keys from `budget_form.*` to `pay_in_request_form.*` in both the code and the `.po` files, but PR #1696 (merged shortly after) reverted only the `.po` entries back to `budget_form.*` while the code kept calling the new keys.

This re-applies the rename in all 7 language `.po` files. Translations are preserved — only the `msgid` values change.

Fixes https://app.basecamp.com/5734045/buckets/35926565/todos/10188267556

## Test plan
- [ ] Open the Pay-in request modal on a Panl assignment (creator-side "request budget for paid slots" flow).
- [ ] Title, description, all field labels, buttons and validation messages show translated text instead of raw keys like `pay_in_request_form.title`.
- [ ] Same check in each language the user can switch to (en/nl/de/es/it/lt/ro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)