### PR TITLE
fix(home): align history-row hover highlight with dividers, uniform edges

### DIFF
--- a/core/systems/home/participated_view.ex
+++ b/core/systems/home/participated_view.ex
@@ -22,7 +22,7 @@ defmodule Systems.Home.ParticipatedView do
       </Text.title2>
       <.spacing value="M" />
 
-      <div class="flex flex-col divide-y divide-grey4">
+      <div class="flex flex-col divide-y divide-grey4 -mb-2">
         <%= for item <- @content_items do %>
           <.row item={item} labels={@labels} />
         <% end %>
@@ -38,7 +38,7 @@ defmodule Systems.Home.ParticipatedView do
     ~H"""
     <a
       href={@item.path}
-      class="flex flex-row items-start gap-3 md:gap-4 py-4 first:pt-0 last:pb-0 hover:bg-grey6 -mx-2 px-2 rounded"
+      class="flex flex-row items-start gap-3 md:gap-4 py-4 hover:bg-grey6 -mx-2 px-2"
       data-testid="participated-row"
     >
       <div class="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- Removed `first:pt-0 last:pb-0` on rows so the hover highlight is the same height on the top and bottom rows as it is on middle rows
- Removed `rounded` on the row so the highlight edges line up with the `divide-y` separator lines instead of curving away from them
- Added `-mb-2` on the rows container to keep the bottom edge comfortable after restoring the last row's bottom padding

Fixes: FX#10201105603

## Test plan
- [ ] Open the participant Home page with a few history items
- [ ] Hover the first row → highlight fills the full row, aligns with the separator below
- [ ] Hover a middle row → same shape
- [ ] Hover the last row → same shape, doesn't overflow the card border

🤖 Generated with [Claude Code](https://claude.com/claude-code)