### PR TITLE
Fix slow manual task launch

### DIFF
--- a/core/systems/assignment/crew_task_list_view.ex
+++ b/core/systems/assignment/crew_task_list_view.ex
@@ -13,7 +13,7 @@ defmodule Systems.Assignment.CrewTaskListView do
   def get_model(:not_mounted_at_router, _session, %{assigns: %{assignment_id: assignment_id}}) do
     Assignment.Public.get!(assignment_id, [
       :crew,
-      workflow: [items: [tool_ref: Systems.Workflow.ToolRefModel.preload_graph(:down)]]
+      workflow: [items: [tool_ref: Systems.Workflow.ToolRefModel.preload_graph(:tool)]]
     ])
   end
 

--- a/core/systems/assignment/crew_task_single_view.ex
+++ b/core/systems/assignment/crew_task_single_view.ex
@@ -10,7 +10,7 @@ defmodule Systems.Assignment.CrewTaskSingleView do
   def get_model(:not_mounted_at_router, _session, %{assigns: %{assignment_id: assignment_id}}) do
     Assignment.Public.get!(assignment_id, [
       :crew,
-      workflow: [items: [tool_ref: Systems.Workflow.ToolRefModel.preload_graph(:down)]]
+      workflow: [items: [tool_ref: Systems.Workflow.ToolRefModel.preload_graph(:tool)]]
     ])
   end
 

--- a/core/systems/workflow/tool_ref_model.ex
+++ b/core/systems/workflow/tool_ref_model.ex
@@ -57,8 +57,11 @@ defmodule Systems.Workflow.ToolRefModel do
     |> validate_required(@required_fields)
   end
 
-  def preload_graph(:down),
-    do: preload_graph(@tools)
+  def preload_graph(:down), do: preload_graph(@tools)
+
+  # Task lists only need the tool record to choose and launch its view.
+  # Loading each tool's full graph makes that context part of the LiveView session.
+  def preload_graph(:tool), do: @tools
 
   def preload_graph(tool_id_field) when is_atom(tool_id_field) do
     if Enum.member?(@tools, tool_id_field) do


### PR DESCRIPTION
## Summary
- preload only the selected tool records when building task views
- avoid serializing full manual graphs into nested LiveView sessions

## Validation
- `cd core && mix test test/systems/assignment/crew_task_list_view_test.exs test/systems/assignment/crew_task_single_view_test.exs`
- local Chrome comparison: ~37 ms / 62 KB with the fix vs ~521 ms / 949 KB without it