### PR TITLE
fix(next_action): NBA card CTA no longer dominates the card on tablet/mobile

### DIFF
--- a/core/systems/next_action/view.ex
+++ b/core/systems/next_action/view.ex
@@ -38,8 +38,8 @@ defmodule Systems.NextAction.View do
 
     ~H"""
     <Button.action {@cta_action}>
-      <div class={"p-4 md:p-6 flex flex-col lg:flex-row lg:items-center gap-4 lg:gap-0 lg:space-x-4 rounded-md #{@colors.bg}"}>
-        <div class="flex-grow min-w-0">
+      <div class={"p-4 md:p-6 flex flex-wrap items-center gap-4 rounded-md #{@colors.bg}"}>
+        <div class="flex-1 min-w-[16rem]">
           <div class={"#{@title_css} mb-2 break-words"}>
             <%= @title %>
           </div>
@@ -47,7 +47,7 @@ defmodule Systems.NextAction.View do
             <%= @description %>
           </div>
         </div>
-        <div class={"w-full lg:w-auto font-button text-button text-center p-3 rounded-md whitespace-nowrap #{@colors.button}"}>
+        <div class={"font-button text-button text-center p-3 rounded-md whitespace-nowrap #{@colors.button}"}>
           <%= @cta_label %>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replaced the breakpoint-driven `w-full lg:w-auto` layout with a `flex-wrap` row
- Text container has a min-width so it can host at least a couple of lines; button is content-width with `whitespace-nowrap`
- Text + button sit inline when there is room; button hops to the next line when there is not
- No `lg:` gymnastics — layout is content-aware at every viewport width

Fixes: FX#10203172017

## Test plan
- [ ] Resize the participant Home page from wide to narrow: button stays inline until row runs out of room, then wraps under the text
- [ ] Very long NBA descriptions: text wraps, button still fits sensibly
- [ ] Mobile: NBA card is not dominated by a full-width button anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)