### PR TITLE
Reopen assignment spots after contribution rejection

### DIFF
--- a/core/systems/assignment/_public.ex
+++ b/core/systems/assignment/_public.ex
@@ -639,14 +639,14 @@ defmodule Systems.Assignment.Public do
     end
   end
 
-  def decline_member(%Assignment.Model{crew: crew}, user) do
+  def expire_member(%Assignment.Model{crew: crew}, user) do
     if member = Crew.Public.get_member(crew, user) do
       Multi.new()
       |> Crew.Public.expire_member(member)
-      |> Signal.Public.multi_dispatch({:crew_member, :declined}, message: %{crew_member: member})
+      |> Signal.Public.multi_dispatch({:crew_member, :expired}, message: %{crew_member: member})
       |> Repo.commit()
     else
-      Logger.warning("Unable to decline member, probably expired already")
+      Logger.warning("Unable to expire member, probably expired already")
     end
   end
 
@@ -1047,7 +1047,7 @@ defmodule Systems.Assignment.Public do
 
   @doc """
   Marks a participation as rejected — the owner declined the contribution.
-  Sets `rejected_at` + `rejected_message`, rejects the associated reward
+  Sets `rejected_at` + `rejected_message` and rejects the associated reward
   (rolling the deposit back into the fund) if any, and dispatches
   `{:assignment_participation, :rejected}`. All in one transaction.
   Idempotent on `rejected_at`.

--- a/core/systems/assignment/_switch.ex
+++ b/core/systems/assignment/_switch.ex
@@ -108,6 +108,8 @@ defmodule Systems.Assignment.Switch do
       dispatch!({:fund_rewards_summary, :updated}, %{user_id: participation.user_id})
     end
 
+    Assignment.Public.expire_member(assignment, participation.user_id)
+
     notify_participant(:contribution_declined, %{participation | assignment: assignment})
 
     update_content_page(assignment, from_pid)
@@ -216,7 +218,8 @@ defmodule Systems.Assignment.Switch do
             crew_member
           )
 
-        {:crew_member, :declined} ->
+        {:crew_member, :expired} ->
+          # Keep the historical :declined metric key; changing it would split existing reporting.
           Assignment.Private.log_performance_event(assignment, :declined, crew_member)
 
           Assignment.Private.send_progress_event(

--- a/core/systems/assignment/crew_page.ex
+++ b/core/systems/assignment/crew_page.ex
@@ -108,7 +108,7 @@ defmodule Systems.Assignment.CrewPage do
         %{name: :decline},
         %{assigns: %{model: model, current_user: user}} = socket
       ) do
-    Assignment.Public.decline_member(model, user)
+    Assignment.Public.expire_member(model, user)
     socket = store(socket, onboarding_identifier(socket), "{\"status\":\"consent declined\"}")
     {:stop, socket |> handle_action(:decline)}
   end

--- a/core/test/systems/assignment/_public_test.exs
+++ b/core/test/systems/assignment/_public_test.exs
@@ -3,6 +3,7 @@ defmodule Systems.Assignment.PublicTest do
   import Systems.NextAction.TestHelper
   import Systems.Fund.TestHelper
 
+  alias Systems.Account
   alias Systems.Assignment
   alias Systems.Crew
   alias Systems.Fund
@@ -377,7 +378,7 @@ defmodule Systems.Assignment.PublicTest do
       assert %{expired: false} = Crew.Public.get_task!(task.id)
     end
 
-    test "decline_member/2 does expire member and tasks and updates metric" do
+    test "expire_member/2 does expire member and tasks and updates metric" do
       %{crew: crew} = assignment = Assignment.Factories.create_assignment(31, 1)
       user = Factories.insert!(:member)
       member = Crew.Factories.create_member(crew, user)
@@ -388,7 +389,7 @@ defmodule Systems.Assignment.PublicTest do
       assert %{expired: false} = Crew.Public.get_task!(task.id)
       assert 0 = Monitor.Public.count(metric)
 
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
 
       assert %{expired: true} = Crew.Public.get_member!(member.id)
       assert %{expired: true} = Crew.Public.get_task!(task.id)
@@ -807,6 +808,22 @@ defmodule Systems.Assignment.PublicTest do
 
       assert %{status: :rejected, deposit_id: nil} =
                Systems.Fund.Public.get_reward(idempotence_key, [])
+    end
+
+    test "reopens the assignment spot", %{participation: participation} do
+      assignment = Assignment.Public.get!(participation.assignment_id, [:crew, :info])
+      user = Account.Public.get_user!(participation.user_id)
+      {:ok, _} = Assignment.Public.add_participant!(assignment, user)
+
+      assignment = Assignment.Public.get!(participation.assignment_id, [:crew, :info])
+      assert Assignment.Public.count_participants(assignment) == 1
+      refute Assignment.Public.has_open_spots?(assignment)
+
+      {:ok, _} = Assignment.Public.reject_participation(participation, "bad data")
+
+      assignment = Assignment.Public.get!(participation.assignment_id, [:crew, :info])
+      assert Assignment.Public.count_participants(assignment) == 0
+      assert Assignment.Public.has_open_spots?(assignment)
     end
 
     test "is idempotent — second call is a no-op", %{participation: participation} do

--- a/core/test/systems/assignment/_switch_test.exs
+++ b/core/test/systems/assignment/_switch_test.exs
@@ -39,7 +39,7 @@ defmodule Systems.Assignment.SwitchTest do
 
     test "crew_member declined", %{user: user, crew: crew, crew_member: crew_member} do
       message = %{crew: crew, crew_member: crew_member, from_pid: self()}
-      assert :ok = Switch.intercept({:crew, {:crew_member, :declined}}, message)
+      assert :ok = Switch.intercept({:crew, {:crew_member, :expired}}, message)
 
       assert %{monitor_event: {_, :declined, _}} =
                assert_signal_dispatched({:assignment, :monitor_event})

--- a/core/test/systems/assignment/crew_page_builder_test.exs
+++ b/core/test/systems/assignment/crew_page_builder_test.exs
@@ -82,7 +82,7 @@ defmodule Systems.Assignment.CrewPageBuilderTest do
       assert consent_view.implementation == Assignment.OnboardingConsentView
 
       # User declines - simulate round trip with action and vm.view from previous render
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
       assigns_with_action = build_assigns(user, %{view: consent_view, action: :decline})
       %{view: view} = Assignment.CrewPageBuilder.view_model(assignment, assigns_with_action)
 
@@ -94,7 +94,7 @@ defmodule Systems.Assignment.CrewPageBuilderTest do
       assignment = Assignment.Factories.add_participant(assignment, user)
 
       # Decline consent
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
 
       # Simulate retry from finished view by including previous view in assigns
       previous_view = %{implementation: Assignment.FinishedView}
@@ -164,7 +164,7 @@ defmodule Systems.Assignment.CrewPageBuilderTest do
       %{view: consent_view} = Assignment.CrewPageBuilder.view_model(assignment, assigns)
 
       # User declines - simulate round trip with action and vm.view from previous render
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
       assigns_with_action = build_assigns(user, %{view: consent_view, action: :decline})
       %{view: view} = Assignment.CrewPageBuilder.view_model(assignment, assigns_with_action)
 

--- a/core/test/systems/assignment/finished_view_builder_test.exs
+++ b/core/test/systems/assignment/finished_view_builder_test.exs
@@ -59,7 +59,7 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
         Assignment.Factories.create_assignment_with_consent_and_affiliate(nil)
         |> Assignment.Factories.add_participant(user)
 
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
 
       assigns = build_assigns(user)
       vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
@@ -86,7 +86,7 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
         |> Assignment.Factories.add_affiliate_user(user)
         |> Assignment.Factories.add_participant(user)
 
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
 
       assigns = build_assigns(user, redirect_url)
       vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
@@ -148,7 +148,7 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
         |> Assignment.Factories.add_affiliate_user(user)
         |> Assignment.Factories.add_participant(user)
 
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
 
       assigns = build_assigns(user, redirect_url)
       vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)
@@ -292,7 +292,7 @@ defmodule Systems.Assignment.FinishedViewBuilderTest do
         |> Core.Repo.preload(Systems.Assignment.Model.preload_graph(:down))
         |> Assignment.Factories.add_participant(user)
 
-      Assignment.Public.decline_member(assignment, user)
+      Assignment.Public.expire_member(assignment, user)
 
       assigns = build_assigns(user)
       vm = Assignment.FinishedViewBuilder.view_model(assignment, assigns)


### PR DESCRIPTION
## Goal
[Declined contribution doesn’t reopen the assignment spot](https://app.basecamp.com/5734045/buckets/35926565/todos/10231120399)

When an owner rejects a contribution, the participant must stop occupying an assignment spot so another participant can join.

## Changes
- Keep contribution rejection as the single transaction signal.
- Handle the downstream crew effect in `Assignment.Switch`: expire the crew member and their tasks, then emit `{:crew_member, :expired}`.
- Rename the crew lifecycle API and signal from `decline_member` / `:declined` to `expire_member` / `:expired`.
- Preserve the historical `:declined` performance-event key for reporting compatibility.
- Add a regression test proving rejection reduces participant count and reopens the spot.

## Verification
- `make test` — Core: 2,645 tests and 27 features; assets: 13 tests; banking_proxy: 19 tests.
- `cd core && mix dialyzer`
- Push hooks: format, compile, Credo, test, and Dialyzer.