### PR TITLE
fix(manual): defer chapter page loading

### DIFF
--- a/core/systems/manual/_public.ex
+++ b/core/systems/manual/_public.ex
@@ -27,13 +27,13 @@ defmodule Systems.Manual.Public do
   Gets a manual by its id.
   """
   def get_manual!(id, preload \\ []) do
-    Manual.Queries.get_by_id(id)
-    |> Repo.one!()
+    Repo.get!(Manual.Model, id)
     |> Repo.preload(preload)
   end
 
-  def get_chapter!(chapter_id) do
+  def get_chapter!(chapter_id, preload \\ []) do
     Repo.get!(Manual.ChapterModel, chapter_id)
+    |> Repo.preload(preload)
   end
 
   def get_chapter_by_step(%Userflow.StepModel{id: step_id}) do

--- a/core/systems/manual/model.ex
+++ b/core/systems/manual/model.ex
@@ -33,6 +33,7 @@ defmodule Systems.Manual.Model do
   def preload_graph(:down), do: preload_graph([:userflow, :chapters])
   def preload_graph(:up), do: []
 
+  def preload_graph(:chapter_list), do: [chapters: [:userflow_step]]
   def preload_graph(:userflow), do: [userflow: Userflow.Model.preload_graph(:down)]
   def preload_graph(:chapters), do: [chapters: Manual.ChapterModel.preload_graph(:down)]
 end

--- a/core/systems/manual/view.ex
+++ b/core/systems/manual/view.ex
@@ -10,7 +10,7 @@ defmodule Systems.Manual.View do
     do: [:manual_id, :title, :current_user, :presentation, {:user_state, [:chapter, :page]}]
 
   def get_model(:not_mounted_at_router, _session, %{assigns: %{manual_id: manual_id}}) do
-    Manual.Public.get_manual!(manual_id, Manual.Model.preload_graph(:down))
+    Manual.Public.get_manual!(manual_id, Manual.Model.preload_graph(:chapter_list))
   end
 
   @impl true

--- a/core/systems/manual/view_builder.ex
+++ b/core/systems/manual/view_builder.ex
@@ -45,10 +45,9 @@ defmodule Systems.Manual.ViewBuilder do
   defp find_selected_chapter(_chapters, nil), do: nil
 
   defp find_selected_chapter(chapters, selected_chapter_id) do
-    case Enum.find(chapters, &(&1.id == selected_chapter_id)) do
-      nil -> List.first(chapters)
-      chapter -> chapter
-    end
+    chapter = Enum.find(chapters, &(&1.id == selected_chapter_id)) || List.first(chapters)
+
+    Manual.Public.get_chapter!(chapter.id, Manual.ChapterModel.preload_graph(:down))
   end
 
   defp build_chapter_list_view(manual, title, selected_chapter_id) do

--- a/core/systems/manual/view_builder.ex
+++ b/core/systems/manual/view_builder.ex
@@ -14,6 +14,7 @@ defmodule Systems.Manual.ViewBuilder do
         presentation: presentation,
         user_state: user_state
       }) do
+    manual = ensure_chapter_list(manual)
     chapter_id = user_state[:chapter]
     page_id = user_state[:page]
     chapters = get_chapters(manual)
@@ -34,6 +35,12 @@ defmodule Systems.Manual.ViewBuilder do
       buttons: buttons
     }
   end
+
+  defp ensure_chapter_list(%Manual.Model{chapters: %Ecto.Association.NotLoaded{}, id: id}) do
+    Manual.Public.get_manual!(id, Manual.Model.preload_graph(:chapter_list))
+  end
+
+  defp ensure_chapter_list(manual), do: manual
 
   defp get_chapters(%{chapters: [_ | _] = chapters}) do
     chapters |> Enum.sort_by(& &1.userflow_step.order)

--- a/core/test/support/helpers.ex
+++ b/core/test/support/helpers.ex
@@ -23,6 +23,21 @@ defmodule Core.TestHelpers do
   @moduledoc """
   Helper functions to make testing convenient.
   """
+
+  def eventually_render(view, expected, retries \\ 20)
+
+  def eventually_render(view, _expected, 0), do: Phoenix.LiveViewTest.render(view)
+
+  def eventually_render(view, expected, retries) do
+    html = Phoenix.LiveViewTest.render(view)
+
+    if html =~ expected do
+      html
+    else
+      Process.sleep(25)
+      eventually_render(view, expected, retries - 1)
+    end
+  end
 end
 
 defmodule Core.AuthTestHelpers do

--- a/core/test/support/helpers.ex
+++ b/core/test/support/helpers.ex
@@ -24,6 +24,20 @@ defmodule Core.TestHelpers do
   Helper functions to make testing convenient.
   """
 
+  def eventually_has_element?(view, selector, text_filter \\ nil, retries \\ 20)
+
+  def eventually_has_element?(view, selector, text_filter, 0),
+    do: Phoenix.LiveViewTest.has_element?(view, selector, text_filter)
+
+  def eventually_has_element?(view, selector, text_filter, retries) do
+    if Phoenix.LiveViewTest.has_element?(view, selector, text_filter) do
+      true
+    else
+      Process.sleep(25)
+      eventually_has_element?(view, selector, text_filter, retries - 1)
+    end
+  end
+
   def eventually_render(view, expected, retries \\ 20)
 
   def eventually_render(view, _expected, 0), do: Phoenix.LiveViewTest.render(view)

--- a/core/test/systems/account/payouts_reactive_test.exs
+++ b/core/test/systems/account/payouts_reactive_test.exs
@@ -69,19 +69,4 @@ defmodule Systems.Account.PayoutsReactiveTest do
 
     assert eventually_render(view, "Verified") =~ "Verified"
   end
-
-  defp eventually_render(view, _expected, 0), do: render(view)
-
-  defp eventually_render(view, expected, retries) do
-    html = render(view)
-
-    if html =~ expected do
-      html
-    else
-      Process.sleep(25)
-      eventually_render(view, expected, retries - 1)
-    end
-  end
-
-  defp eventually_render(view, expected), do: eventually_render(view, expected, 20)
 end

--- a/core/test/systems/manual/view_builder_test.exs
+++ b/core/test/systems/manual/view_builder_test.exs
@@ -66,6 +66,30 @@ defmodule Systems.Manual.ViewBuilderTest do
       assert %LiveNest.Element{} = vm.chapter_list_view
     end
 
+    test "loads selected chapter from a chapter-list preload", %{
+      user: user,
+      manual: manual,
+      chapter1: chapter1
+    } do
+      manual =
+        Manual.Public.get_manual!(manual.id, Manual.Model.preload_graph(:chapter_list))
+
+      [chapter | _] = manual.chapters
+      assert %Ecto.Association.NotLoaded{} = chapter.pages
+
+      assigns = %{
+        title: "Test Manual",
+        current_user: user,
+        presentation: :modal,
+        user_state: %{chapter: chapter1.id, page: nil}
+      }
+
+      vm = Manual.ViewBuilder.view_model(manual, assigns)
+
+      assert vm.selected_chapter.id == chapter1.id
+      assert [_page] = vm.selected_chapter.pages
+    end
+
     test "selects correct chapter from multiple chapters", %{
       user: user,
       manual: manual,

--- a/core/test/systems/manual/view_builder_test.exs
+++ b/core/test/systems/manual/view_builder_test.exs
@@ -90,6 +90,59 @@ defmodule Systems.Manual.ViewBuilderTest do
       assert [_page] = vm.selected_chapter.pages
     end
 
+    test "loads pages for a newly selected chapter", %{
+      user: user,
+      manual: manual,
+      chapter1: chapter1,
+      chapter2: chapter2
+    } do
+      manual =
+        Manual.Public.get_manual!(manual.id, Manual.Model.preload_graph(:chapter_list))
+
+      assigns = %{
+        title: "Test Manual",
+        current_user: user,
+        presentation: :modal,
+        user_state: %{chapter: chapter1.id, page: nil}
+      }
+
+      vm = Manual.ViewBuilder.view_model(manual, assigns)
+      assert vm.selected_chapter.id == chapter1.id
+      assert [%{chapter_id: chapter1_id}] = vm.selected_chapter.pages
+      assert chapter1_id == chapter1.id
+
+      vm =
+        Manual.ViewBuilder.view_model(vm.manual, %{
+          assigns
+          | user_state: %{chapter: chapter2.id, page: nil}
+        })
+
+      assert vm.selected_chapter.id == chapter2.id
+      assert [%{chapter_id: chapter2_id}] = vm.selected_chapter.pages
+      assert chapter2_id == chapter2.id
+    end
+
+    test "loads every page of a selected chapter", %{user: user} do
+      manual = Manual.Factories.create_manual(1, 3)
+      [chapter] = manual.chapters
+
+      manual =
+        Manual.Public.get_manual!(manual.id, Manual.Model.preload_graph(:chapter_list))
+
+      vm =
+        Manual.ViewBuilder.view_model(manual, %{
+          title: "Test Manual",
+          current_user: user,
+          presentation: :modal,
+          user_state: %{chapter: chapter.id, page: nil}
+        })
+
+      assert Enum.map(vm.selected_chapter.pages, & &1.id) ==
+               chapter.pages
+               |> Enum.sort_by(& &1.userflow_step.order)
+               |> Enum.map(& &1.id)
+    end
+
     test "selects correct chapter from multiple chapters", %{
       user: user,
       manual: manual,

--- a/core/test/systems/manual/view_test.exs
+++ b/core/test/systems/manual/view_test.exs
@@ -44,6 +44,54 @@ defmodule Systems.Manual.ViewTest do
       refute view |> has_element?("[data-testid='chapter-view']")
     end
 
+    test "loads every page after selecting a chapter", %{conn: conn, user: user} do
+      manual = Manual.Factories.create_manual(1, 3)
+      [chapter] = manual.chapters
+
+      [_first_page, _second_page, third_page] =
+        Enum.sort_by(chapter.pages, & &1.userflow_step.order)
+
+      third_page =
+        third_page
+        |> Ecto.Changeset.change(title: "Third page")
+        |> Core.Repo.update!()
+
+      context =
+        LiveContext.new(%{
+          manual_id: manual.id,
+          title: "Test Manual",
+          current_user: user,
+          presentation: :modal,
+          user_state: %{},
+          user_state_namespace: [:manual, manual.id]
+        })
+
+      conn = Map.put(conn, :request_path, "/manual/view")
+
+      {:ok, view, _html} =
+        live_isolated(conn, Manual.View, session: %{"live_context" => context})
+
+      view
+      |> element("[data-testid='chapter-list-item-#{chapter.id}']")
+      |> render_click()
+
+      assert eventually_has_element?(
+               view,
+               "[data-testid='chapter-view']",
+               chapter.title
+             )
+
+      view
+      |> element("[phx-click='select_page'][phx-value-item='#{third_page.id}']")
+      |> render_click()
+
+      assert eventually_has_element?(
+               view,
+               "[data-testid='chapter-view']",
+               third_page.title
+             )
+    end
+
     test "renders chapter view when chapter is selected", %{
       conn: conn,
       user: user,

--- a/core/test/systems/manual/view_test.exs
+++ b/core/test/systems/manual/view_test.exs
@@ -157,13 +157,7 @@ defmodule Systems.Manual.ViewTest do
       # Send :next_page toolbar event
       send(view.pid, {:toolbar_action, :next_page})
 
-      # Force a render to process the send_update
-      _ = render(view)
-      # Render again to see the updated component
-      html = render(view)
-
-      # Should now show second page
-      assert html =~ "2/3"
+      assert eventually_render(view, "2/3") =~ "2/3"
     end
 
     test "previous_page event navigates to previous page", %{
@@ -201,13 +195,7 @@ defmodule Systems.Manual.ViewTest do
       # Send :previous_page toolbar event
       send(view.pid, {:toolbar_action, :previous_page})
 
-      # Force a render to process the send_update
-      _ = render(view)
-      # Render again to see the updated component
-      html = render(view)
-
-      # Should now show first page
-      assert html =~ "1/3"
+      assert eventually_render(view, "1/3") =~ "1/3"
     end
 
     test "previous_page on first page triggers back to chapter list", %{
@@ -358,12 +346,7 @@ defmodule Systems.Manual.ViewTest do
 
       send(view.pid, {:live_nest_event, event})
 
-      # Force renders to process the update
-      _ = render(view)
-      html = render(view)
-
-      # Should now show second page
-      assert html =~ "2/3"
+      assert eventually_render(view, "2/3") =~ "2/3"
     end
 
     test "toolbar previous_page action navigates to previous page", %{
@@ -405,12 +388,7 @@ defmodule Systems.Manual.ViewTest do
 
       send(view.pid, {:live_nest_event, event})
 
-      # Force renders to process the update
-      _ = render(view)
-      html = render(view)
-
-      # Should now show first page
-      assert html =~ "1/3"
+      assert eventually_render(view, "1/3") =~ "1/3"
     end
 
     test "toolbar back action on first page clears chapter selection", %{


### PR DESCRIPTION
## Summary
- load only chapter-list metadata when opening a manual
- fetch selected chapter pages in `Manual.ViewBuilder`
- reload the lightweight chapter list when LiveNest rebuilds with `chapters` unloaded
- add builder and LiveView regression coverage for multi-page chapter selection
- share LiveView retry test helpers

## Test
- `cd core && mix test test/systems/manual/view_builder_test.exs test/systems/manual/view_test.exs test/systems/account/payouts_reactive_test.exs`
- Chrome: selecting a 20-page chapter rendered all pages in 44.6 ms and remained selected after 1 second