### PR TITLE
i18n(assignment): add English for pay_in_request_form validation messages

### DIFF
--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -755,6 +755,18 @@ msgid "pay_in_request_form.aim.placeholder"
 msgstr "A short description of your study"
 
 #, elixir-autogen, elixir-format
+msgid "pay_in_request_form.aim.required"
+msgstr "Please enter the aim of the study"
+
+#, elixir-autogen, elixir-format
+msgid "pay_in_request_form.fee.required"
+msgstr "Please enter the participant fee"
+
+#, elixir-autogen, elixir-format
+msgid "pay_in_request_form.slots.required"
+msgstr "Please enter the number of participants"
+
+#, elixir-autogen, elixir-format
 msgid "tabbar.item.contributions"
 msgstr "Contributions"
 


### PR DESCRIPTION
## Summary
Follow-up fix to #1722. That PR restored the `pay_in_request_form.*` gettext keys but missed the three validation-message keys used in `pay_in_request_model.ex` (`slots.required`, `aim.required`, `fee.required`). Without them the form shows raw keys when the participant submits without filling required fields.

Only `en/eyra-assignment.po` gets the entries — creators are pinned to English in this app, so other locales don't render this modal.

Fixes https://app.basecamp.com/5734045/buckets/35926565/todos/10188267556

## Test plan
- [ ] Open the Pay-in request modal, click Confirm without filling any field.
- [ ] Each required field shows a proper English validation message ("Please enter the aim of the study", "Please enter the participant fee", "Please enter the number of participants"), not a raw key like \`pay_in_request_form.slots.required\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)