### PR TITLE
feat(assignment): notify participants of contribution outcome + realtime NBA refresh

### DIFF
--- a/core/config/config.exs
+++ b/core/config/config.exs
@@ -18,6 +18,15 @@ config :mime, :types, %{
 # defaulting to :prod for safety.
 config :core, :deploy_env, :local
 
+# Notify system — list of per-system notifier modules that declare their
+# events via `use Systems.Notify.EventDeclaration`. Add a system to this list
+# when it drops a `_notify.ex`; envs can override to short-circuit notifiers
+# (e.g. omit an integration-only notifier in dev).
+config :core, Systems.Notify,
+  notifiers: [
+    Systems.Assignment.Notify
+  ]
+
 # UserCheck email validation. Default to real HTTP client; dev/test override to mock.
 config :core, Frameworks.UserCheck,
   client: Frameworks.UserCheck.HTTPClient,

--- a/core/priv/gettext/en/LC_MESSAGES/eyra-nextaction.po
+++ b/core/priv/gettext/en/LC_MESSAGES/eyra-nextaction.po
@@ -93,3 +93,23 @@ msgstr "Review completed contributions on %{name}."
 #, elixir-autogen, elixir-format
 msgid "assignment.pending_contributions.title"
 msgstr "New contributions"
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.accepted.title"
+msgstr "Contribution accepted"
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.declined.title"
+msgstr "Contribution declined"
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.accepted.description"
+msgstr "The researcher accepted your contribution."
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.declined.description"
+msgstr "The researcher declined your contribution."
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.cta"
+msgstr "View outcome"

--- a/core/priv/gettext/nl/LC_MESSAGES/eyra-nextaction.po
+++ b/core/priv/gettext/nl/LC_MESSAGES/eyra-nextaction.po
@@ -93,3 +93,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "assignment.pending_contributions.title"
 msgstr ""
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.accepted.title"
+msgstr "Bijdrage geaccepteerd"
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.declined.title"
+msgstr "Bijdrage afgewezen"
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.accepted.description"
+msgstr "De onderzoeker heeft je bijdrage geaccepteerd."
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.declined.description"
+msgstr "De onderzoeker heeft je bijdrage afgewezen."
+
+#, elixir-autogen, elixir-format
+msgid "assignment.contribution_reviewed.cta"
+msgstr "Bekijk resultaat"

--- a/core/priv/repo/migrations/20260812150000_create_notify_tables.exs
+++ b/core/priv/repo/migrations/20260812150000_create_notify_tables.exs
@@ -1,0 +1,39 @@
+defmodule Core.Repo.Migrations.CreateNotifyTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:notify_event) do
+      add(:type, :string, null: false)
+      add(:subject_user_id, references(:users, on_delete: :nilify_all), null: false)
+      add(:actor_user_id, references(:users, on_delete: :nilify_all))
+      add(:metadata, :map, default: %{}, null: false)
+      add(:correlation_id, :string)
+      add(:source, :string)
+      add(:dispatched_at, :utc_datetime_usec)
+
+      timestamps()
+    end
+
+    create(index(:notify_event, [:subject_user_id]))
+    create(index(:notify_event, [:type]))
+    create(index(:notify_event, [:correlation_id]))
+    # For the scheduler worker: find pending events cheaply
+    create(index(:notify_event, [:dispatched_at]))
+
+    create table(:notify_message) do
+      add(:event_id, references(:notify_event, on_delete: :delete_all), null: false)
+      add(:channel, :string, null: false)
+      add(:payload, :map, default: %{}, null: false)
+      add(:status, :string, null: false, default: "pending")
+      add(:delivered_at, :utc_datetime_usec)
+      add(:seen_at, :utc_datetime_usec)
+      add(:failure_reason, :text)
+      add(:attempts, :integer, default: 0, null: false)
+
+      timestamps()
+    end
+
+    create(index(:notify_message, [:event_id]))
+    create(index(:notify_message, [:status, :channel]))
+  end
+end

--- a/core/systems/assignment/_notify.ex
+++ b/core/systems/assignment/_notify.ex
@@ -1,0 +1,13 @@
+defmodule Systems.Assignment.Notify do
+  @moduledoc """
+  Notification events published by the Assignment system.
+
+  Add new events here as they're introduced elsewhere in the codebase; the
+  channel list drives which delivery adapters `Systems.Notify.Dispatcher`
+  fans out to.
+  """
+  use Systems.Notify.EventDeclaration
+
+  event(:contribution_accepted, channels: [:email, :na])
+  event(:contribution_declined, channels: [:email, :na])
+end

--- a/core/systems/assignment/_public.ex
+++ b/core/systems/assignment/_public.ex
@@ -968,6 +968,17 @@ defmodule Systems.Assignment.Public do
   Downstream housekeeping (owner next-action, view refreshes) lives in
   `Assignment.Switch` and runs after the transaction commits.
   """
+  def complete_participation(%Assignment.Model{} = assignment, %User{} = user) do
+    case get_participation(assignment, user) do
+      %Assignment.ParticipationModel{completed_at: %NaiveDateTime{}} = p ->
+        {:ok, p}
+
+      _ ->
+        {:ok, participation} = obtain_participation(assignment, user)
+        complete_participation(participation)
+    end
+  end
+
   def complete_participation(%Assignment.ParticipationModel{completed_at: %NaiveDateTime{}} = p),
     do: {:ok, p}
 

--- a/core/systems/assignment/_switch.ex
+++ b/core/systems/assignment/_switch.ex
@@ -9,6 +9,7 @@ defmodule Systems.Assignment.Switch do
   alias Systems.Project
   alias Systems.Account
   alias Systems.Assignment
+  alias Systems.Notify
   alias Systems.Workflow
   alias Systems.Crew
   alias Systems.NextAction
@@ -82,9 +83,10 @@ defmodule Systems.Assignment.Switch do
       Assignment.Public.get!(participation.assignment_id, Assignment.Model.preload_graph(:down))
 
     if assignment.fund do
-      clear_pending_payout_if_empty(assignment)
       dispatch!({:fund_rewards_summary, :updated}, %{user_id: participation.user_id})
     end
+
+    notify_participant(:contribution_accepted, %{participation | assignment: assignment})
 
     update_content_page(assignment, from_pid)
     update_assignment_embedded_views(assignment, from_pid)
@@ -103,9 +105,10 @@ defmodule Systems.Assignment.Switch do
       Assignment.Public.get!(participation.assignment_id, Assignment.Model.preload_graph(:down))
 
     if assignment.fund do
-      clear_pending_payout_if_empty(assignment)
       dispatch!({:fund_rewards_summary, :updated}, %{user_id: participation.user_id})
     end
+
+    notify_participant(:contribution_declined, %{participation | assignment: assignment})
 
     update_content_page(assignment, from_pid)
     update_assignment_embedded_views(assignment, from_pid)
@@ -507,7 +510,13 @@ defmodule Systems.Assignment.Switch do
        }) do
     users = auth_module().users_with_role(auth_node_id, :owner)
 
-    opts = [key: "#{assignment_id}", params: %{id: assignment_id}]
+    opts = [
+      key: "#{assignment_id}",
+      params: %{
+        "id" => assignment_id,
+        "node_id" => Systems.Project.Public.get_node_id_by(assignment_id)
+      }
+    ]
 
     case {old_status, new_status} do
       {_, :rejected} ->
@@ -527,33 +536,31 @@ defmodule Systems.Assignment.Switch do
     member = Assignment.Public.get_member_by_task(crew_task, [:user])
 
     if member && Crew.Public.finished?(member) do
-      {:ok, participation} = Assignment.Public.obtain_participation(assignment, member.user)
-      Assignment.Public.complete_participation(participation)
+      Assignment.Public.complete_participation(assignment, member.user)
     end
   end
 
-  defp clear_pending_payout_if_empty(%Assignment.Model{fund: nil} = assignment) do
-    clear_pending_payout(assignment)
-  end
-
-  defp clear_pending_payout_if_empty(%Assignment.Model{fund: fund} = assignment) do
-    if Systems.Fund.Public.list_pending_approvals(fund) == [] do
-      clear_pending_payout(assignment)
-    end
-  end
-
-  defp clear_pending_payout(%Assignment.Model{id: assignment_id} = assignment) do
-    case Assignment.Public.owners(assignment) do
-      [] ->
-        :ok
-
-      owners ->
-        NextAction.Public.clear_next_action(
-          owners,
-          Systems.Assignment.NextActions.PendingContributions,
-          key: "#{assignment_id}"
-        )
-    end
+  defp notify_participant(
+         type,
+         %Assignment.ParticipationModel{
+           id: participation_id,
+           user_id: user_id,
+           rejected_message: rejected_message,
+           assignment: %Assignment.Model{id: assignment_id, info: info} = assignment
+         }
+       ) do
+    Notify.Public.record_event(%{
+      type: type,
+      subject_user: %{id: user_id},
+      metadata: %{
+        "assignment_id" => assignment_id,
+        "assignment_title" => info && info.title,
+        "node_id" => Systems.Project.Public.get_node_id_by(assignment),
+        "rejected_message" => rejected_message
+      },
+      correlation_id: "participation:#{participation_id}",
+      source: __MODULE__
+    })
   end
 
   defp create_pending_contributions_next_action(%Assignment.Model{id: assignment_id} = assignment) do
@@ -566,7 +573,10 @@ defmodule Systems.Assignment.Switch do
           owners,
           Systems.Assignment.NextActions.PendingContributions,
           key: "#{assignment_id}",
-          params: %{"assignment_id" => assignment_id}
+          params: %{
+            "assignment_id" => assignment_id,
+            "node_id" => Systems.Project.Public.get_node_id_by(assignment)
+          }
         )
     end
   end

--- a/core/systems/assignment/_switch.ex
+++ b/core/systems/assignment/_switch.ex
@@ -549,7 +549,7 @@ defmodule Systems.Assignment.Switch do
            assignment: %Assignment.Model{id: assignment_id, info: info} = assignment
          }
        ) do
-    Notify.Public.record_event(%{
+    Notify.Public.record_event(%Notify.EventAttrs{
       type: type,
       subject_user: %{id: user_id},
       metadata: %{

--- a/core/systems/assignment/contributions_view.ex
+++ b/core/systems/assignment/contributions_view.ex
@@ -5,6 +5,7 @@ defmodule Systems.Assignment.ContributionsView do
 
   alias Frameworks.Pixel.Text
   alias Systems.Assignment
+  alias Systems.NextAction
 
   @decline_modal_id "decline-contribution-modal"
 
@@ -15,7 +16,17 @@ defmodule Systems.Assignment.ContributionsView do
   end
 
   @impl true
-  def mount(:not_mounted_at_router, _session, socket) do
+  def mount(
+        :not_mounted_at_router,
+        _session,
+        %{assigns: %{assignment_id: assignment_id, current_user: user}} = socket
+      ) do
+    NextAction.Public.clear_next_action(
+      user,
+      Systems.Assignment.NextActions.PendingContributions,
+      key: "#{assignment_id}"
+    )
+
     {:ok, socket}
   end
 

--- a/core/systems/assignment/crew_page.ex
+++ b/core/systems/assignment/crew_page.ex
@@ -133,8 +133,7 @@ defmodule Systems.Assignment.CrewPage do
         %{name: :work_done},
         %{assigns: %{model: assignment, current_user: user}} = socket
       ) do
-    {:ok, participation} = Assignment.Public.obtain_participation(assignment, user)
-    Assignment.Public.complete_participation(participation)
+    Assignment.Public.complete_participation(assignment, user)
 
     {:stop, socket |> handle_action(:work_done)}
   end

--- a/core/systems/assignment/next_actions/contribution_reviewed.ex
+++ b/core/systems/assignment/next_actions/contribution_reviewed.ex
@@ -1,0 +1,36 @@
+defmodule Systems.Assignment.NextActions.ContributionReviewed do
+  @moduledoc """
+  Next-action surfaced to a participant after the owner has reviewed their
+  contribution — variants for `accepted` and `declined`. Links back to the
+  assignment's participation outcome page.
+  """
+  @behaviour Systems.NextAction.ViewModel
+  use CoreWeb, :verified_routes
+
+  use Gettext, backend: CoreWeb.Gettext
+
+  @impl Systems.NextAction.ViewModel
+  def to_view_model(_count, %{"assignment_id" => assignment_id, "outcome" => outcome}) do
+    %{
+      title: title(outcome),
+      description: description(outcome),
+      cta_label: dgettext("eyra-nextaction", "assignment.contribution_reviewed.cta"),
+      cta_action: %{
+        type: :redirect,
+        to: ~p"/assignment/#{assignment_id}"
+      }
+    }
+  end
+
+  defp title("accepted"),
+    do: dgettext("eyra-nextaction", "assignment.contribution_reviewed.accepted.title")
+
+  defp title("declined"),
+    do: dgettext("eyra-nextaction", "assignment.contribution_reviewed.declined.title")
+
+  defp description("accepted"),
+    do: dgettext("eyra-nextaction", "assignment.contribution_reviewed.accepted.description")
+
+  defp description("declined"),
+    do: dgettext("eyra-nextaction", "assignment.contribution_reviewed.declined.description")
+end

--- a/core/systems/assignment/participation_view.ex
+++ b/core/systems/assignment/participation_view.ex
@@ -11,6 +11,7 @@ defmodule Systems.Assignment.ParticipationView do
   alias Frameworks.Pixel.Text
 
   alias Systems.Assignment
+  alias Systems.Notify
 
   def dependencies(), do: [:assignment_id, :current_user]
 
@@ -19,8 +20,26 @@ defmodule Systems.Assignment.ParticipationView do
   end
 
   @impl true
-  def mount(:not_mounted_at_router, _session, socket) do
+  def mount(
+        :not_mounted_at_router,
+        _session,
+        %{assigns: %{assignment_id: assignment_id, current_user: user}} = socket
+      ) do
+    # Participant has landed on their outcome page → tell Notify the outcome
+    # messages for this participation have been seen.
+    mark_outcome_seen(assignment_id, user)
+
     {:ok, socket}
+  end
+
+  defp mark_outcome_seen(assignment_id, user) do
+    case Assignment.Public.get_participation(%Assignment.Model{id: assignment_id}, user) do
+      %Assignment.ParticipationModel{id: participation_id} ->
+        Notify.Public.mark_seen(user, correlation_id: "participation:#{participation_id}")
+
+      _ ->
+        :ok
+    end
   end
 
   @impl true

--- a/core/systems/email/email/contribution_accepted.html.eex
+++ b/core/systems/email/email/contribution_accepted.html.eex
@@ -1,0 +1,12 @@
+<h1>Your contribution was accepted</h1>
+
+<p>Thank you! Your time and effort help this research move forward. See you next time.</p>
+
+<%= if @metadata["assignment_title"] do %>
+<p><strong>Assignment:</strong> <%= @metadata["assignment_title"] %></p>
+<% end %>
+
+<br />
+Kind regards,
+<br /><br />
+The Eyra team

--- a/core/systems/email/email/contribution_accepted.text.eex
+++ b/core/systems/email/email/contribution_accepted.text.eex
@@ -1,0 +1,9 @@
+Your contribution was accepted
+
+Thank you! Your time and effort help this research move forward. See you next time.
+
+<%= if @metadata["assignment_title"] do %>Assignment: <%= @metadata["assignment_title"] %><% end %>
+
+Kind regards,
+
+The Eyra team

--- a/core/systems/email/email/contribution_declined.html.eex
+++ b/core/systems/email/email/contribution_declined.html.eex
@@ -1,0 +1,17 @@
+<h1>Your contribution was declined</h1>
+
+<%= if @metadata["rejected_message"] && @metadata["rejected_message"] != "" do %>
+<p>Your contribution was declined for the following reason:</p>
+<p><em>&ldquo;<%= @metadata["rejected_message"] %>&rdquo;</em></p>
+<% else %>
+<p>Your contribution was declined.</p>
+<% end %>
+
+<%= if @metadata["assignment_title"] do %>
+<p><strong>Assignment:</strong> <%= @metadata["assignment_title"] %></p>
+<% end %>
+
+<br />
+Kind regards,
+<br /><br />
+The Eyra team

--- a/core/systems/email/email/contribution_declined.text.eex
+++ b/core/systems/email/email/contribution_declined.text.eex
@@ -1,0 +1,12 @@
+Your contribution was declined
+
+<%= if @metadata["rejected_message"] && @metadata["rejected_message"] != "" do %>Your contribution was declined for the following reason:
+
+"<%= @metadata["rejected_message"] %>"
+<% else %>Your contribution was declined.<% end %>
+
+<%= if @metadata["assignment_title"] do %>Assignment: <%= @metadata["assignment_title"] %><% end %>
+
+Kind regards,
+
+The Eyra team

--- a/core/systems/email/email_html.ex
+++ b/core/systems/email/email_html.ex
@@ -81,4 +81,20 @@ defmodule Systems.Email.EmailHTML do
   def update_email_instructions("text", assigns) do
     update_email_instructions_text(assigns)
   end
+
+  def contribution_accepted("html", assigns) do
+    contribution_accepted_html(assigns)
+  end
+
+  def contribution_accepted("text", assigns) do
+    contribution_accepted_text(assigns)
+  end
+
+  def contribution_declined("html", assigns) do
+    contribution_declined_html(assigns)
+  end
+
+  def contribution_declined("text", assigns) do
+    contribution_declined_text(assigns)
+  end
 end

--- a/core/systems/email/factory.ex
+++ b/core/systems/email/factory.ex
@@ -61,6 +61,18 @@ defmodule Systems.Email.Factory do
     |> render(:debug_message, body: message, from_user: from_user, to_user: to_user)
   end
 
+  def contribution_accepted(user, metadata) do
+    mail_user(user)
+    |> subject("Your contribution was accepted")
+    |> render(:contribution_accepted, metadata: metadata)
+  end
+
+  def contribution_declined(user, metadata) do
+    mail_user(user)
+    |> subject("Your contribution was declined")
+    |> render(:contribution_declined, metadata: metadata)
+  end
+
   def notification(title, byline, message, to) do
     text_message = message
     html_message = message |> to_html()

--- a/core/systems/home/_switch.ex
+++ b/core/systems/home/_switch.ex
@@ -11,8 +11,20 @@ defmodule Systems.Home.Switch do
 
   @impl true
   def intercept({:fund_rewards_summary, _}, %{user_id: user_id}) do
+    refresh_home_for(user_id)
+    :ok
+  end
+
+  # NextAction changes affect the NBA card on Home. Fires for both :created
+  # and :cleared so the card appears/disappears live without a page reload.
+  @impl true
+  def intercept({:next_action, _}, %{user: %{id: user_id}}) do
+    refresh_home_for(user_id)
+    :ok
+  end
+
+  defp refresh_home_for(user_id) do
     model = Observatory.SingletonModel.instance()
     Observatory.Public.dispatch(Home.Page, [model.id, user_id], %{model: model})
-    :ok
   end
 end

--- a/core/systems/notify/_public.ex
+++ b/core/systems/notify/_public.ex
@@ -15,26 +15,16 @@ defmodule Systems.Notify.Public do
   alias Systems.Notify.EventModel
   alias Systems.Notify.EventType
   alias Systems.Notify.MessageModel
+  alias Systems.Notify.EventAttrs
   alias Systems.Notify.Scheduler
 
   @doc """
   Record a domain event and hand it to the scheduler.
 
-  Attrs shape:
-
-      %{
-        type: :contribution_accepted,           # required
-        subject_user: %User{},                  # required — the recipient
-        actor_user: %User{} | nil,              # optional — who caused it
-        metadata: %{...},                       # required — event-type-specific
-        correlation_id: "participation:42",     # optional — future batching
-        source: "Systems.Assignment.Switch"     # optional — for debugging
-      }
-
   Also increments a `Systems.Monitor` counter for aggregate observability;
   Monitor failures don't fail the event persistence.
   """
-  def record_event(attrs) do
+  def record_event(%EventAttrs{} = attrs) do
     normalized = normalize(attrs)
 
     with :ok <- validate_type(normalized.type),
@@ -45,14 +35,14 @@ defmodule Systems.Notify.Public do
     end
   end
 
-  defp normalize(%{} = attrs) do
+  defp normalize(%EventAttrs{} = attrs) do
     %{
-      type: to_string(attrs[:type] || attrs["type"]),
-      subject_user_id: user_id(attrs[:subject_user] || attrs["subject_user"]),
-      actor_user_id: user_id(attrs[:actor_user] || attrs["actor_user"]),
-      metadata: attrs[:metadata] || attrs["metadata"] || %{},
-      correlation_id: attrs[:correlation_id] || attrs["correlation_id"],
-      source: source(attrs[:source] || attrs["source"])
+      type: to_string(attrs.type),
+      subject_user_id: user_id(attrs.subject_user),
+      actor_user_id: user_id(attrs.actor_user),
+      metadata: attrs.metadata,
+      correlation_id: attrs.correlation_id,
+      source: source(attrs.source)
     }
   end
 

--- a/core/systems/notify/_public.ex
+++ b/core/systems/notify/_public.ex
@@ -1,0 +1,171 @@
+defmodule Systems.Notify.Public do
+  @moduledoc """
+  Public API for `Systems.Notify`. Domain code calls `record_event/1` from
+  wherever a notifiable thing happens; the scheduler + channels take it from
+  there.
+  """
+  require Logger
+
+  import Ecto.Query
+
+  alias Core.Repo
+
+  alias Systems.Monitor
+  alias Systems.Notify
+  alias Systems.Notify.EventModel
+  alias Systems.Notify.EventType
+  alias Systems.Notify.MessageModel
+  alias Systems.Notify.Scheduler
+
+  @doc """
+  Record a domain event and hand it to the scheduler.
+
+  Attrs shape:
+
+      %{
+        type: :contribution_accepted,           # required
+        subject_user: %User{},                  # required — the recipient
+        actor_user: %User{} | nil,              # optional — who caused it
+        metadata: %{...},                       # required — event-type-specific
+        correlation_id: "participation:42",     # optional — future batching
+        source: "Systems.Assignment.Switch"     # optional — for debugging
+      }
+
+  Also increments a `Systems.Monitor` counter for aggregate observability;
+  Monitor failures don't fail the event persistence.
+  """
+  def record_event(attrs) do
+    normalized = normalize(attrs)
+
+    with :ok <- validate_type(normalized.type),
+         {:ok, event} <- insert_event(normalized) do
+      log_to_monitor(event)
+      Scheduler.schedule(event)
+      {:ok, event}
+    end
+  end
+
+  defp normalize(%{} = attrs) do
+    %{
+      type: to_string(attrs[:type] || attrs["type"]),
+      subject_user_id: user_id(attrs[:subject_user] || attrs["subject_user"]),
+      actor_user_id: user_id(attrs[:actor_user] || attrs["actor_user"]),
+      metadata: attrs[:metadata] || attrs["metadata"] || %{},
+      correlation_id: attrs[:correlation_id] || attrs["correlation_id"],
+      source: source(attrs[:source] || attrs["source"])
+    }
+  end
+
+  # Accept a module atom (`Systems.Assignment.Switch`) or a plain string; store
+  # as string so the DB column stays portable + inspectable.
+  defp source(nil), do: nil
+  defp source(module) when is_atom(module), do: inspect(module)
+  defp source(str) when is_binary(str), do: str
+
+  defp user_id(nil), do: nil
+  defp user_id(%{id: id}), do: id
+
+  defp validate_type(type) do
+    if EventType.known?(type) do
+      :ok
+    else
+      {:error, {:unknown_event_type, type}}
+    end
+  end
+
+  defp insert_event(attrs) do
+    %EventModel{}
+    |> EventModel.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Mark messages as seen by the user. Each channel adapter's `mark_seen/1`
+  callback (if implemented) runs the side effect (e.g. NA clears the NBA);
+  message status flips to `:seen` and `seen_at` stamped.
+
+  Filter options (at least one required):
+
+      * `correlation_id: "participation:42"` — match a specific correlation
+      * `event_types: [:contribution_accepted, :contribution_declined]` — match by type
+
+  Idempotent: messages already `:seen` are ignored.
+  """
+  def mark_seen(%{id: user_id}, opts) when is_list(opts) do
+    messages = messages_to_mark_seen(user_id, opts)
+
+    Enum.each(messages, &mark_message_seen/1)
+
+    {:ok, length(messages)}
+  end
+
+  defp messages_to_mark_seen(user_id, opts) do
+    correlation_id = Keyword.get(opts, :correlation_id)
+    event_types = Keyword.get(opts, :event_types, []) |> Enum.map(&to_string/1)
+
+    query =
+      from(m in MessageModel,
+        join: e in EventModel,
+        on: e.id == m.event_id,
+        where: e.subject_user_id == ^user_id and m.status != :seen
+      )
+
+    query
+    |> maybe_filter_correlation(correlation_id)
+    |> maybe_filter_event_types(event_types)
+    |> Repo.all()
+  end
+
+  defp maybe_filter_correlation(query, nil), do: query
+
+  defp maybe_filter_correlation(query, correlation_id) do
+    from([m, e] in query, where: e.correlation_id == ^correlation_id)
+  end
+
+  defp maybe_filter_event_types(query, []), do: query
+
+  defp maybe_filter_event_types(query, event_types) do
+    from([m, e] in query, where: e.type in ^event_types)
+  end
+
+  defp mark_message_seen(%MessageModel{channel: channel} = message) do
+    adapter = channel_adapter(channel)
+
+    if function_exported?(adapter, :mark_seen, 1) do
+      case safe_mark_seen(adapter, message) do
+        :ok ->
+          :ok
+
+        other ->
+          Logger.warning(
+            "[Notify] channel #{channel} mark_seen returned #{inspect(other)} for message #{message.id}"
+          )
+      end
+    end
+
+    message
+    |> MessageModel.changeset(%{status: :seen, seen_at: DateTime.utc_now()})
+    |> Repo.update()
+  end
+
+  defp safe_mark_seen(adapter, message) do
+    adapter.mark_seen(message)
+  rescue
+    error ->
+      {:error, Exception.message(error)}
+  end
+
+  # Keep in sync with Dispatcher.channel_adapter/1
+  defp channel_adapter(:email), do: Notify.Channel.Email
+  defp channel_adapter(:na), do: Notify.Channel.NA
+
+  # Fire-and-forget metric log. A failure here shouldn't roll back the event.
+  defp log_to_monitor(%EventModel{type: type, subject_user_id: user_id}) do
+    try do
+      Monitor.Public.log(["notify=#{type}", "user=#{user_id}"])
+    rescue
+      error ->
+        Logger.warning("[Notify] monitor log failed: #{Exception.message(error)}")
+    end
+  end
+end

--- a/core/systems/notify/channel.ex
+++ b/core/systems/notify/channel.ex
@@ -1,0 +1,26 @@
+defmodule Systems.Notify.Channel do
+  @moduledoc """
+  Channel-adapter behaviour. A channel takes a persisted `MessageModel` (with
+  its event context) and ships it. The dispatcher handles status transitions
+  based on the return value — adapters just focus on delivery.
+
+  A channel MUST also expose `build_payload/1` — turning an event into the
+  channel-specific payload the dispatcher persists on the message. This
+  keeps rendering (subject/body/action-params) next to delivery.
+  """
+
+  alias Systems.Notify.EventModel
+  alias Systems.Notify.MessageModel
+
+  @callback build_payload(%EventModel{}) :: {:ok, map()} | {:error, term()} | :skip
+  @callback deliver(%MessageModel{}) :: :ok | {:error, term()}
+
+  @doc """
+  Called when `Systems.Notify.Public.mark_seen/2` matches this message.
+  Adapters translate "user has seen the outcome" into channel-specific side
+  effects (NA clears the NBA, future InApp marks the inbox record as read,
+  Email is a no-op). Optional — dispatch handles absence as a no-op.
+  """
+  @callback mark_seen(%MessageModel{}) :: :ok | {:error, term()}
+  @optional_callbacks [mark_seen: 1]
+end

--- a/core/systems/notify/channel/email.ex
+++ b/core/systems/notify/channel/email.ex
@@ -1,0 +1,78 @@
+defmodule Systems.Notify.Channel.Email do
+  @moduledoc """
+  Email channel adapter. Builds a Bamboo email per event and ships it via the
+  existing `Systems.Email` pipeline.
+
+  Payload shape: `%{"factory_fn" => atom_string, "args" => [...]}`. Rendering
+  happens at delivery time in the recipient's locale — we persist only the raw
+  args so a resend still respects locale/copy changes.
+
+  Register per-event-type payload builders as `build_payload/1` clauses below.
+  Unhandled types return `:skip` so the dispatcher just doesn't create an
+  email message for them.
+  """
+  @behaviour Systems.Notify.Channel
+
+  require Logger
+
+  alias Core.Repo
+  alias Systems.Account
+  alias Systems.Email
+  alias Systems.Notify.EventModel
+  alias Systems.Notify.MessageModel
+
+  @impl true
+  def build_payload(%EventModel{type: "contribution_accepted"} = event) do
+    {:ok,
+     %{
+       "factory_fn" => "contribution_accepted",
+       "subject_user_id" => event.subject_user_id,
+       "metadata" => event.metadata
+     }}
+  end
+
+  def build_payload(%EventModel{type: "contribution_declined"} = event) do
+    {:ok,
+     %{
+       "factory_fn" => "contribution_declined",
+       "subject_user_id" => event.subject_user_id,
+       "metadata" => event.metadata
+     }}
+  end
+
+  def build_payload(_event), do: :skip
+
+  @impl true
+  def deliver(%MessageModel{payload: payload}) do
+    with {:ok, user} <- fetch_user(payload["subject_user_id"]),
+         {:ok, email} <- build_email(payload["factory_fn"], user, payload["metadata"]) do
+      Email.Public.deliver_later(email)
+      :ok
+    end
+  end
+
+  defp fetch_user(nil), do: {:error, :no_recipient}
+
+  defp fetch_user(user_id) do
+    case Repo.get(Account.User, user_id) do
+      nil -> {:error, :user_not_found}
+      user -> {:ok, user}
+    end
+  end
+
+  defp build_email("contribution_accepted", user, metadata) do
+    {:ok, Email.Factory.contribution_accepted(user, metadata)}
+  end
+
+  defp build_email("contribution_declined", user, metadata) do
+    {:ok, Email.Factory.contribution_declined(user, metadata)}
+  end
+
+  defp build_email(other, _user, _metadata),
+    do: {:error, {:unknown_factory_fn, other}}
+
+  # Email is out-of-band; the server has no way to unsend or mark-as-read a
+  # message once it's been handed to the delivery worker. Nothing to do.
+  @impl true
+  def mark_seen(_message), do: :ok
+end

--- a/core/systems/notify/channel/na.ex
+++ b/core/systems/notify/channel/na.ex
@@ -1,0 +1,102 @@
+defmodule Systems.Notify.Channel.NA do
+  @moduledoc """
+  Next-Action channel adapter. Creates an NBA on the recipient's Home for the
+  event, via the existing `Systems.NextAction` infrastructure.
+
+  Payload shape: `%{"action_module" => module_string, "key" => string,
+  "params" => map}`. Rendering of the NBA card copy still happens in
+  `<action_module>.to_view_model/2` at request time — that keeps locale-live
+  and lets the NBA update if the underlying data changes.
+  """
+  @behaviour Systems.Notify.Channel
+
+  require Logger
+
+  alias Core.Repo
+  alias Systems.Account
+  alias Systems.NextAction
+  alias Systems.Notify.EventModel
+  alias Systems.Notify.MessageModel
+
+  @impl true
+  def build_payload(%EventModel{
+        type: "contribution_accepted",
+        metadata: %{"assignment_id" => assignment_id} = metadata
+      }) do
+    {:ok,
+     %{
+       "action_module" => "Elixir.Systems.Assignment.NextActions.ContributionReviewed",
+       "key" => "#{assignment_id}:accepted",
+       "params" => %{
+         "assignment_id" => assignment_id,
+         "node_id" => Map.get(metadata, "node_id"),
+         "outcome" => "accepted"
+       }
+     }}
+  end
+
+  def build_payload(%EventModel{
+        type: "contribution_declined",
+        metadata: %{"assignment_id" => assignment_id} = metadata
+      }) do
+    {:ok,
+     %{
+       "action_module" => "Elixir.Systems.Assignment.NextActions.ContributionReviewed",
+       "key" => "#{assignment_id}:declined",
+       "params" => %{
+         "assignment_id" => assignment_id,
+         "node_id" => Map.get(metadata, "node_id"),
+         "outcome" => "declined"
+       }
+     }}
+  end
+
+  def build_payload(_event), do: :skip
+
+  @impl true
+  def deliver(%MessageModel{event_id: event_id, payload: payload}) do
+    with {:ok, event} <- fetch_event(event_id),
+         {:ok, user} <- fetch_user(event.subject_user_id),
+         {:ok, action_module} <- resolve_module(payload["action_module"]) do
+      NextAction.Public.create_next_action(user, action_module,
+        key: payload["key"],
+        params: payload["params"]
+      )
+
+      :ok
+    end
+  end
+
+  defp fetch_event(event_id) do
+    case Repo.get(EventModel, event_id) do
+      nil -> {:error, :event_not_found}
+      event -> {:ok, event}
+    end
+  end
+
+  defp fetch_user(nil), do: {:error, :no_recipient}
+
+  defp fetch_user(user_id) do
+    case Repo.get(Account.User, user_id) do
+      nil -> {:error, :user_not_found}
+      user -> {:ok, user}
+    end
+  end
+
+  defp resolve_module(module_string) when is_binary(module_string) do
+    module = String.to_existing_atom(module_string)
+    {:ok, module}
+  rescue
+    ArgumentError -> {:error, {:unknown_action_module, module_string}}
+  end
+
+  @impl true
+  def mark_seen(%MessageModel{event_id: event_id, payload: payload}) do
+    with {:ok, event} <- fetch_event(event_id),
+         {:ok, user} <- fetch_user(event.subject_user_id),
+         {:ok, action_module} <- resolve_module(payload["action_module"]) do
+      NextAction.Public.clear_next_action(user, action_module, key: payload["key"])
+      :ok
+    end
+  end
+end

--- a/core/systems/notify/dispatcher.ex
+++ b/core/systems/notify/dispatcher.ex
@@ -1,0 +1,128 @@
+defmodule Systems.Notify.Dispatcher do
+  @moduledoc """
+  Event → Messages → Channel delivery.
+
+  For an event, looks up the channels routed to it, asks each channel's
+  adapter to build its payload, persists a `MessageModel` per channel, then
+  hands each message to its channel for delivery. Delivery result flips the
+  message status to `:sent` / `:failed`.
+
+  Channels that decide the event isn't relevant to them can return `:skip`
+  from `build_payload/1` — no message is persisted for that channel.
+  """
+  require Logger
+
+  alias Core.Repo
+  alias Ecto.Multi
+
+  alias Systems.Notify
+  alias Systems.Notify.EventModel
+  alias Systems.Notify.MessageModel
+
+  @doc """
+  Fan an event out to all channels registered for its type. Persists a message
+  per channel and delivers immediately (v1 has no batching / scheduling).
+  Returns `{:ok, messages}` or `{:error, reason}`.
+  """
+  def dispatch(%EventModel{} = event) do
+    channels = Notify.EventType.channels_for(event.type)
+
+    with {:ok, messages} <- build_and_persist_messages(event, channels) do
+      Enum.each(messages, &deliver/1)
+      mark_dispatched(event)
+      {:ok, messages}
+    end
+  end
+
+  defp build_and_persist_messages(event, channels) do
+    channels
+    |> Enum.reduce(Multi.new(), fn channel, multi ->
+      case build_payload(channel, event) do
+        {:ok, payload} ->
+          changeset =
+            MessageModel.changeset(%MessageModel{}, %{
+              event_id: event.id,
+              channel: channel,
+              payload: payload,
+              status: :pending
+            })
+
+          Multi.insert(multi, {:message, channel}, changeset)
+
+        :skip ->
+          multi
+
+        {:error, reason} ->
+          Logger.warning(
+            "[Notification] channel #{channel} build_payload failed for event #{event.id}: #{inspect(reason)}"
+          )
+
+          multi
+      end
+    end)
+    |> Repo.commit()
+    |> case do
+      {:ok, changes} ->
+        messages =
+          changes
+          |> Enum.filter(fn {k, _} -> match?({:message, _}, k) end)
+          |> Enum.map(fn {_, msg} -> msg end)
+
+        {:ok, messages}
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
+    end
+  end
+
+  defp deliver(%MessageModel{} = message) do
+    adapter = channel_adapter(message.channel)
+
+    result =
+      try do
+        adapter.deliver(message)
+      rescue
+        error ->
+          {:error, Exception.message(error)}
+      end
+
+    update_message_after_delivery(message, result)
+  end
+
+  defp update_message_after_delivery(message, :ok) do
+    message
+    |> MessageModel.changeset(%{
+      status: :sent,
+      delivered_at: DateTime.utc_now(),
+      attempts: message.attempts + 1
+    })
+    |> Repo.update()
+  end
+
+  defp update_message_after_delivery(message, {:error, reason}) do
+    message
+    |> MessageModel.changeset(%{
+      status: :failed,
+      failure_reason: inspect(reason),
+      attempts: message.attempts + 1
+    })
+    |> Repo.update()
+  end
+
+  defp mark_dispatched(event) do
+    event
+    |> EventModel.changeset(%{dispatched_at: DateTime.utc_now()})
+    |> Repo.update()
+  end
+
+  defp build_payload(channel, event) do
+    channel
+    |> channel_adapter()
+    |> apply(:build_payload, [event])
+  end
+
+  # Channel routing. Keeping this as a case rather than a data structure so a
+  # rename shows up in `mix xref`.
+  defp channel_adapter(:email), do: Notify.Channel.Email
+  defp channel_adapter(:na), do: Notify.Channel.NA
+end

--- a/core/systems/notify/event_attrs.ex
+++ b/core/systems/notify/event_attrs.ex
@@ -1,0 +1,17 @@
+defmodule Systems.Notify.EventAttrs do
+  @moduledoc """
+  Input struct for `Systems.Notify.Public.record_event/1`. Keeps the
+  contract explicit so callers get a `FunctionClauseError` on the wrong
+  shape instead of a silent `nil` deep in normalize.
+  """
+
+  @enforce_keys [:type, :subject_user]
+  defstruct [
+    :type,
+    :subject_user,
+    :actor_user,
+    :correlation_id,
+    :source,
+    metadata: %{}
+  ]
+end

--- a/core/systems/notify/event_declaration.ex
+++ b/core/systems/notify/event_declaration.ex
@@ -1,0 +1,47 @@
+defmodule Systems.Notify.EventDeclaration do
+  @moduledoc """
+  Per-system notification event registration, mirroring the `_routes.ex`
+  convention. A system opts in by dropping a `_notify.ex`:
+
+      defmodule Systems.Assignment.Notify do
+        use Systems.Notify.EventDeclaration
+
+        event(:contribution_accepted, channels: [:email, :na])
+        event(:contribution_declined, channels: [:email, :na])
+      end
+
+  Then register the notifier module in application config so
+  `Systems.Notify.EventType` finds it:
+
+      config :core, Systems.Notify,
+        notifiers: [Systems.Assignment.Notify, ...]
+
+  Only systems that actually publish events need a `_notify.ex`; adding one
+  later requires no changes elsewhere except a single line in that config
+  list.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      import Systems.Notify.EventDeclaration, only: [event: 2]
+      Module.register_attribute(__MODULE__, :notify_events_acc, accumulate: true)
+      @before_compile Systems.Notify.EventDeclaration
+    end
+  end
+
+  defmacro event(type, opts) do
+    quote do
+      @notify_events_acc {unquote(type), unquote(opts)}
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      @doc """
+      Returns the list of `{event_type, opts}` declared in this module. Used
+      by `Systems.Notify.EventType` to build the global registry.
+      """
+      def notify_events, do: @notify_events_acc
+    end
+  end
+end

--- a/core/systems/notify/event_model.ex
+++ b/core/systems/notify/event_model.ex
@@ -1,0 +1,41 @@
+defmodule Systems.Notify.EventModel do
+  @moduledoc """
+  A raw fact that something happened. Records the "what + who + when" —
+  channels + timing are decided later by `Systems.Notify.Scheduler`.
+
+  `metadata` holds event-type-specific raw data (IDs + snapshotted fields).
+  Rendering to user-facing text happens at message-build time in the
+  recipient's locale.
+  """
+  use Ecto.Schema
+  use Frameworks.Utility.Schema
+
+  import Ecto.Changeset
+
+  alias Systems.Account
+  alias Systems.Notify
+
+  schema "notify_event" do
+    field(:type, :string)
+    field(:metadata, :map, default: %{})
+    field(:correlation_id, :string)
+    field(:source, :string)
+    field(:dispatched_at, :utc_datetime_usec)
+
+    belongs_to(:subject_user, Account.User)
+    belongs_to(:actor_user, Account.User)
+
+    has_many(:messages, Notify.MessageModel, foreign_key: :event_id)
+
+    timestamps()
+  end
+
+  @fields ~w(type metadata correlation_id source subject_user_id actor_user_id dispatched_at)a
+  @required ~w(type subject_user_id)a
+
+  def changeset(event, attrs) do
+    event
+    |> cast(attrs, @fields)
+    |> validate_required(@required)
+  end
+end

--- a/core/systems/notify/event_type.ex
+++ b/core/systems/notify/event_type.ex
@@ -1,0 +1,52 @@
+defmodule Systems.Notify.EventType do
+  @moduledoc """
+  Global registry of notification event types → channel routing.
+
+  Built at first-use from all modules listed in
+  `config :core, Systems.Notify, notifiers: [...]`; each notifier declares
+  its events via `use Systems.Notify.EventDeclaration`.
+
+  Cached in `:persistent_term` — one lookup at first call, direct-map after.
+  """
+
+  @cache_key {__MODULE__, :registry}
+
+  def known?(type) when is_binary(type), do: Map.has_key?(registry(), type)
+  def known?(type) when is_atom(type), do: known?(Atom.to_string(type))
+
+  def channels_for(type) when is_binary(type), do: Map.get(registry(), type, [])
+  def channels_for(type) when is_atom(type), do: channels_for(Atom.to_string(type))
+
+  def all, do: Map.keys(registry())
+
+  @doc """
+  Force a rebuild — useful in tests that swap notifier config on the fly.
+  """
+  def reset do
+    :persistent_term.erase(@cache_key)
+    :ok
+  end
+
+  defp registry do
+    case :persistent_term.get(@cache_key, nil) do
+      nil -> build()
+      map -> map
+    end
+  end
+
+  defp build do
+    notifiers =
+      Application.get_env(:core, Systems.Notify, [])
+      |> Keyword.get(:notifiers, [])
+
+    registry =
+      notifiers
+      |> Enum.flat_map(& &1.notify_events())
+      |> Map.new(fn {type, opts} ->
+        {to_string(type), Keyword.get(opts, :channels, [])}
+      end)
+
+    :persistent_term.put(@cache_key, registry)
+    registry
+  end
+end

--- a/core/systems/notify/message_model.ex
+++ b/core/systems/notify/message_model.ex
@@ -1,0 +1,42 @@
+defmodule Systems.Notify.MessageModel do
+  @moduledoc """
+  A message produced from an event for one specific channel. Channel adapters
+  interpret `payload` shape (e.g. email carries `%{subject, text, html}`, NA
+  carries `%{action_module, key, params}`).
+  """
+  use Ecto.Schema
+  use Frameworks.Utility.Schema
+
+  import Ecto.Changeset
+
+  alias Systems.Notify
+
+  @channels ~w(email na)a
+  @statuses ~w(pending sent failed skipped seen)a
+
+  schema "notify_message" do
+    field(:channel, Ecto.Enum, values: @channels)
+    field(:payload, :map, default: %{})
+    field(:status, Ecto.Enum, values: @statuses, default: :pending)
+    field(:delivered_at, :utc_datetime_usec)
+    field(:seen_at, :utc_datetime_usec)
+    field(:failure_reason, :string)
+    field(:attempts, :integer, default: 0)
+
+    belongs_to(:event, Notify.EventModel)
+
+    timestamps()
+  end
+
+  @fields ~w(channel payload status delivered_at seen_at failure_reason attempts event_id)a
+  @required ~w(channel event_id)a
+
+  def channels, do: @channels
+  def statuses, do: @statuses
+
+  def changeset(message, attrs) do
+    message
+    |> cast(attrs, @fields)
+    |> validate_required(@required)
+  end
+end

--- a/core/systems/notify/scheduler.ex
+++ b/core/systems/notify/scheduler.ex
@@ -1,0 +1,21 @@
+defmodule Systems.Notify.Scheduler do
+  @moduledoc """
+  Decides when + how an event turns into messages.
+
+  v1 is trivial: schedule = dispatch now. The abstraction is here so that later
+  work (batching windows, quiet-hours, throttling, user preferences) plugs in
+  as rule modules without touching event producers.
+  """
+
+  alias Systems.Notify.Dispatcher
+  alias Systems.Notify.EventModel
+
+  @doc """
+  Schedule an event for delivery. In v1 dispatches immediately; future
+  revisions will consult rules (event type, recipient state, time) to decide
+  channels + timing + batching.
+  """
+  def schedule(%EventModel{} = event) do
+    Dispatcher.dispatch(event)
+  end
+end

--- a/core/systems/project/_public.ex
+++ b/core/systems/project/_public.ex
@@ -106,6 +106,17 @@ defmodule Systems.Project.Public do
     get_item_by_special(:storage_endpoint, storage_endpoint_id)
   end
 
+  def get_node_id_by(%Assignment.Model{} = assignment) do
+    case get_item_by(assignment) do
+      %Project.ItemModel{node_id: node_id} -> node_id
+      _ -> nil
+    end
+  end
+
+  def get_node_id_by(assignment_id) when is_integer(assignment_id) do
+    get_node_id_by(%Assignment.Model{id: assignment_id})
+  end
+
   defp get_item_by_special(special_name, special_id) do
     item_query_by_special(special_name, special_id)
     |> Repo.one()

--- a/core/systems/project/_switch.ex
+++ b/core/systems/project/_switch.ex
@@ -39,6 +39,24 @@ defmodule Systems.Project.Switch do
     :ok
   end
 
+  @impl true
+  def intercept({:next_action, _}, %{user: user} = message) do
+    from_pid = Map.get(message, :from_pid, self())
+    update_page(Project.OverviewPage, user, from_pid)
+
+    with node_id when is_integer(node_id) <- node_id_from(message),
+         %Project.NodeModel{} = node <- Project.Public.get_node!(node_id) do
+      update_page(Project.NodePage, node, from_pid)
+    end
+
+    :ok
+  end
+
+  defp node_id_from(%{action: %{params: %{"node_id" => node_id}}}) when is_integer(node_id),
+    do: node_id
+
+  defp node_id_from(_), do: nil
+
   defp update_pages(%Project.NodeModel{} = node, from_pid) do
     [Project.NodePage]
     |> Enum.each(&update_page(&1, node, from_pid))

--- a/core/test/systems/assignment/_public_test.exs
+++ b/core/test/systems/assignment/_public_test.exs
@@ -64,6 +64,38 @@ defmodule Systems.Assignment.PublicTest do
                %{id: ^id_3}
              ] = Assignment.Public.list_participations(assignment)
     end
+
+    test "complete_participation/2 creates and completes when no participation exists" do
+      assignment = Factories.insert!(:assignment)
+      %{user: user} = Factories.build(:affiliate_user) |> Repo.insert!()
+
+      assert {:ok, %{completed_at: %NaiveDateTime{}}} =
+               Assignment.Public.complete_participation(assignment, user)
+    end
+
+    test "complete_participation/2 completes an existing incomplete participation" do
+      assignment = Factories.insert!(:assignment)
+      %{user: user} = Factories.build(:affiliate_user) |> Repo.insert!()
+
+      %{id: participation_id, completed_at: nil} =
+        Assignment.Public.obtain_participation!(assignment, user)
+
+      assert {:ok, %{id: ^participation_id, completed_at: %NaiveDateTime{}}} =
+               Assignment.Public.complete_participation(assignment, user)
+    end
+
+    test "complete_participation/2 is a no-op when participation is already completed" do
+      assignment = Factories.insert!(:assignment)
+      %{user: user} = Factories.build(:affiliate_user) |> Repo.insert!()
+
+      {:ok, %{id: participation_id, completed_at: first_completed_at}} =
+        Assignment.Public.complete_participation(assignment, user)
+
+      {:ok, %{id: ^participation_id, completed_at: second_completed_at}} =
+        Assignment.Public.complete_participation(assignment, user)
+
+      assert first_completed_at == second_completed_at
+    end
   end
 
   describe "assignments" do

--- a/core/test/systems/notify/channel/na_test.exs
+++ b/core/test/systems/notify/channel/na_test.exs
@@ -1,0 +1,71 @@
+defmodule Systems.Notify.Channel.NATest do
+  use ExUnit.Case, async: true
+
+  alias Systems.Notify.Channel.NA
+  alias Systems.Notify.EventModel
+
+  describe "build_payload/1 :contribution_accepted" do
+    test "carries node_id from metadata into params" do
+      event = %EventModel{
+        type: "contribution_accepted",
+        metadata: %{"assignment_id" => 42, "node_id" => 7}
+      }
+
+      assert {:ok,
+              %{
+                "action_module" => "Elixir.Systems.Assignment.NextActions.ContributionReviewed",
+                "key" => "42:accepted",
+                "params" => %{
+                  "assignment_id" => 42,
+                  "node_id" => 7,
+                  "outcome" => "accepted"
+                }
+              }} = NA.build_payload(event)
+    end
+
+    test "sets node_id nil when metadata does not include it" do
+      event = %EventModel{
+        type: "contribution_accepted",
+        metadata: %{"assignment_id" => 42}
+      }
+
+      assert {:ok, %{"params" => %{"node_id" => nil}}} = NA.build_payload(event)
+    end
+  end
+
+  describe "build_payload/1 :contribution_declined" do
+    test "carries node_id from metadata into params" do
+      event = %EventModel{
+        type: "contribution_declined",
+        metadata: %{"assignment_id" => 42, "node_id" => 7}
+      }
+
+      assert {:ok,
+              %{
+                "action_module" => "Elixir.Systems.Assignment.NextActions.ContributionReviewed",
+                "key" => "42:declined",
+                "params" => %{
+                  "assignment_id" => 42,
+                  "node_id" => 7,
+                  "outcome" => "declined"
+                }
+              }} = NA.build_payload(event)
+    end
+
+    test "sets node_id nil when metadata does not include it" do
+      event = %EventModel{
+        type: "contribution_declined",
+        metadata: %{"assignment_id" => 42}
+      }
+
+      assert {:ok, %{"params" => %{"node_id" => nil}}} = NA.build_payload(event)
+    end
+  end
+
+  describe "build_payload/1 unknown event type" do
+    test "returns :skip" do
+      event = %EventModel{type: "unknown_event", metadata: %{}}
+      assert :skip = NA.build_payload(event)
+    end
+  end
+end

--- a/core/test/systems/notify/dispatcher_test.exs
+++ b/core/test/systems/notify/dispatcher_test.exs
@@ -10,7 +10,7 @@ defmodule Systems.Notify.DispatcherTest do
       user = Factories.insert!(:member)
 
       {:ok, event} =
-        Notify.Public.record_event(%{
+        Notify.Public.record_event(%Notify.EventAttrs{
           type: :contribution_accepted,
           subject_user: user,
           metadata: %{"assignment_id" => 42, "assignment_title" => "Test study"}

--- a/core/test/systems/notify/dispatcher_test.exs
+++ b/core/test/systems/notify/dispatcher_test.exs
@@ -1,0 +1,47 @@
+defmodule Systems.Notify.DispatcherTest do
+  use Core.DataCase, async: false
+
+  alias Core.Factories
+  alias Core.Repo
+  alias Systems.Notify
+
+  describe "dispatch/1" do
+    setup do
+      user = Factories.insert!(:member)
+
+      {:ok, event} =
+        Notify.Public.record_event(%{
+          type: :contribution_accepted,
+          subject_user: user,
+          metadata: %{"assignment_id" => 42, "assignment_title" => "Test study"}
+        })
+
+      %{user: user, event: event}
+    end
+
+    test "creates one message per configured channel", %{event: event} do
+      messages =
+        Notify.MessageModel
+        |> Repo.all()
+        |> Enum.filter(&(&1.event_id == event.id))
+
+      channels = messages |> Enum.map(& &1.channel) |> Enum.sort()
+      assert channels == [:email, :na]
+    end
+
+    test "each message ends up in :sent status after delivery", %{event: event} do
+      messages =
+        Notify.MessageModel
+        |> Repo.all()
+        |> Enum.filter(&(&1.event_id == event.id))
+
+      assert Enum.all?(messages, &(&1.status == :sent))
+      assert Enum.all?(messages, &(&1.delivered_at != nil))
+      assert Enum.all?(messages, &(&1.attempts == 1))
+    end
+
+    test "stamps dispatched_at on the event", %{event: event} do
+      assert Repo.reload!(event).dispatched_at != nil
+    end
+  end
+end

--- a/core/test/systems/notify/event_type_test.exs
+++ b/core/test/systems/notify/event_type_test.exs
@@ -1,0 +1,33 @@
+defmodule Systems.Notify.EventTypeTest do
+  use ExUnit.Case, async: false
+
+  alias Systems.Notify.EventType
+
+  setup do
+    # Ensure the persistent_term cache is fresh — other tests may have primed it
+    on_exit(fn -> EventType.reset() end)
+    EventType.reset()
+    :ok
+  end
+
+  test "channels_for/1 reads from configured notifiers" do
+    assert EventType.channels_for(:contribution_accepted) == [:email, :na]
+    assert EventType.channels_for(:contribution_declined) == [:email, :na]
+    assert EventType.channels_for("contribution_accepted") == [:email, :na]
+  end
+
+  test "known?/1 returns true for declared event types" do
+    assert EventType.known?(:contribution_accepted)
+    assert EventType.known?("contribution_declined")
+  end
+
+  test "known?/1 returns false for undeclared event types" do
+    refute EventType.known?(:nope)
+    refute EventType.known?("nope")
+  end
+
+  test "all/0 lists declared event types" do
+    types = EventType.all() |> MapSet.new()
+    assert MapSet.subset?(MapSet.new(["contribution_accepted", "contribution_declined"]), types)
+  end
+end

--- a/core/test/systems/notify/mark_seen_test.exs
+++ b/core/test/systems/notify/mark_seen_test.exs
@@ -1,0 +1,139 @@
+defmodule Systems.Notify.MarkSeenTest do
+  use Core.DataCase, async: false
+
+  alias Core.Factories
+  alias Core.Repo
+
+  alias Systems.NextAction
+  alias Systems.Notify
+
+  describe "mark_seen/2 by correlation_id" do
+    setup do
+      user = Factories.insert!(:member)
+
+      {:ok, event} =
+        Notify.Public.record_event(%{
+          type: :contribution_accepted,
+          subject_user: user,
+          metadata: %{"assignment_id" => 42},
+          correlation_id: "participation:7"
+        })
+
+      %{user: user, event: event}
+    end
+
+    test "flips every message for that correlation to :seen with a timestamp", %{
+      user: user,
+      event: event
+    } do
+      {:ok, count} = Notify.Public.mark_seen(user, correlation_id: "participation:7")
+
+      # Two channels for this event type → two messages marked
+      assert count == 2
+
+      messages =
+        Notify.MessageModel
+        |> Repo.all()
+        |> Enum.filter(&(&1.event_id == event.id))
+
+      assert Enum.all?(messages, &(&1.status == :seen))
+      assert Enum.all?(messages, &(&1.seen_at != nil))
+    end
+
+    test "is idempotent — a second call marks zero", %{user: user} do
+      {:ok, first} = Notify.Public.mark_seen(user, correlation_id: "participation:7")
+      {:ok, second} = Notify.Public.mark_seen(user, correlation_id: "participation:7")
+
+      assert first == 2
+      assert second == 0
+    end
+
+    test "leaves messages for other correlations alone", %{user: user, event: event} do
+      {:ok, _other_event} =
+        Notify.Public.record_event(%{
+          type: :contribution_accepted,
+          subject_user: user,
+          metadata: %{"assignment_id" => 99},
+          correlation_id: "participation:99"
+        })
+
+      {:ok, _} = Notify.Public.mark_seen(user, correlation_id: "participation:7")
+
+      # Only the messages for event 7 are :seen; event 99's are still :sent
+      messages_by_event =
+        Notify.MessageModel
+        |> Repo.all()
+        |> Enum.group_by(& &1.event_id)
+
+      for msg <- messages_by_event[event.id], do: assert(msg.status == :seen)
+
+      other_id = Enum.find(Map.keys(messages_by_event), &(&1 != event.id))
+      for msg <- messages_by_event[other_id], do: assert(msg.status == :sent)
+    end
+  end
+
+  describe "mark_seen/2 by event_types" do
+    test "matches messages by event type regardless of correlation" do
+      user = Factories.insert!(:member)
+
+      {:ok, _accepted} =
+        Notify.Public.record_event(%{
+          type: :contribution_accepted,
+          subject_user: user,
+          metadata: %{"assignment_id" => 1},
+          correlation_id: "participation:1"
+        })
+
+      {:ok, _declined} =
+        Notify.Public.record_event(%{
+          type: :contribution_declined,
+          subject_user: user,
+          metadata: %{"assignment_id" => 2},
+          correlation_id: "participation:2"
+        })
+
+      # Only accepted-type messages should get :seen
+      {:ok, count} = Notify.Public.mark_seen(user, event_types: [:contribution_accepted])
+
+      # Two channels for the accepted event
+      assert count == 2
+
+      accepted_messages =
+        Notify.MessageModel
+        |> Repo.all()
+        |> Enum.filter(fn m ->
+          event = Repo.get!(Notify.EventModel, m.event_id)
+          event.type == "contribution_accepted"
+        end)
+
+      assert Enum.all?(accepted_messages, &(&1.status == :seen))
+    end
+  end
+
+  describe "NA channel side effect" do
+    test "clears the NBA on the recipient's inbox when messages are marked seen" do
+      user = Factories.insert!(:member)
+
+      {:ok, _event} =
+        Notify.Public.record_event(%{
+          type: :contribution_declined,
+          subject_user: user,
+          metadata: %{"assignment_id" => 42},
+          correlation_id: "participation:7"
+        })
+
+      # After record_event, the NA channel created the NBA
+      assert nba_exists?(user, "42:declined")
+
+      {:ok, _} = Notify.Public.mark_seen(user, correlation_id: "participation:7")
+
+      # NA channel's mark_seen ran → NBA cleared
+      refute nba_exists?(user, "42:declined")
+    end
+  end
+
+  defp nba_exists?(%{id: user_id}, key) do
+    import Ecto.Query
+    Repo.exists?(from(na in NextAction.Model, where: na.user_id == ^user_id and na.key == ^key))
+  end
+end

--- a/core/test/systems/notify/mark_seen_test.exs
+++ b/core/test/systems/notify/mark_seen_test.exs
@@ -12,7 +12,7 @@ defmodule Systems.Notify.MarkSeenTest do
       user = Factories.insert!(:member)
 
       {:ok, event} =
-        Notify.Public.record_event(%{
+        Notify.Public.record_event(%Notify.EventAttrs{
           type: :contribution_accepted,
           subject_user: user,
           metadata: %{"assignment_id" => 42},
@@ -50,7 +50,7 @@ defmodule Systems.Notify.MarkSeenTest do
 
     test "leaves messages for other correlations alone", %{user: user, event: event} do
       {:ok, _other_event} =
-        Notify.Public.record_event(%{
+        Notify.Public.record_event(%Notify.EventAttrs{
           type: :contribution_accepted,
           subject_user: user,
           metadata: %{"assignment_id" => 99},
@@ -77,7 +77,7 @@ defmodule Systems.Notify.MarkSeenTest do
       user = Factories.insert!(:member)
 
       {:ok, _accepted} =
-        Notify.Public.record_event(%{
+        Notify.Public.record_event(%Notify.EventAttrs{
           type: :contribution_accepted,
           subject_user: user,
           metadata: %{"assignment_id" => 1},
@@ -85,7 +85,7 @@ defmodule Systems.Notify.MarkSeenTest do
         })
 
       {:ok, _declined} =
-        Notify.Public.record_event(%{
+        Notify.Public.record_event(%Notify.EventAttrs{
           type: :contribution_declined,
           subject_user: user,
           metadata: %{"assignment_id" => 2},
@@ -115,7 +115,7 @@ defmodule Systems.Notify.MarkSeenTest do
       user = Factories.insert!(:member)
 
       {:ok, _event} =
-        Notify.Public.record_event(%{
+        Notify.Public.record_event(%Notify.EventAttrs{
           type: :contribution_declined,
           subject_user: user,
           metadata: %{"assignment_id" => 42},

--- a/core/test/systems/notify/public_test.exs
+++ b/core/test/systems/notify/public_test.exs
@@ -1,0 +1,63 @@
+defmodule Systems.Notify.PublicTest do
+  use Core.DataCase, async: false
+
+  alias Core.Factories
+  alias Core.Repo
+  alias Systems.Notify
+
+  describe "record_event/1" do
+    setup do
+      user = Factories.insert!(:member)
+      %{user: user}
+    end
+
+    test "persists the event with the supplied attrs", %{user: user} do
+      assert {:ok, event} =
+               Notify.Public.record_event(%{
+                 type: :contribution_accepted,
+                 subject_user: user,
+                 metadata: %{"assignment_id" => 42},
+                 correlation_id: "participation:7",
+                 source: __MODULE__
+               })
+
+      assert event.type == "contribution_accepted"
+      assert event.subject_user_id == user.id
+      assert event.metadata == %{"assignment_id" => 42}
+      assert event.correlation_id == "participation:7"
+      # source: module atom persisted as its inspect string
+      assert event.source == inspect(__MODULE__)
+    end
+
+    test "hands the event to the scheduler — dispatched_at is stamped", %{user: user} do
+      {:ok, event} =
+        Notify.Public.record_event(%{
+          type: :contribution_accepted,
+          subject_user: user,
+          metadata: %{}
+        })
+
+      # Re-read: record_event returns the pre-dispatch struct
+      reloaded = Repo.reload!(event)
+      assert reloaded.dispatched_at
+    end
+
+    test "rejects unknown event types", %{user: user} do
+      assert {:error, {:unknown_event_type, "totally_made_up"}} =
+               Notify.Public.record_event(%{
+                 type: :totally_made_up,
+                 subject_user: user
+               })
+    end
+
+    test "requires subject_user", %{user: _user} do
+      assert {:error, changeset} =
+               Notify.Public.record_event(%{
+                 type: :contribution_accepted,
+                 metadata: %{}
+               })
+
+      assert %{subject_user_id: ["can't be blank"]} = errors_on(changeset)
+    end
+  end
+end

--- a/core/test/systems/notify/public_test.exs
+++ b/core/test/systems/notify/public_test.exs
@@ -13,7 +13,7 @@ defmodule Systems.Notify.PublicTest do
 
     test "persists the event with the supplied attrs", %{user: user} do
       assert {:ok, event} =
-               Notify.Public.record_event(%{
+               Notify.Public.record_event(%Notify.EventAttrs{
                  type: :contribution_accepted,
                  subject_user: user,
                  metadata: %{"assignment_id" => 42},
@@ -31,10 +31,9 @@ defmodule Systems.Notify.PublicTest do
 
     test "hands the event to the scheduler — dispatched_at is stamped", %{user: user} do
       {:ok, event} =
-        Notify.Public.record_event(%{
+        Notify.Public.record_event(%Notify.EventAttrs{
           type: :contribution_accepted,
-          subject_user: user,
-          metadata: %{}
+          subject_user: user
         })
 
       # Re-read: record_event returns the pre-dispatch struct
@@ -44,20 +43,16 @@ defmodule Systems.Notify.PublicTest do
 
     test "rejects unknown event types", %{user: user} do
       assert {:error, {:unknown_event_type, "totally_made_up"}} =
-               Notify.Public.record_event(%{
+               Notify.Public.record_event(%Notify.EventAttrs{
                  type: :totally_made_up,
                  subject_user: user
                })
     end
 
-    test "requires subject_user", %{user: _user} do
-      assert {:error, changeset} =
-               Notify.Public.record_event(%{
-                 type: :contribution_accepted,
-                 metadata: %{}
-               })
-
-      assert %{subject_user_id: ["can't be blank"]} = errors_on(changeset)
+    test "requires subject_user at struct construction time" do
+      assert_raise ArgumentError, fn ->
+        struct!(Notify.EventAttrs, type: :contribution_accepted)
+      end
     end
   end
 end

--- a/core/test/systems/project/_public_test.exs
+++ b/core/test/systems/project/_public_test.exs
@@ -79,4 +79,37 @@ defmodule Systems.Project.PublicTest do
       assert [] = Project.Public.list_items(node, {:assignment, :benchmark_challenge})
     end
   end
+
+  describe "get_node_id_by/1" do
+    setup do
+      assignment = Core.Factories.build(:assignment)
+      item = Project.Factories.build_item(assignment)
+
+      %{root: %{id: node_id, items: [%{assignment: %{id: assignment_id}}]}} =
+        Project.Factories.build_node(items: [item])
+        |> Project.Factories.build_project()
+        |> Repo.insert!()
+
+      %{assignment_id: assignment_id, node_id: node_id}
+    end
+
+    test "returns node_id for an assignment struct", %{
+      assignment_id: assignment_id,
+      node_id: node_id
+    } do
+      assert ^node_id =
+               Project.Public.get_node_id_by(%Systems.Assignment.Model{id: assignment_id})
+    end
+
+    test "returns node_id for an integer assignment_id", %{
+      assignment_id: assignment_id,
+      node_id: node_id
+    } do
+      assert ^node_id = Project.Public.get_node_id_by(assignment_id)
+    end
+
+    test "returns nil when no project item exists for the assignment" do
+      assert nil == Project.Public.get_node_id_by(-1)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- New `Systems.Notify` scaffold — event/message models, Email + NA channels, config-driven per-system event declarations, `mark_seen` API
- Contribution accepted/declined: email to the participant + `ContributionReviewed` NBA on Home; `ParticipationView` marks the outcome seen on mount
- Realtime NBA refresh: `PendingContributions` NBA now propagates `node_id` through params so Project overview and Project node pages re-render live alongside Home (already wired)
- Strict NBA dismissal on `ContributionsView` mount replaces action-based clearing for the researcher's `PendingContributions`
- Gap fix: new `Assignment.Public.complete_participation(assignment, user)` fetches fresh state and skips if already completed — prevents a phantom NBA when a participant clicks "I'm done" after their contribution was already reviewed

Fixes: FX#10190572703 (Contribution notification for participants)

## Test plan
- [ ] Participant completes a task → researcher sees the PendingContributions NBA on Home, Project overview, and Project node page in realtime
- [ ] Researcher accepts → participant receives email + sees ContributionReviewed NBA on Home in realtime
- [ ] Researcher declines with reason → participant receives email (reason included) + sees ContributionReviewed NBA in realtime
- [ ] Participant clicks the NBA → `ParticipationView` shows outcome + reason (if declined) → NBA disappears on mount
- [ ] Researcher clicks NBA → `ContributionsView` mounts → NBA disappears
- [ ] Participant completes task, researcher approves, participant clicks "I'm done" → no phantom NBA appears on researcher side

🤖 Generated with [Claude Code](https://claude.com/claude-code)