### PR TITLE
fix(assignment): guard PendingContributions NBA on fund having pay-ins

### DIFF
--- a/core/systems/assignment/_public.ex
+++ b/core/systems/assignment/_public.ex
@@ -45,6 +45,15 @@ defmodule Systems.Assignment.Public do
     |> Repo.preload(preload)
   end
 
+  @doc """
+  A "funded" assignment has a fund AND at least one pay-in on that fund.
+  The fund alone doesn't qualify — every assignment gets an empty fund
+  at assembly time (`_assembly.ex`), so fund-existence is not a signal
+  that money is actually involved.
+  """
+  def funded?(%Assignment.Model{fund: %Fund.Model{} = fund}), do: Fund.Public.has_pay_ins?(fund)
+  def funded?(%Assignment.Model{}), do: false
+
   def get_workflow!(id, preload \\ []) do
     from(a in Workflow.Model, preload: ^preload)
     |> Repo.get!(id)

--- a/core/systems/assignment/_switch.ex
+++ b/core/systems/assignment/_switch.ex
@@ -61,7 +61,7 @@ defmodule Systems.Assignment.Switch do
     assignment =
       Assignment.Public.get!(participation.assignment_id, Assignment.Model.preload_graph(:down))
 
-    if assignment.fund do
+    if Assignment.Public.funded?(assignment) do
       create_pending_contributions_next_action(assignment)
     end
 

--- a/core/systems/fund/_public.ex
+++ b/core/systems/fund/_public.ex
@@ -16,6 +16,7 @@ defmodule Systems.Fund.Public do
   alias Systems.Account
 
   alias Systems.Fund
+  alias Systems.Budget
   alias Systems.Bookkeeping
   alias Systems.Banking
   alias Systems.Payment
@@ -112,6 +113,11 @@ defmodule Systems.Fund.Public do
     reward_query(fund, :pending_approval)
     |> preload(^preload)
     |> Repo.all()
+  end
+
+  def has_pay_ins?(%Fund.Model{id: fund_id}) do
+    from(t in Budget.TransactionModel, where: t.target_fund_id == ^fund_id)
+    |> Repo.exists?()
   end
 
   def list_paid_rewards(%Fund.Model{} = fund, preload \\ [:user, :payment]) do

--- a/core/test/systems/assignment/_public_test.exs
+++ b/core/test/systems/assignment/_public_test.exs
@@ -635,6 +635,7 @@ defmodule Systems.Assignment.PublicTest do
 
       idempotence_key = Assignment.Private.reward_idempotence_key(assignment, user)
       {:ok, _} = Systems.Fund.Public.create_reward(fund, 1000, user, idempotence_key)
+      Systems.Fund.Factories.insert_pay_in!(fund, project_owner)
       {:ok, participation} = Assignment.Public.obtain_participation(assignment, user)
 
       {:ok,

--- a/core/test/systems/assignment/_switch_test.exs
+++ b/core/test/systems/assignment/_switch_test.exs
@@ -241,7 +241,21 @@ defmodule Systems.Assignment.SwitchTest do
       }
     end
 
-    test ":completed creates PendingContributions next-action for the owner", %{
+    test ":completed creates PendingContributions next-action when the fund has pay-ins", %{
+      assignment: %{id: id},
+      fund: fund,
+      participation: participation,
+      owner: owner
+    } do
+      Fund.Factories.insert_pay_in!(fund, owner)
+
+      message = %{assignment_participation: participation, from_pid: self()}
+      assert :ok = Switch.intercept({:assignment_participation, :completed}, message)
+
+      assert_next_action(owner, "/assignment/#{id}/content?tab=contributions")
+    end
+
+    test ":completed on a fund without pay-ins skips NA creation", %{
       assignment: %{id: id},
       participation: participation,
       owner: owner
@@ -249,7 +263,7 @@ defmodule Systems.Assignment.SwitchTest do
       message = %{assignment_participation: participation, from_pid: self()}
       assert :ok = Switch.intercept({:assignment_participation, :completed}, message)
 
-      assert_next_action(owner, "/assignment/#{id}/content?tab=contributions")
+      refute_next_action(owner, "/assignment/#{id}/content?tab=contributions")
     end
 
     test ":completed refreshes content page + embedded views", %{participation: participation} do

--- a/core/test/systems/fund/factories.ex
+++ b/core/test/systems/fund/factories.ex
@@ -1,5 +1,6 @@
 defmodule Systems.Fund.Factories do
   alias Systems.{
+    Budget,
     Fund
   }
 
@@ -69,6 +70,21 @@ defmodule Systems.Fund.Factories do
       currency: currency,
       account: account
     })
+  end
+
+  def insert_pay_in!(%Fund.Model{id: fund_id}, %Systems.Account.User{id: user_id}) do
+    %Budget.TransactionModel{}
+    |> Budget.TransactionModel.changeset(%{
+      transaction_id: "tx_#{System.unique_integer([:positive])}",
+      status: :completed,
+      idempotence_key: Ecto.UUID.generate(),
+      invoice_id: "INV-#{System.unique_integer([:positive])}",
+      subject_count: 1,
+      total_amount: 100
+    })
+    |> Ecto.Changeset.put_change(:user_id, user_id)
+    |> Ecto.Changeset.put_change(:target_fund_id, fund_id)
+    |> Core.Repo.insert!()
   end
 
   def create_reward(assignment, user, fund, amount \\ 2) do


### PR DESCRIPTION
## Summary
Iris reported that completing a Data Donation assignment with no reward configured still surfaced a "Pending contributions" next-best-action on the owner's Home. The intent was for that NBA to only fire on paid assignments.

The completion handler in `Assignment.Switch` guarded NBA creation with `if assignment.fund do …`. That guard was effectively always-true: every assignment gets an empty fund at assembly time (`_assembly.ex`), so fund-existence is not a signal that money is actually involved.

Fix: replace the guard with `Assignment.Public.funded?/1`, which requires **both** a fund on the assignment **and** at least one pay-in on that fund. This makes "funded" match the user-facing notion of a paid study — money has actually been added, not just a stub fund created at setup.

Fixes https://app.basecamp.com/5734045/buckets/35926565/todos/10188267512

## What changed
- `Fund.Public.has_pay_ins?/1` — low-level `Repo.exists?` on `Budget.TransactionModel` keyed by target fund.
- `Assignment.Public.funded?/1` — semantic wrapper with a docstring explaining why fund-existence alone doesn't count.
- `Assignment.Switch` completion handler now calls `Assignment.Public.funded?/1`.
- `Fund.Factories.insert_pay_in!/2` — shared test factory.
- Tests updated: `_switch_test` and `_public_test` now seed a pay-in where they expect the NBA to fire; new switch test asserts a fund with no pay-ins skips NBA creation.

## Test plan
- [ ] Data Donation assignment (no reward configured): complete as a participant → owner's Home shows **no** "Pending contributions" NBA.
- [ ] Panl assignment (with pay-in): complete as a participant → NBA appears on owner's Home as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)