### PR TITLE
fix(assignment): only expose organic recruit link on pre-launch questionnaire assignments

### DIFF
--- a/core/systems/assignment/template_questionnaire.ex
+++ b/core/systems/assignment/template_questionnaire.ex
@@ -46,10 +46,11 @@ defmodule Systems.Assignment.TemplateQuestionnaire do
     end
 
     defp participants_opt_in do
-      [:recruit_participants] ++
-        if feature_enabled?(:panl_post_launch),
-          do: [:advert_in_pool, :paid_slots],
-          else: []
+      if feature_enabled?(:panl_post_launch) do
+        [:advert_in_pool, :paid_slots]
+      else
+        [:recruit_participants]
+      end
     end
 
     # Contributions is only meaningful when paid_slots is on — otherwise

--- a/core/test/systems/assignment/template_migration_test.exs
+++ b/core/test/systems/assignment/template_migration_test.exs
@@ -51,7 +51,9 @@ defmodule Systems.Assignment.TemplateMigrationTest do
       {_title, participants_flags} = tabs[:participants]
       assert participants_flags.advert_in_pool == true
       assert participants_flags.invite_participants == false
-      assert participants_flags.recruit_participants == true
+      # Recruit link is only opt-in pre-launch (panl_post_launch off); this
+      # test suite runs with panl_post_launch on, so it must be off here.
+      assert participants_flags.recruit_participants == false
     end
 
     test "PaperScreening template has correct opt-in flags" do


### PR DESCRIPTION
## Summary
Iris flagged that the Participants tab still surfaced the public recruitment link (`/r/…`) next to the Panl advertisement block. Post-launch, Panl owns the recruitment flow — the organic link duplicates it and confuses the tab.

Gated the `:recruit_participants` opt-in on `:panl_post_launch` being **off**:

- `panl_post_launch` **on** → participants opt-in: `advert_in_pool + paid_slots`
- `panl_post_launch` **off** → participants opt-in: `recruit_participants` (unchanged from before)

Kept the `recruit_url` plumbing in `Systems.Assignment.ParticipantsView` — still needed for the pre-launch path.

Fixes https://app.basecamp.com/5734045/buckets/35926565/todos/10188267452

## Test plan
- [ ] With `panl_post_launch` on (staging/dev default): open a questionnaire assignment's Participants tab — the "Recruit participants" block with the `/r/…` link should be gone. Panl advertisement block stays.
- [ ] With `panl_post_launch` off (pre-launch envs): the "Recruit participants" block still renders with the `/r/…` link, Panl advertisement block gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)