### PR TITLE
fix(account): gate Payouts tab behind panl_post_launch

### DIFF
--- a/core/systems/account/payouts_tab.ex
+++ b/core/systems/account/payouts_tab.ex
@@ -1,12 +1,15 @@
 defmodule Systems.Account.PayoutsTab do
   @moduledoc """
-  Payouts (Uitbetalingen) tab implementation.
-  Visible for all participants: shows the bank-account verification status and
-  the payout history.
+  Payouts (Uitbetalingen) tab implementation: shows the bank-account
+  verification status and the payout history.
+
+  Part of the post-launch money surface, so it follows `:panl_post_launch`
+  along with the rewards summary and the participation history.
   """
   @behaviour Systems.Account.Page.Tab
 
   use Gettext, backend: CoreWeb.Gettext
+  use Core.FeatureFlags
 
   alias Frameworks.Concept.LiveContext
   alias Systems.Account
@@ -15,7 +18,7 @@ defmodule Systems.Account.PayoutsTab do
   def key, do: :payouts
 
   @impl true
-  def visible?(_user), do: true
+  def visible?(_user), do: feature_enabled?(:panl_post_launch)
 
   @impl true
   def build(_user, live_context) do

--- a/core/test/systems/account/page_builder_test.exs
+++ b/core/test/systems/account/page_builder_test.exs
@@ -1,5 +1,6 @@
 defmodule Systems.Account.PageBuilderTest do
   use Core.DataCase
+  use Core.FeatureFlags.Test
   use Gettext, backend: CoreWeb.Gettext
 
   alias Systems.Account
@@ -93,6 +94,15 @@ defmodule Systems.Account.PageBuilderTest do
       result = Account.PageBuilder.tab_keys(user)
 
       assert result == [:profile, :payouts]
+    end
+
+    test "excludes payouts key when post-launch is disabled" do
+      user = Factories.insert!(:member)
+      set_feature_flag(:panl_post_launch, false)
+
+      result = Account.PageBuilder.tab_keys(user)
+
+      refute :payouts in result
     end
 
     test "excludes features key when PANL pool does not exist" do


### PR DESCRIPTION
De rest van de post-launch money surface — rewards summary, Panl marketplace, participation history — zit achter `:panl_post_launch`, maar `Systems.Account.PayoutsTab.visible?/1` gaf onvoorwaardelijk `true` terug. Daardoor rendert de Uitbetalingen-tab op de account-pagina voor elke deelnemer, met een lege bank-verificatie en payout-historie.

## Wat er verandert
- `visible?/1` volgt nu `feature_enabled?(:panl_post_launch)`, net als de rest van die surface
- moduledoc bijgewerkt: de tab is niet langer "visible for all participants"
- test: `excludes payouts key when post-launch is disabled`

## Test plan
- [x] `mix test test/systems/account test/systems/home --warnings-as-errors` → 285 tests, 0 failures
- [x] `mix format` + `mix credo` schoon
- [ ] Op een omgeving met `panl_post_launch` uit: geen Uitbetalingen-tab op `/user/account`
- [ ] Met de flag aan: tab werkt als voorheen

Fixes: FX#10217149898

🤖 Generated with [Claude Code](https://claude.com/claude-code)