### PR TITLE
fix(desktop): show 6 most recent project items instead of projects

### DIFF
--- a/core/systems/desktop/page_builder.ex
+++ b/core/systems/desktop/page_builder.ex
@@ -2,13 +2,18 @@ defmodule Systems.Desktop.PageBuilder do
   use CoreWeb, :verified_routes
 
   use Gettext, backend: CoreWeb.Gettext
-  alias Systems.Project
-  alias Systems.NextAction
 
-  def view_model(user, _assigns) do
+  alias Frameworks.Utility.ViewModelBuilder
+  alias Systems.NextAction
+  alias Systems.Project
+
+  @recent_items_limit 6
+
+  def view_model(user, assigns) do
     content_items =
-      Project.Public.list_owned_projects(user, preload: Project.Model.preload_graph(:down))
-      |> Enum.map(&map_project/1)
+      user
+      |> recent_items()
+      |> Enum.map(&ViewModelBuilder.view_model(&1, {Project.NodePage, :item_card}, assigns))
 
     next_best_action = NextAction.Public.next_best_action(user)
 
@@ -20,20 +25,12 @@ defmodule Systems.Desktop.PageBuilder do
     }
   end
 
-  def map_project(%{
-        name: name,
-        root: %{
-          id: root_node_id
-        }
-      }) do
-    %{
-      path: ~p"/project/node/#{root_node_id}",
-      title: name,
-      subtitle: "<subtitle>",
-      tag: %{text: "Concept", type: :success},
-      level: :critical,
-      image: nil,
-      quick_summary: ""
-    }
+  defp recent_items(user) do
+    user
+    |> Project.Public.list_owned_projects(preload: Project.Model.preload_graph(:down))
+    |> Enum.flat_map(& &1.root.items)
+    |> Enum.reject(&(&1.name == "Data"))
+    |> Enum.sort_by(& &1.updated_at, {:desc, NaiveDateTime})
+    |> Enum.take(@recent_items_limit)
   end
 end

--- a/core/systems/desktop/view.ex
+++ b/core/systems/desktop/view.ex
@@ -1,9 +1,10 @@
 defmodule Systems.Desktop.View do
   use CoreWeb, :live_component_fabric
 
-  import Frameworks.Pixel.Content
+  alias Frameworks.Pixel.Grid
   alias Frameworks.Pixel.Text
   alias Systems.NextAction
+  alias Systems.Project
 
   @impl true
   def update(%{vm: vm}, socket) do
@@ -26,7 +27,12 @@ defmodule Systems.Desktop.View do
           <%= dgettext("eyra-dashboard", "recent-items.title") %>
           <span class="text-primary"> <%= Enum.count(@vm.content_items) %></span>
         </Text.title2>
-        <.list items={@vm.content_items} />
+        <Margin.y id={:title2_bottom} />
+        <Grid.dynamic>
+          <%= for card <- @vm.content_items do %>
+            <Project.CardView.dynamic card={card} />
+          <% end %>
+        </Grid.dynamic>
       </Area.content>
     </div>
     """


### PR DESCRIPTION
## Summary
- Desktop now flattens all owned projects' items and shows the 6 most recently updated ("Data" items excluded, matching the Project node page)
- Renders as rich cards via the existing `{:item_card}` view model + `Project.CardView.dynamic`, so the look matches the Project node overview
- Old project cards had almost no useful info (name + a placeholder subtitle); project items carry title, kind icon, status, tags and image

Fixes: FX#10201105047

## Test plan
- [ ] Log in as a researcher with several assignments/adverts across projects
- [ ] Open Desktop → see up to 6 recent project item cards (assignments, adverts, leaderboards)
- [ ] Cards should look like the ones on the Project node overview
- [ ] Ordering: most recently updated first
- [ ] Clicking a card navigates to that item's content page

🤖 Generated with [Claude Code](https://claude.com/claude-code)