### PR TITLE
feat(assignment): show reviewed contribution outcome on a dedicated ParticipationView

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-assignment.po
@@ -736,3 +736,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "contributions.confirm_all.error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.accepted"
+msgstr "Vielen Dank!"
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.rejected"
+msgstr "Ihr Beitrag wurde abgelehnt"
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.accepted"
+msgstr "Ihre Zeit und Mühe bringen diese Forschung voran.<br>Bis zum nächsten Mal."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected"
+msgstr "Ihr Beitrag wurde abgelehnt."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected.with_reason"
+msgstr "Ihr Beitrag wurde aus folgendem Grund abgelehnt:"
+
+#, elixir-autogen, elixir-format
+msgid "participation.back_home.button"
+msgstr "Zurück zur Startseite"

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-assignment.po
@@ -783,3 +783,27 @@ msgstr[1] "Could not confirm %{count} contributions. Please try again."
 #, elixir-autogen, elixir-format
 msgid "contributions.confirm_all.error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.accepted"
+msgstr "Thank you!"
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.rejected"
+msgstr "Your contribution was declined"
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.accepted"
+msgstr "Your time and effort help this research move forward.<br>See you next time."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected"
+msgstr "Your contribution was declined."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected.with_reason"
+msgstr "Your contribution was declined for the following reason:"
+
+#, elixir-autogen, elixir-format
+msgid "participation.back_home.button"
+msgstr "Back to home"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-assignment.po
@@ -736,3 +736,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "contributions.confirm_all.error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.accepted"
+msgstr "¡Gracias!"
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.rejected"
+msgstr "Tu contribución ha sido rechazada"
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.accepted"
+msgstr "Tu tiempo y esfuerzo ayudan a que esta investigación avance.<br>Hasta la próxima."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected"
+msgstr "Tu contribución ha sido rechazada."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected.with_reason"
+msgstr "Tu contribución ha sido rechazada por el siguiente motivo:"
+
+#, elixir-autogen, elixir-format
+msgid "participation.back_home.button"
+msgstr "Volver al inicio"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-assignment.po
@@ -736,3 +736,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "contributions.confirm_all.error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.accepted"
+msgstr "Grazie!"
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.rejected"
+msgstr "Il tuo contributo è stato rifiutato"
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.accepted"
+msgstr "Il tuo tempo e impegno aiutano questa ricerca ad andare avanti.<br>Alla prossima."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected"
+msgstr "Il tuo contributo è stato rifiutato."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected.with_reason"
+msgstr "Il tuo contributo è stato rifiutato per il seguente motivo:"
+
+#, elixir-autogen, elixir-format
+msgid "participation.back_home.button"
+msgstr "Torna alla home"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-assignment.po
@@ -746,3 +746,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "contributions.confirm_all.error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.accepted"
+msgstr "Ačiū!"
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.rejected"
+msgstr "Jūsų indėlis buvo atmestas"
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.accepted"
+msgstr "Jūsų laikas ir pastangos padeda šiam tyrimui judėti į priekį.<br>Iki kito karto."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected"
+msgstr "Jūsų indėlis buvo atmestas."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected.with_reason"
+msgstr "Jūsų indėlis buvo atmestas dėl šios priežasties:"
+
+#, elixir-autogen, elixir-format
+msgid "participation.back_home.button"
+msgstr "Grįžti į pradžią"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-assignment.po
@@ -735,3 +735,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "contributions.confirm_all.error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.accepted"
+msgstr "Bedankt!"
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.rejected"
+msgstr "Je bijdrage is afgewezen"
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.accepted"
+msgstr "Jouw tijd en moeite helpen dit onderzoek verder.<br>Graag tot de volgende keer."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected"
+msgstr "Je bijdrage is afgewezen."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected.with_reason"
+msgstr "Je bijdrage is afgewezen om de volgende reden:"
+
+#, elixir-autogen, elixir-format
+msgid "participation.back_home.button"
+msgstr "Terug naar startpagina"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-assignment.po
@@ -746,3 +746,27 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "contributions.confirm_all.error"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.accepted"
+msgstr "Îți mulțumim!"
+
+#, elixir-autogen, elixir-format
+msgid "participation.title.rejected"
+msgstr "Contribuția ta a fost respinsă"
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.accepted"
+msgstr "Timpul și efortul tău ajută această cercetare să avanseze.<br>Pe curând."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected"
+msgstr "Contribuția ta a fost respinsă."
+
+#, elixir-autogen, elixir-format
+msgid "participation.body.rejected.with_reason"
+msgstr "Contribuția ta a fost respinsă din următorul motiv:"
+
+#, elixir-autogen, elixir-format
+msgid "participation.back_home.button"
+msgstr "Înapoi la pagina principală"

--- a/core/systems/assignment/crew_page_builder.ex
+++ b/core/systems/assignment/crew_page_builder.ex
@@ -97,7 +97,7 @@ defmodule Systems.Assignment.CrewPageBuilder do
         email_or_work_view(assignment, assigns, tester?)
 
       :decline ->
-        finished_view(assignment, assigns)
+        participation_or_finished_view(assignment, assigns)
 
       :retry ->
         consent_or_work_view(assignment, assigns, tester?)
@@ -106,7 +106,7 @@ defmodule Systems.Assignment.CrewPageBuilder do
         work_view(assignment, assigns)
 
       :work_done ->
-        finished_view(assignment, assigns)
+        participation_or_finished_view(assignment, assigns)
     end
   end
 
@@ -124,7 +124,7 @@ defmodule Systems.Assignment.CrewPageBuilder do
         activate_account_view(assignment, assigns)
 
       tasks_finished?(assignment, assigns) ->
-        finished_view(assignment, assigns)
+        participation_or_finished_view(assignment, assigns)
 
       not is_nil(user_state) ->
         work_view(assignment, assigns)
@@ -233,6 +233,26 @@ defmodule Systems.Assignment.CrewPageBuilder do
     CoreWeb.Live.Element.prepare_live_view(
       "finished_view_#{assignment_id}",
       Assignment.FinishedView,
+      live_context: context
+    )
+  end
+
+  # After the owner has accepted or rejected the participant's contribution the
+  # outcome is terminal — no retry, no email capture, just a short outcome
+  # message + navigate-home. Falls through to the finished_view for the still-
+  # pending / no-review-yet state.
+  defp participation_or_finished_view(assignment, %{current_user: user} = assigns) do
+    case Assignment.Public.get_participation(assignment, user) do
+      %{rejected_at: %NaiveDateTime{}} -> participation_view(assignment, assigns)
+      %{accepted_at: %NaiveDateTime{}} -> participation_view(assignment, assigns)
+      _ -> finished_view(assignment, assigns)
+    end
+  end
+
+  defp participation_view(%{id: assignment_id} = _assignment, %{live_context: context} = _assigns) do
+    CoreWeb.Live.Element.prepare_live_view(
+      "participation_view_#{assignment_id}",
+      Assignment.ParticipationView,
       live_context: context
     )
   end

--- a/core/systems/assignment/participation_view.ex
+++ b/core/systems/assignment/participation_view.ex
@@ -1,0 +1,51 @@
+defmodule Systems.Assignment.ParticipationView do
+  @moduledoc """
+  Terminal outcome page for a reviewed contribution: :accepted or :rejected.
+  No retry affordance. A "back to home" plain-arrow button lets the participant
+  navigate away.
+  """
+  use CoreWeb, :embedded_live_view
+  use CoreWeb, :verified_routes
+
+  alias Frameworks.Pixel.Button
+  alias Frameworks.Pixel.Text
+
+  alias Systems.Assignment
+
+  def dependencies(), do: [:assignment_id, :current_user]
+
+  def get_model(:not_mounted_at_router, _session, %{assigns: %{assignment_id: assignment_id}}) do
+    Assignment.Public.get!(assignment_id, Assignment.Model.preload_graph(:down))
+  end
+
+  @impl true
+  def mount(:not_mounted_at_router, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col w-full h-full py-10" data-testid="participation-view">
+      <div class="flex-grow" />
+      <Area.sheet>
+        <div class="flex flex-col gap-8 items-center text-center">
+          <div data-testid={"participation-#{@vm.outcome}"} class="flex flex-col gap-6 items-center">
+            <Text.title2 margin=""><%= @vm.title %></Text.title2>
+            <div class="flex flex-col gap-2 items-center">
+              <Text.body align="text-center"><%= Phoenix.HTML.raw(@vm.body) %></Text.body>
+              <div :if={@vm.reason} class="italic" data-testid="participation-reason">
+                <Text.body align="text-center">&ldquo;<%= @vm.reason %>&rdquo;</Text.body>
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-row justify-center" data-testid="participation-buttons">
+            <Button.dynamic {@vm.home_button} testid="participation-home-button" />
+          </div>
+        </div>
+      </Area.sheet>
+      <div class="flex-grow" />
+    </div>
+    """
+  end
+end

--- a/core/systems/assignment/participation_view_builder.ex
+++ b/core/systems/assignment/participation_view_builder.ex
@@ -1,0 +1,57 @@
+defmodule Systems.Assignment.ParticipationViewBuilder do
+  @moduledoc """
+  View model for `Systems.Assignment.ParticipationView` — shown after the owner
+  has reviewed a participant's contribution (accepted or rejected). Terminal
+  from the participant's perspective; no retry.
+  """
+  use Gettext, backend: CoreWeb.Gettext
+
+  alias Systems.Assignment
+
+  def view_model(%Assignment.Model{} = assignment, %{current_user: user}) do
+    participation = Assignment.Public.get_participation(assignment, user)
+    outcome = outcome(participation)
+
+    %{
+      outcome: outcome,
+      title: title(outcome),
+      body: body(outcome, participation),
+      reason: reason(outcome, participation),
+      home_button: home_button()
+    }
+  end
+
+  defp outcome(%Assignment.ParticipationModel{rejected_at: %NaiveDateTime{}}), do: :rejected
+  defp outcome(%Assignment.ParticipationModel{accepted_at: %NaiveDateTime{}}), do: :accepted
+
+  defp title(:accepted), do: dgettext("eyra-assignment", "participation.title.accepted")
+  defp title(:rejected), do: dgettext("eyra-assignment", "participation.title.rejected")
+
+  defp body(:accepted, _participation),
+    do: dgettext("eyra-assignment", "participation.body.accepted")
+
+  defp body(:rejected, %Assignment.ParticipationModel{rejected_message: reason})
+       when is_binary(reason) and reason != "",
+       do: dgettext("eyra-assignment", "participation.body.rejected.with_reason")
+
+  defp body(:rejected, _participation),
+    do: dgettext("eyra-assignment", "participation.body.rejected")
+
+  defp reason(:rejected, %Assignment.ParticipationModel{rejected_message: reason})
+       when is_binary(reason) and reason != "",
+       do: reason
+
+  defp reason(_outcome, _participation), do: nil
+
+  defp home_button do
+    %{
+      action: %{type: :redirect, to: "/"},
+      face: %{
+        type: :plain,
+        icon: :back,
+        icon_align: :left,
+        label: dgettext("eyra-assignment", "participation.back_home.button")
+      }
+    }
+  end
+end


### PR DESCRIPTION
## Summary
UJ-Link-05 step 6 requires that when an owner rejects a participant's contribution, the reason is surfaced together with the Declined status. Today the participant only sees a raw "Rejected" pill on the Home rewards card — no reason anywhere.

Rather than crowd the reason into the existing `FinishedView` (which still offers a "retry" affordance and an email-capture flow), give the reviewed outcome its own terminal page: `Systems.Assignment.ParticipationView`. `CrewPageBuilder` routes to it whenever `Assignment.Participation.accepted_at || rejected_at` is set. No retry — the outcome is final. Simple back-to-home plain button.

**Rejected variant** — title + "declined for the following reason:" body + the researcher's `rejected_message` in typographic quotes + italics, on its own line.
**Accepted variant** — warm "Thank you!" title with a short body ending in "See you next time." (no double-thanks with the title).

The reason is a separate view-model field (not interpolated into the msgstr) so it can be styled independently. Body msgstrs allow richtext via `<br>` and render with `Phoenix.HTML.raw`. Content is centered horizontally + vertically inside `Area.sheet` (760px) so the terminal page has consistent visual weight.

Translations added for all 7 locales.

Fixes https://app.basecamp.com/5734045/buckets/35926565/todos/10188267534

## Test plan
- [ ] Complete a Data Donation assignment as a participant on eyra-next-dev.
- [ ] As the owner, accept the contribution → participant re-visits the assignment URL and sees the accepted page ("Thank you!" + "Your time and effort..." + "See you next time." + back-to-home).
- [ ] Repeat: reject the contribution with a reason → participant sees the rejected page (title + "declined for the following reason:" + the reason quoted + italic on its own line).
- [ ] Verify all 7 locales render translated text (creator-side is pinned to English so switch a participant to nl/de/it/es/lt/ro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)