### PR TITLE
fix(desktop): handle card_clicked event so recent items are clickable

### DIFF
--- a/core/systems/desktop/view.ex
+++ b/core/systems/desktop/view.ex
@@ -12,6 +12,17 @@ defmodule Systems.Desktop.View do
   end
 
   @impl true
+  def handle_event(
+        "card_clicked",
+        %{"item" => card_id},
+        %{assigns: %{vm: %{content_items: content_items}}} = socket
+      ) do
+    card_id = String.to_integer(card_id)
+    %{path: path} = Enum.find(content_items, &(&1.id == card_id))
+    {:noreply, push_navigate(socket, to: path)}
+  end
+
+  @impl true
   def render(assigns) do
     ~H"""
     <div>


### PR DESCRIPTION
## Problem

Recent items cards on the Desktop page were not clickable. `ClickableCard` fires `phx-click="card_clicked"`, but `Desktop.View` had no matching `handle_event("card_clicked", ...)`, so clicks went nowhere.

## Fix

Added a `handle_event("card_clicked", ...)` to `Systems.Desktop.View` that looks up the path in `@vm.content_items` and navigates to it, mirroring the existing pattern in `Systems.Project.NodePageGridView`.

Flux issue: 10208375333
