### PR TITLE
fix(email): stop apostrophe-in-name from flaking CI

### DIFF
--- a/core/systems/email/email_html.ex
+++ b/core/systems/email/email_html.ex
@@ -5,96 +5,64 @@ defmodule Systems.Email.EmailHTML do
   embed_templates("email/*.html", suffix: "_html")
   embed_templates("email/*.text", suffix: "_text")
 
+  # bamboo_phoenix 2.0 expects the template function to return a plain string
+  # or a Phoenix.HTML safe tuple. It flattens safe iodata with Enum.map, which
+  # crashes on the improper lists Phoenix.HTML.Safe emits when escaping
+  # apostrophes (`[<<...>> | "&#39;"]`). Convert to binary here so bamboo
+  # hits its `is_binary/1` clause and skips the broken flatten path.
+  defp to_binary({:safe, _} = safe), do: Phoenix.HTML.safe_to_string(safe)
+  defp to_binary(binary) when is_binary(binary), do: binary
+
   # Define template functions for bamboo_phoenix 2.0
   # Each function takes format ("html" or "text") as first arg and assigns as second
-  # Returns whatever the embedded templates return (safe tuples for HTML, strings for text)
-  # bamboo_phoenix will handle the normalization
+  def otp_sign_in("html", assigns), do: otp_sign_in_html(assigns) |> to_binary()
+  def otp_sign_in("text", assigns), do: otp_sign_in_text(assigns) |> to_binary()
 
-  def otp_sign_in("html", assigns) do
-    otp_sign_in_html(assigns)
-  end
+  def account_confirmation_instructions("html", assigns),
+    do: account_confirmation_instructions_html(assigns) |> to_binary()
 
-  def otp_sign_in("text", assigns) do
-    otp_sign_in_text(assigns)
-  end
+  def account_confirmation_instructions("text", assigns),
+    do: account_confirmation_instructions_text(assigns) |> to_binary()
 
-  def account_confirmation_instructions("html", assigns) do
-    account_confirmation_instructions_html(assigns)
-  end
+  def account_created("html", assigns), do: account_created_html(assigns) |> to_binary()
+  def account_created("text", assigns), do: account_created_text(assigns) |> to_binary()
 
-  def account_confirmation_instructions("text", assigns) do
-    account_confirmation_instructions_text(assigns)
-  end
+  def already_activated_notification("html", assigns),
+    do: already_activated_notification_html(assigns) |> to_binary()
 
-  def account_created("html", assigns) do
-    account_created_html(assigns)
-  end
+  def already_activated_notification("text", assigns),
+    do: already_activated_notification_text(assigns) |> to_binary()
 
-  def account_created("text", assigns) do
-    account_created_text(assigns)
-  end
+  def debug_message("html", assigns), do: debug_message_html(assigns) |> to_binary()
+  def debug_message("text", assigns), do: debug_message_text(assigns) |> to_binary()
 
-  def already_activated_notification("html", assigns) do
-    already_activated_notification_html(assigns)
-  end
+  def notification("html", assigns), do: notification_html(assigns) |> to_binary()
+  def notification("text", assigns), do: notification_text(assigns) |> to_binary()
 
-  def already_activated_notification("text", assigns) do
-    already_activated_notification_text(assigns)
-  end
+  def new_notification("html", assigns), do: new_notification_html(assigns) |> to_binary()
+  def new_notification("text", assigns), do: new_notification_text(assigns) |> to_binary()
 
-  def debug_message("html", assigns) do
-    debug_message_html(assigns)
-  end
+  def reset_password_instructions("html", assigns),
+    do: reset_password_instructions_html(assigns) |> to_binary()
 
-  def debug_message("text", assigns) do
-    debug_message_text(assigns)
-  end
+  def reset_password_instructions("text", assigns),
+    do: reset_password_instructions_text(assigns) |> to_binary()
 
-  def notification("html", assigns) do
-    notification_html(assigns)
-  end
+  def update_email_instructions("html", assigns),
+    do: update_email_instructions_html(assigns) |> to_binary()
 
-  def notification("text", assigns) do
-    notification_text(assigns)
-  end
+  def update_email_instructions("text", assigns),
+    do: update_email_instructions_text(assigns) |> to_binary()
 
-  def new_notification("html", assigns) do
-    new_notification_html(assigns)
-  end
+  def contribution_accepted("html", assigns),
+    do: contribution_accepted_html(assigns) |> to_binary()
 
-  def new_notification("text", assigns) do
-    new_notification_text(assigns)
-  end
+  def contribution_accepted("text", assigns),
+    do: contribution_accepted_text(assigns) |> to_binary()
 
-  def reset_password_instructions("html", assigns) do
-    reset_password_instructions_html(assigns)
-  end
+  def contribution_declined("html", assigns),
+    do: contribution_declined_html(assigns) |> to_binary()
 
-  def reset_password_instructions("text", assigns) do
-    reset_password_instructions_text(assigns)
-  end
-
-  def update_email_instructions("html", assigns) do
-    update_email_instructions_html(assigns)
-  end
-
-  def update_email_instructions("text", assigns) do
-    update_email_instructions_text(assigns)
-  end
-
-  def contribution_accepted("html", assigns) do
-    contribution_accepted_html(assigns)
-  end
-
-  def contribution_accepted("text", assigns) do
-    contribution_accepted_text(assigns)
-  end
-
-  def contribution_declined("html", assigns) do
-    contribution_declined_html(assigns)
-  end
-
-  def contribution_declined("text", assigns) do
-    contribution_declined_text(assigns)
-  end
+  def contribution_declined("text", assigns),
+    do: contribution_declined_text(assigns) |> to_binary()
 end

--- a/core/test/systems/email/integration_test.exs
+++ b/core/test/systems/email/integration_test.exs
@@ -78,6 +78,23 @@ defmodule Systems.Email.IntegrationTest do
       assert email.text_body =~ message
     end
 
+    # Regression: bamboo_phoenix 2.0's flatten_safe_iodata uses Enum.map,
+    # which crashes on the improper lists Phoenix.HTML.Safe emits when
+    # escaping apostrophes. Guard against that with a name that will HTML-
+    # escape to `&#39;`.
+    test "renders emails whose assigns contain an apostrophe" do
+      from_user = %{email: "obrien@example.com", displayname: "O'Brien"}
+      to_user = %{email: "dangelo@example.com", displayname: "D'Angelo"}
+
+      email = Factory.debug("Debug", "Body", from_user, to_user)
+
+      assert email.html_body =~ "O&#39;Brien"
+      assert email.html_body =~ "D&#39;Angelo"
+      # Inner template HTML must survive the layout wrap — not double-escaped
+      assert email.html_body =~ "<h1>Hi D&#39;Angelo"
+      refute email.html_body =~ "&lt;h1&gt;"
+    end
+
     test "email with header image assignment renders correctly" do
       user = Factories.build(:member)
       email = Factory.account_created(user)


### PR DESCRIPTION
## Summary
- bamboo_phoenix 2.0's `flatten_safe_iodata` uses `Enum.map`, which crashes with `FunctionClauseError` on the improper lists Phoenix.HTML.Safe emits when escaping apostrophes (`[<<...>> | "&#39;"]`)
- Any email whose assigns contain an apostrophe (e.g., a Faker-seeded name like `O'Brien` in the integration test) crashes at render time
- Fix at our boundary: each `EmailHTML` template helper now flattens its safe result to a plain binary via `Phoenix.HTML.safe_to_string/1`. Bamboo takes it via `is_binary/1` and skips the broken flatten path
- Layout wrapping still works — the layout uses `<%= @inner_content %>` with a plain binary, verified by asserting inner HTML tags survive unescaped

Adds a deterministic regression test with an explicit `O'Brien` / `D'Angelo` name so this class of failure can no longer flake by seed.

Fixes: FX#10203187609

## Test plan
- [ ] CI green (previous failure repro'd locally by seeding an apostrophe into a name assign)
- [ ] All 11 tests in `test/systems/email/integration_test.exs` pass
- [ ] Manual: send any templated email (account_created, etc.) — content still renders as HTML, not double-escaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)