### PR TITLE
i18n(fund): fill missing "Pay out" / "Retry payout" translations (de/it/es/lt/ro)

### DIFF
--- a/core/priv/gettext/de/LC_MESSAGES/eyra-fund.po
+++ b/core/priv/gettext/de/LC_MESSAGES/eyra-fund.po
@@ -155,9 +155,9 @@ msgstr "Vergütungen"
 msgid "rewards_summary.payout.below_threshold"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.button"
-msgstr ""
+msgstr "Auszahlen"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.handoff.body"
@@ -195,9 +195,9 @@ msgstr ""
 msgid "rewards_summary.payout.manual"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.retry"
-msgstr ""
+msgstr "Auszahlung wiederholen"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.awaiting.body"

--- a/core/priv/gettext/es/LC_MESSAGES/eyra-fund.po
+++ b/core/priv/gettext/es/LC_MESSAGES/eyra-fund.po
@@ -155,9 +155,9 @@ msgstr "Recompensas"
 msgid "rewards_summary.payout.below_threshold"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.button"
-msgstr ""
+msgstr "Cobrar"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.handoff.body"
@@ -195,9 +195,9 @@ msgstr ""
 msgid "rewards_summary.payout.manual"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.retry"
-msgstr ""
+msgstr "Reintentar cobro"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.awaiting.body"

--- a/core/priv/gettext/it/LC_MESSAGES/eyra-fund.po
+++ b/core/priv/gettext/it/LC_MESSAGES/eyra-fund.po
@@ -155,9 +155,9 @@ msgstr "Ricompense"
 msgid "rewards_summary.payout.below_threshold"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.button"
-msgstr ""
+msgstr "Riscuoti"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.handoff.body"
@@ -195,9 +195,9 @@ msgstr ""
 msgid "rewards_summary.payout.manual"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.retry"
-msgstr ""
+msgstr "Riprova riscossione"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.awaiting.body"

--- a/core/priv/gettext/lt/LC_MESSAGES/eyra-fund.po
+++ b/core/priv/gettext/lt/LC_MESSAGES/eyra-fund.po
@@ -155,9 +155,9 @@ msgstr "Atlygiai"
 msgid "rewards_summary.payout.below_threshold"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.button"
-msgstr ""
+msgstr "Išmokėti"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.handoff.body"
@@ -195,9 +195,9 @@ msgstr ""
 msgid "rewards_summary.payout.manual"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.retry"
-msgstr ""
+msgstr "Bandyti išmokėti dar kartą"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.awaiting.body"

--- a/core/priv/gettext/ro/LC_MESSAGES/eyra-fund.po
+++ b/core/priv/gettext/ro/LC_MESSAGES/eyra-fund.po
@@ -155,9 +155,9 @@ msgstr "Recompense"
 msgid "rewards_summary.payout.below_threshold"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.button"
-msgstr ""
+msgstr "Încasează"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.handoff.body"
@@ -195,9 +195,9 @@ msgstr ""
 msgid "rewards_summary.payout.manual"
 msgstr ""
 
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "rewards_summary.payout.retry"
-msgstr ""
+msgstr "Reîncearcă încasarea"
 
 #, elixir-autogen, elixir-format, fuzzy
 msgid "rewards_summary.payout.awaiting.body"


### PR DESCRIPTION
## Summary
- Two remaining raw keys on the participant Home Rewards card, missed in the earlier sweep (FX#10190913570)
- `rewards_summary.payout.button` (the "Pay out" link)
- `rewards_summary.payout.retry` (the "Retry payout" link, shown when a payout is stuck)

Fixes: FX#10199131012

## Test plan
- [ ] Switch locale to de/it/es/lt/ro on the participant Home page
- [ ] Verify the "Pay out" link renders translated (not the raw key)
- [ ] Verify the "Retry payout" link renders translated when a stranded payout is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)